### PR TITLE
Fix branch parsing for GitHub repos

### DIFF
--- a/src/content/files/github-reader.js
+++ b/src/content/files/github-reader.js
@@ -89,8 +89,11 @@ export function parseGitHubUrl(input) {
     let branch = "main";
 
     // /tree/branch-name or /tree/branch/subpath
-    if (parts[2] === "tree" && parts[3]) {
-      branch = parts[3];
+    // Only consider it a branch if "tree" is the 3rd segment
+    // All segments after "tree" are considered part of the branch name
+    // to support slashes in branch names
+    if (parts[2] === "tree") {
+      branch = parts.slice(3).join("/");
     }
 
     return { owner, repo, branch };
@@ -105,7 +108,7 @@ export function parseGitHubUrl(input) {
  * @param {(status: string) => void} onStatus - status callback
  * @returns {Promise<File|null>}
  */
-export async function fetchGitHubRepo(repoUrl, onStatus = () => {}) {
+export async function fetchGitHubRepo(repoUrl, onStatus = () => { }) {
   const parsed = parseGitHubUrl(repoUrl);
   if (!parsed) {
     throw new Error("Invalid GitHub URL. Use: https://github.com/owner/repo");
@@ -117,7 +120,7 @@ export async function fetchGitHubRepo(repoUrl, onStatus = () => {}) {
   // Fetch via background service worker to bypass CORS
   let zipData = null;
   for (const b of [branch, branch === "main" ? "master" : null].filter(Boolean)) {
-    const codeloadUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${b}`;
+    const codeloadUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${encodeURIComponent(b)}`;
     onStatus(`Downloading ${owner}/${repo} (${b})...`);
 
     try {
@@ -142,7 +145,7 @@ export async function fetchGitHubRepo(repoUrl, onStatus = () => {}) {
   }
 
   if (!zipData) {
-    throw new Error(`Could not download ${owner}/${repo}. Check the URL and make sure the repo is public.`);
+    throw new Error(`Could not download ${owner}/${repo}/${branch}. Check the URL and make sure the repo is public.`);
   }
 
   onStatus("Extracting ZIP...");
@@ -211,7 +214,7 @@ export async function fetchGitHubRepo(repoUrl, onStatus = () => {}) {
   validEntries.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
 
   // Build file tree
-  let output = `Repository: ${owner}/${repo}\n`;
+  let output = `Repository: ${owner}/${repo}/${branch}\n`;
   output += `${"=".repeat(48)}\n\n`;
   output += "Directory Tree:\n";
   output += buildTree(validEntries.map((e) => e.relativePath));

--- a/src/content/files/github-reader.js
+++ b/src/content/files/github-reader.js
@@ -120,7 +120,7 @@ export async function fetchGitHubRepo(repoUrl, onStatus = () => { }) {
   // Fetch via background service worker to bypass CORS
   let zipData = null;
   for (const b of [branch, branch === "main" ? "master" : null].filter(Boolean)) {
-    const codeloadUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${encodeURIComponent(b)}`;
+    const codeloadUrl = `https://codeload.github.com/${owner}/${repo}/zip/refs/heads/${b}`;
     onStatus(`Downloading ${owner}/${repo} (${b})...`);
 
     try {


### PR DESCRIPTION
This makes branch parsing of GitHub repository links more robust by parsing the segments after `tree` as the whole branch name.