### PR TITLE
fix: sidebar search hidden on collapse

### DIFF
--- a/src/content/ui/SidebarSearch.js
+++ b/src/content/ui/SidebarSearch.js
@@ -59,6 +59,33 @@ export function injectSearchInput() {
   searchInput.addEventListener('input', (e) => {
     handleSearch(e.target.value);
   });
+
+  watchSidebarVisibility(container);
+}
+
+/**
+ * Use rAF to track the sidebar panel width and hide the search container
+ * when the sidebar is collapsed (width collapses to 0 via CSS transition).
+ * @param {HTMLElement} container
+ */
+function watchSidebarVisibility(container) {
+  const sidebarPanel = container.closest('.dc04ec1d');
+  if (!sidebarPanel) return;
+
+  const isHidden = () => sidebarPanel.getBoundingClientRect().width === 0;
+  let lastHidden = isHidden();
+  container.style.display = lastHidden ? 'none' : '';
+
+  function tick() {
+    const hidden = isHidden();
+    if (hidden !== lastHidden) {
+      container.style.display = hidden ? 'none' : '';
+      lastHidden = hidden;
+    }
+    requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
 }
 
 let searchDebounceTimer = 0;

--- a/src/content/ui/mount.js
+++ b/src/content/ui/mount.js
@@ -41,5 +41,35 @@ export function mountUi() {
   };
 
   state.ui = api;
+  initPreviewAvoidance(root);
   return api;
+}
+
+/**
+ * Continuously track DeepSeek's file-preview panel with rAF so #bds-root
+ * follows the panel's left edge in real time during open/close animations.
+ * @param {HTMLElement} root
+ */
+function initPreviewAvoidance(root) {
+  const PANEL_SELECTOR = "._519be07";
+  const DEFAULT_RIGHT = 16;
+  const GAP = 8;
+
+  let lastRight = DEFAULT_RIGHT;
+
+  function tick() {
+    const panel = document.querySelector(PANEL_SELECTOR);
+    const targetRight = panel
+      ? Math.max(window.innerWidth - panel.getBoundingClientRect().left + GAP, DEFAULT_RIGHT)
+      : DEFAULT_RIGHT;
+
+    if (targetRight !== lastRight) {
+      root.style.right = targetRight === DEFAULT_RIGHT ? "" : `${targetRight}px`;
+      lastRight = targetRight;
+    }
+
+    requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
 }

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -67,6 +67,7 @@ html.dark, body.dark, .dark :root {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  transition: none;
 }
 
 #bds-root * {


### PR DESCRIPTION
fix: track the sidebar panel width with a `requestAnimationFrame`
loop and set `display: none` on the search container when the width
reaches 0. The initial state is also applied synchronously at
injection time.

before:
<img width="1442" height="996" alt="PixPin截图_2026-05-04_05-50-16" src="https://github.com/user-attachments/assets/20405802-a7fa-4807-bc28-44461866ea11" />
