### PR TITLE
Fix folder upload in Firefox browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ DeepSeek will use the appropriate tags automatically (guided by the injected sys
 When DeepSeek writes to memory using `<BDS:memory_write>`, the entries appear in the "Stored Memory" section of the drawer. You can also manually import/export memory as JSON.
 
 ### Uploading Folders and GitHub Repos
-Click the "+" button next to the chat input to reveal the advanced upload menu. Choose "Upload Folder" to select a local directory; the extension will concatenate all text files into a single upload. "GitHub Repo" fetches the repository as a ZIP and converts it to a gitingest-style text file for context.
+Click the "+" button next to the chat input to reveal the advanced upload menu. Choose "Upload Folder" to select a local directory; the extension will concatenate all text files into a single upload. On browsers without the File System Access API (Firefox), the folder picker falls back to the browser's native directory input so the flow still works. "GitHub Repo" fetches the repository as a ZIP and converts it to a gitingest-style text file for context.
 
 ## Development
 

--- a/src/content/files/folder-reader.js
+++ b/src/content/files/folder-reader.js
@@ -5,53 +5,149 @@
  */
 
 export async function pickFolderAndConcatenate() {
-  try {
-    const dirHandle = await window.showDirectoryPicker();
-    const allFiles = [];
-    await readDirectory(dirHandle, dirHandle.name, allFiles);
-
-    // Add file tree at the top
-    let concatText = generateTree(allFiles);
-    concatText += "\n\n========================================\n\n";
-
-    for (const file of allFiles) {
-      if (isTextFile(file.name)) {
-        if (file.size > 2 * 1024 * 1024) continue; // skip files > 2MB to avoid freezing
-        
-        try {
-          const text = await file.text();
-          
-          if (text.indexOf("\0") !== -1) {
-            continue;
-          }
-
-          concatText += `\n\n--- [FILE: ${file.path}] ---\n\n`;
-          concatText += text;
-        } catch (e) {
-          console.warn(`Could not read ${file.path}`, e);
-        }
-      }
-    }
-
-    if (!concatText || concatText.trim() === "Directory Tree:") {
-      return null;
-    }
-
-    const blob = new Blob([concatText], { type: "text/plain" });
-    const fakeFile = new File([blob], `${dirHandle.name}_workspace.txt`, { type: "text/plain" });
-    return fakeFile;
-  } catch (err) {
-    if (err.name !== "AbortError") {
-      console.error("[AttachMenu] Folder read error:", err);
-    }
+  const selection = await selectFolderSelection();
+  if (!selection) {
     return null;
   }
+
+  const allFiles = selection.files.slice();
+  allFiles.sort((a, b) => a.path.localeCompare(b.path));
+
+  // Add file tree at the top
+  let concatText = generateTree(allFiles);
+  concatText += "\n\n========================================\n\n";
+  let textFileCount = 0;
+
+  for (const file of allFiles) {
+    if (!isTextFile(file.name)) {
+      continue;
+    }
+
+    if (file.size > 2 * 1024 * 1024) continue; // skip files > 2MB to avoid freezing
+
+    try {
+      const text = await file.text();
+
+      if (text.indexOf("\0") !== -1) {
+        continue;
+      }
+
+      concatText += `\n\n--- [FILE: ${file.path}] ---\n\n`;
+      concatText += text;
+      textFileCount += 1;
+    } catch (e) {
+      console.warn(`Could not read ${file.path}`, e);
+    }
+  }
+
+  if (!textFileCount) {
+    return null;
+  }
+
+  const blob = new Blob([concatText], { type: "text/plain" });
+  const workspaceName = `${selection.rootName || "folder"}_workspace.txt`;
+  return new File([blob], workspaceName, { type: "text/plain" });
+}
+
+async function selectFolderSelection() {
+  if (supportsDirectoryPicker()) {
+    try {
+      const dirHandle = await window.showDirectoryPicker();
+      const files = [];
+      await readDirectory(dirHandle, dirHandle.name, files);
+      return {
+        rootName: dirHandle.name || "folder",
+        files,
+      };
+    } catch (err) {
+      if (isAbortError(err)) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  return await selectFolderSelectionWithInput();
+}
+
+async function selectFolderSelectionWithInput() {
+  if (!supportsDirectoryInput()) {
+    throw new Error("Folder uploads are not supported in this browser.");
+  }
+
+  return await new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    input.setAttribute("webkitdirectory", "");
+    input.setAttribute("aria-hidden", "true");
+    input.tabIndex = -1;
+    input.style.position = "fixed";
+    input.style.left = "-9999px";
+    input.style.top = "0";
+    input.style.width = "1px";
+    input.style.height = "1px";
+    input.style.opacity = "0";
+
+    const cleanup = () => {
+      window.removeEventListener("focus", handleWindowFocus);
+      input.removeEventListener("change", handleChange);
+      if (input.parentNode) {
+        input.parentNode.removeChild(input);
+      }
+    };
+
+    const finish = (value) => {
+      cleanup();
+      resolve(value);
+    };
+
+    const handleChange = () => {
+      const files = Array.from(input.files || []);
+      if (!files.length) {
+        finish(null);
+        return;
+      }
+
+      const selectedFiles = files
+        .map((file) => {
+          const relativePath = file.webkitRelativePath || file.name;
+          file.path = relativePath;
+          return file;
+        })
+        .filter((file) => shouldKeepPath(file.path));
+
+      finish({
+        rootName: inferRootName(selectedFiles),
+        files: selectedFiles,
+      });
+    };
+
+    const handleWindowFocus = () => {
+      window.setTimeout(() => {
+        if (input.files && input.files.length) {
+          return;
+        }
+
+        finish(null);
+      }, 0);
+    };
+
+    input.addEventListener("change", handleChange, { once: true });
+    window.addEventListener("focus", handleWindowFocus, { once: true });
+    document.body.appendChild(input);
+    input.click();
+  });
 }
 
 async function readDirectory(dirHandle, path, allFiles) {
   try {
     for await (const entry of dirHandle.values()) {
       const entryPath = `${path}/${entry.name}`;
+      if (!shouldKeepPath(entryPath)) {
+        continue;
+      }
+
       if (entry.kind === "file") {
         try {
           const file = await entry.getFile();
@@ -61,23 +157,6 @@ async function readDirectory(dirHandle, path, allFiles) {
           console.warn(`Skipping file ${entryPath} due to error:`, fileErr);
         }
       } else if (entry.kind === "directory") {
-        const name = entry.name;
-        if (
-          name === "node_modules" || 
-          name === ".git" || 
-          name === ".github" || 
-          name === "dist" || 
-          name === "build" || 
-          name === ".idea" || 
-          name === ".vscode" ||
-          name === ".vs" ||
-          name === "bin" ||
-          name === "obj" ||
-          name === "out" ||
-          name === "target"
-        ) {
-          continue;
-        }
         await readDirectory(entry, entryPath, allFiles);
       }
     }
@@ -126,6 +205,57 @@ function generateTree(allFiles) {
 
   printTree(tree);
   return output;
+}
+
+function supportsDirectoryPicker() {
+  return typeof window !== "undefined" && typeof window.showDirectoryPicker === "function";
+}
+
+function supportsDirectoryInput() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const input = document.createElement("input");
+  return "webkitdirectory" in input;
+}
+
+function inferRootName(files) {
+  if (!files.length) {
+    return "folder";
+  }
+
+  const firstPath = files[0].path || files[0].webkitRelativePath || files[0].name || "";
+  const rootName = firstPath.split("/")[0];
+  return rootName || "folder";
+}
+
+function shouldKeepPath(path) {
+  const segments = String(path || "").split("/");
+  for (const segment of segments) {
+    if (
+      segment === "node_modules" ||
+      segment === ".git" ||
+      segment === ".github" ||
+      segment === "dist" ||
+      segment === "build" ||
+      segment === ".idea" ||
+      segment === ".vscode" ||
+      segment === ".vs" ||
+      segment === "bin" ||
+      segment === "obj" ||
+      segment === "out" ||
+      segment === "target"
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isAbortError(err) {
+  return err && (err.name === "AbortError" || err.code === 20);
 }
 
 function isTextFile(filename) {

--- a/src/content/files/folder-reader.js
+++ b/src/content/files/folder-reader.js
@@ -80,6 +80,8 @@ async function selectFolderSelectionWithInput() {
     input.type = "file";
     input.multiple = true;
     input.setAttribute("webkitdirectory", "");
+    input.setAttribute("directory", "");
+    input.setAttribute("mozdirectory", "");
     input.setAttribute("aria-hidden", "true");
     input.tabIndex = -1;
     input.style.position = "fixed";
@@ -88,56 +90,119 @@ async function selectFolderSelectionWithInput() {
     input.style.width = "1px";
     input.style.height = "1px";
     input.style.opacity = "0";
+    let settled = false;
 
     const cleanup = () => {
-      window.removeEventListener("focus", handleWindowFocus);
       input.removeEventListener("change", handleChange);
+      input.removeEventListener("cancel", handleCancel);
       if (input.parentNode) {
         input.parentNode.removeChild(input);
       }
     };
 
     const finish = (value) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
       cleanup();
       resolve(value);
     };
 
-    const handleChange = () => {
-      const files = Array.from(input.files || []);
-      if (!files.length) {
-        finish(null);
-        return;
-      }
+    const handleChange = async () => {
+      try {
+        const files = await collectFilesFromInput(input);
+        const selectedFiles = files.filter((file) => shouldKeepPath(file.path));
 
-      const selectedFiles = files
-        .map((file) => {
-          const relativePath = file.webkitRelativePath || file.name;
-          file.path = relativePath;
-          return file;
-        })
-        .filter((file) => shouldKeepPath(file.path));
-
-      finish({
-        rootName: inferRootName(selectedFiles),
-        files: selectedFiles,
-      });
-    };
-
-    const handleWindowFocus = () => {
-      window.setTimeout(() => {
-        if (input.files && input.files.length) {
+        if (!selectedFiles.length) {
+          finish(null);
           return;
         }
 
+        finish({
+          rootName: inferRootName(selectedFiles),
+          files: selectedFiles,
+        });
+      } catch (err) {
+        console.warn("[AttachMenu] Could not read folder selection:", err);
         finish(null);
-      }, 0);
+      }
+    };
+
+    const handleCancel = () => {
+      finish(null);
     };
 
     input.addEventListener("change", handleChange, { once: true });
-    window.addEventListener("focus", handleWindowFocus, { once: true });
+    input.addEventListener("cancel", handleCancel, { once: true });
     document.body.appendChild(input);
     input.click();
   });
+}
+
+async function collectFilesFromInput(input) {
+  const entries = Array.from(input.webkitEntries || []);
+  if (entries.length) {
+    const files = [];
+    for (const entry of entries) {
+      await readDirectoryEntry(entry, "", files);
+    }
+    return files;
+  }
+
+  return Array.from(input.files || []).map((file) => {
+    file.path = file.webkitRelativePath || file.name;
+    return file;
+  });
+}
+
+async function readDirectoryEntry(entry, parentPath, allFiles) {
+  const entryPath = joinPath(parentPath, entry.name);
+  if (!shouldKeepPath(entryPath)) {
+    return;
+  }
+
+  if (entry.isFile) {
+    const file = await entryToFile(entry);
+    file.path = normalizePath(entry.fullPath || entryPath);
+    allFiles.push(file);
+    return;
+  }
+
+  if (entry.isDirectory) {
+    const reader = entry.createReader();
+    while (true) {
+      const batch = await readEntries(reader);
+      if (!batch.length) {
+        break;
+      }
+
+      for (const child of batch) {
+        await readDirectoryEntry(child, entryPath, allFiles);
+      }
+    }
+  }
+}
+
+function entryToFile(entry) {
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, reject);
+  });
+}
+
+function readEntries(reader) {
+  return new Promise((resolve, reject) => {
+    reader.readEntries(resolve, reject);
+  });
+}
+
+function joinPath(parentPath, name) {
+  return parentPath ? `${parentPath}/${name}` : name;
+}
+
+function normalizePath(path) {
+  return String(path || "").replace(/^\/+/, "");
 }
 
 async function readDirectory(dirHandle, path, allFiles) {

--- a/src/content/files/folder-reader.js
+++ b/src/content/files/folder-reader.js
@@ -4,8 +4,10 @@
  * and concatenates them into a single File object.
  */
 
+import { pickFolderSelection } from "../../lib/utils/folder-picker.js";
+
 export async function pickFolderAndConcatenate() {
-  const selection = await selectFolderSelection();
+  const selection = await pickFolderSelection();
   if (!selection) {
     return null;
   }
@@ -23,7 +25,9 @@ export async function pickFolderAndConcatenate() {
       continue;
     }
 
-    if (file.size > 2 * 1024 * 1024) continue; // skip files > 2MB to avoid freezing
+    if (file.size > 2 * 1024 * 1024) {
+      continue;  // skip files > 2MB to avoid freezing
+    }
 
     try {
       const text = await file.text();
@@ -47,187 +51,6 @@ export async function pickFolderAndConcatenate() {
   const blob = new Blob([concatText], { type: "text/plain" });
   const workspaceName = `${selection.rootName || "folder"}_workspace.txt`;
   return new File([blob], workspaceName, { type: "text/plain" });
-}
-
-async function selectFolderSelection() {
-  if (supportsDirectoryPicker()) {
-    try {
-      const dirHandle = await window.showDirectoryPicker();
-      const files = [];
-      await readDirectory(dirHandle, dirHandle.name, files);
-      return {
-        rootName: dirHandle.name || "folder",
-        files,
-      };
-    } catch (err) {
-      if (isAbortError(err)) {
-        return null;
-      }
-      throw err;
-    }
-  }
-
-  return await selectFolderSelectionWithInput();
-}
-
-async function selectFolderSelectionWithInput() {
-  if (!supportsDirectoryInput()) {
-    throw new Error("Folder uploads are not supported in this browser.");
-  }
-
-  return await new Promise((resolve) => {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.multiple = true;
-    input.setAttribute("webkitdirectory", "");
-    input.setAttribute("directory", "");
-    input.setAttribute("mozdirectory", "");
-    input.setAttribute("aria-hidden", "true");
-    input.tabIndex = -1;
-    input.style.position = "fixed";
-    input.style.left = "-9999px";
-    input.style.top = "0";
-    input.style.width = "1px";
-    input.style.height = "1px";
-    input.style.opacity = "0";
-    let settled = false;
-
-    const cleanup = () => {
-      input.removeEventListener("change", handleChange);
-      input.removeEventListener("cancel", handleCancel);
-      if (input.parentNode) {
-        input.parentNode.removeChild(input);
-      }
-    };
-
-    const finish = (value) => {
-      if (settled) {
-        return;
-      }
-
-      settled = true;
-      cleanup();
-      resolve(value);
-    };
-
-    const handleChange = async () => {
-      try {
-        const files = await collectFilesFromInput(input);
-        const selectedFiles = files.filter((file) => shouldKeepPath(file.path));
-
-        if (!selectedFiles.length) {
-          finish(null);
-          return;
-        }
-
-        finish({
-          rootName: inferRootName(selectedFiles),
-          files: selectedFiles,
-        });
-      } catch (err) {
-        console.warn("[AttachMenu] Could not read folder selection:", err);
-        finish(null);
-      }
-    };
-
-    const handleCancel = () => {
-      finish(null);
-    };
-
-    input.addEventListener("change", handleChange, { once: true });
-    input.addEventListener("cancel", handleCancel, { once: true });
-    document.body.appendChild(input);
-    input.click();
-  });
-}
-
-async function collectFilesFromInput(input) {
-  const entries = Array.from(input.webkitEntries || []);
-  if (entries.length) {
-    const files = [];
-    for (const entry of entries) {
-      await readDirectoryEntry(entry, "", files);
-    }
-    return files;
-  }
-
-  return Array.from(input.files || []).map((file) => {
-    file.path = file.webkitRelativePath || file.name;
-    return file;
-  });
-}
-
-async function readDirectoryEntry(entry, parentPath, allFiles) {
-  const entryPath = joinPath(parentPath, entry.name);
-  if (!shouldKeepPath(entryPath)) {
-    return;
-  }
-
-  if (entry.isFile) {
-    const file = await entryToFile(entry);
-    file.path = normalizePath(entry.fullPath || entryPath);
-    allFiles.push(file);
-    return;
-  }
-
-  if (entry.isDirectory) {
-    const reader = entry.createReader();
-    while (true) {
-      const batch = await readEntries(reader);
-      if (!batch.length) {
-        break;
-      }
-
-      for (const child of batch) {
-        await readDirectoryEntry(child, entryPath, allFiles);
-      }
-    }
-  }
-}
-
-function entryToFile(entry) {
-  return new Promise((resolve, reject) => {
-    entry.file(resolve, reject);
-  });
-}
-
-function readEntries(reader) {
-  return new Promise((resolve, reject) => {
-    reader.readEntries(resolve, reject);
-  });
-}
-
-function joinPath(parentPath, name) {
-  return parentPath ? `${parentPath}/${name}` : name;
-}
-
-function normalizePath(path) {
-  return String(path || "").replace(/^\/+/, "");
-}
-
-async function readDirectory(dirHandle, path, allFiles) {
-  try {
-    for await (const entry of dirHandle.values()) {
-      const entryPath = `${path}/${entry.name}`;
-      if (!shouldKeepPath(entryPath)) {
-        continue;
-      }
-
-      if (entry.kind === "file") {
-        try {
-          const file = await entry.getFile();
-          file.path = entryPath;
-          allFiles.push(file);
-        } catch (fileErr) {
-          console.warn(`Skipping file ${entryPath} due to error:`, fileErr);
-        }
-      } else if (entry.kind === "directory") {
-        await readDirectory(entry, entryPath, allFiles);
-      }
-    }
-  } catch (dirErr) {
-    console.warn(`Could not read directory ${path}:`, dirErr);
-  }
 }
 
 function generateTree(allFiles) {
@@ -270,57 +93,6 @@ function generateTree(allFiles) {
 
   printTree(tree);
   return output;
-}
-
-function supportsDirectoryPicker() {
-  return typeof window !== "undefined" && typeof window.showDirectoryPicker === "function";
-}
-
-function supportsDirectoryInput() {
-  if (typeof document === "undefined") {
-    return false;
-  }
-
-  const input = document.createElement("input");
-  return "webkitdirectory" in input;
-}
-
-function inferRootName(files) {
-  if (!files.length) {
-    return "folder";
-  }
-
-  const firstPath = files[0].path || files[0].webkitRelativePath || files[0].name || "";
-  const rootName = firstPath.split("/")[0];
-  return rootName || "folder";
-}
-
-function shouldKeepPath(path) {
-  const segments = String(path || "").split("/");
-  for (const segment of segments) {
-    if (
-      segment === "node_modules" ||
-      segment === ".git" ||
-      segment === ".github" ||
-      segment === "dist" ||
-      segment === "build" ||
-      segment === ".idea" ||
-      segment === ".vscode" ||
-      segment === ".vs" ||
-      segment === "bin" ||
-      segment === "obj" ||
-      segment === "out" ||
-      segment === "target"
-    ) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function isAbortError(err) {
-  return err && (err.name === "AbortError" || err.code === 20);
 }
 
 function isTextFile(filename) {

--- a/src/content/ui/AttachMenu.svelte
+++ b/src/content/ui/AttachMenu.svelte
@@ -221,9 +221,20 @@
     closeMenu();
     if (!nativeInput) return;
 
-    const fakeFile = await pickFolderAndConcatenate();
-    if (fakeFile) {
-      injectFile(fakeFile);
+    try {
+      const fakeFile = await pickFolderAndConcatenate();
+      if (fakeFile) {
+        injectFile(fakeFile);
+      }
+    } catch (err) {
+      if (err?.name === "AbortError") {
+        return;
+      }
+
+      console.error("[AttachMenu] Folder upload failed:", err);
+      if (appState.ui) {
+        appState.ui.showToast(err?.message || "Folder upload failed.");
+      }
     }
   }
 

--- a/src/lib/utils/folder-picker.js
+++ b/src/lib/utils/folder-picker.js
@@ -1,0 +1,242 @@
+/**
+ * Folder Picker
+ * Handles browser-specific folder selection and returns a normalized file list.
+ */
+
+export async function pickFolderSelection() {
+  if (supportsDirectoryPicker()) {
+    try {
+      const dirHandle = await window.showDirectoryPicker();
+      const files = [];
+      await readDirectoryHandle(dirHandle, dirHandle.name, files);
+      return {
+        rootName: dirHandle.name || "folder",
+        files,
+      };
+    } catch (err) {
+      if (isAbortError(err)) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  return await pickFolderSelectionWithInput();
+}
+
+async function pickFolderSelectionWithInput() {
+  if (!supportsDirectoryInput()) {
+    throw new Error("Folder uploads are not supported in this browser.");
+  }
+
+  // Make hidden input field and trigger click to open folder picker dialog
+  return await new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = true;
+    input.setAttribute("webkitdirectory", "");
+    input.setAttribute("directory", "");
+    input.setAttribute("mozdirectory", "");
+    input.setAttribute("aria-hidden", "true");
+    input.tabIndex = -1;
+    input.style.position = "fixed";
+    input.style.left = "-9999px";
+    input.style.top = "0";
+    input.style.width = "1px";
+    input.style.height = "1px";
+    input.style.opacity = "0";
+
+    let settled = false;
+
+    const cleanup = () => {
+      input.removeEventListener("change", handleChange);
+      input.removeEventListener("cancel", handleCancel);
+      if (input.parentNode) {
+        input.parentNode.removeChild(input);
+      }
+    };
+
+    const finish = (value) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+
+    const handleChange = async () => {
+      try {
+        const files = await collectFilesFromInput(input);
+        const selectedFiles = files.filter((file) => shouldKeepPath(file.path));
+
+        if (!selectedFiles.length) {
+          finish(null);
+          return;
+        }
+
+        finish({
+          rootName: inferRootName(selectedFiles),
+          files: selectedFiles,
+        });
+      } catch (err) {
+        console.warn("[FolderPicker] Could not read folder selection:", err);
+        finish(null);
+      }
+    };
+
+    const handleCancel = () => {
+      finish(null);
+    };
+
+    input.addEventListener("change", handleChange, { once: true });
+    input.addEventListener("cancel", handleCancel, { once: true });
+    document.body.appendChild(input);
+    input.click();
+  });
+}
+
+async function collectFilesFromInput(input) {
+  const entries = Array.from(input.webkitEntries || []);
+  if (entries.length) {
+    const files = [];
+    for (const entry of entries) {
+      await readEntryRecursively(entry, "", files);
+    }
+    return files;
+  }
+
+  return Array.from(input.files || []).map((file) => {
+    file.path = file.webkitRelativePath || file.name;
+    return file;
+  });
+}
+
+async function readEntryRecursively(entry, parentPath, outFiles) {
+  const entryPath = joinPath(parentPath, entry.name);
+  if (!shouldKeepPath(entryPath)) {
+    return;
+  }
+
+  if (entry.isFile) {
+    try {
+      const file = await entryToFile(entry);
+      file.path = normalizePath(entry.fullPath || entryPath);
+      outFiles.push(file);
+    } catch (err) {
+      console.warn(`Skipping file ${entryPath} due to error:`, err);
+    }
+    return;
+  }
+
+  if (entry.isDirectory) {
+    const reader = entry.createReader();
+    while (true) {
+      const batch = await readEntries(reader);
+      if (!batch.length) {
+        break;
+      }
+
+      for (const child of batch) {
+        await readEntryRecursively(child, entryPath, outFiles);
+      }
+    }
+  }
+}
+
+function readDirectoryHandle(dirHandle, path, allFiles) {
+  return (async () => {
+    for await (const entry of dirHandle.values()) {
+      const entryPath = `${path}/${entry.name}`;
+      if (!shouldKeepPath(entryPath)) {
+        continue;
+      }
+
+      if (entry.kind === "file") {
+        try {
+          const file = await entry.getFile();
+          file.path = entryPath;
+          allFiles.push(file);
+        } catch (fileErr) {
+          console.warn(`Skipping file ${entryPath} due to error:`, fileErr);
+        }
+      } else if (entry.kind === "directory") {
+        await readDirectoryHandle(entry, entryPath, allFiles);
+      }
+    }
+  })().catch((dirErr) => {
+    console.warn(`Could not read directory ${path}:`, dirErr);
+  });
+}
+
+function entryToFile(entry) {
+  return new Promise((resolve, reject) => {
+    entry.file(resolve, reject);
+  });
+}
+
+function readEntries(reader) {
+  return new Promise((resolve, reject) => {
+    reader.readEntries(resolve, reject);
+  });
+}
+
+function joinPath(parentPath, name) {
+  return parentPath ? `${parentPath}/${name}` : name;
+}
+
+function normalizePath(path) {
+  return String(path || "").replace(/^\/+/, "");
+}
+
+function supportsDirectoryPicker() {
+  return typeof window !== "undefined" && typeof window.showDirectoryPicker === "function";
+}
+
+function supportsDirectoryInput() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const input = document.createElement("input");
+  return "webkitdirectory" in input;
+}
+
+function inferRootName(files) {
+  if (!files.length) {
+    return "folder";
+  }
+
+  const firstPath = files[0].path || files[0].webkitRelativePath || files[0].name || "";
+  const rootName = firstPath.split("/")[0];
+  return rootName || "folder";
+}
+
+function shouldKeepPath(path) {
+  const segments = String(path || "").split("/");
+  for (const segment of segments) {
+    if (
+      segment === "node_modules" ||
+      segment === ".git" ||
+      segment === ".github" ||
+      segment === "dist" ||
+      segment === "build" ||
+      segment === ".idea" ||
+      segment === ".vscode" ||
+      segment === ".vs" ||
+      segment === "bin" ||
+      segment === "obj" ||
+      segment === "out" ||
+      segment === "target"
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function isAbortError(err) {
+  return err && (err.name === "AbortError" || err.code === 20);
+}


### PR DESCRIPTION
This fixes the API mismatch in Firefox when uploading folders (it silently fails) by implementing a capability-based `folder-picker` utility. Original PR was closed as I mistakenly used `main` as source.