### PR TITLE
fix: BDS button overlaps deepseek's native close button when preview panel is open

### DIFF
--- a/src/content/ui/mount.js
+++ b/src/content/ui/mount.js
@@ -41,5 +41,35 @@ export function mountUi() {
   };
 
   state.ui = api;
+  initPreviewAvoidance(root);
   return api;
+}
+
+/**
+ * Continuously track DeepSeek's file-preview panel with rAF so #bds-root
+ * follows the panel's left edge in real time during open/close animations.
+ * @param {HTMLElement} root
+ */
+function initPreviewAvoidance(root) {
+  const PANEL_SELECTOR = "._519be07";
+  const DEFAULT_RIGHT = 16;
+  const GAP = 8;
+
+  let lastRight = DEFAULT_RIGHT;
+
+  function tick() {
+    const panel = document.querySelector(PANEL_SELECTOR);
+    const targetRight = panel
+      ? Math.max(window.innerWidth - panel.getBoundingClientRect().left + GAP, DEFAULT_RIGHT)
+      : DEFAULT_RIGHT;
+
+    if (targetRight !== lastRight) {
+      root.style.right = targetRight === DEFAULT_RIGHT ? "" : `${targetRight}px`;
+      lastRight = targetRight;
+    }
+
+    requestAnimationFrame(tick);
+  }
+
+  requestAnimationFrame(tick);
 }

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -67,6 +67,7 @@ html.dark, body.dark, .dark :root {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  transition: none;
 }
 
 #bds-root * {


### PR DESCRIPTION
Fix: added a requestAnimationFrame loop that continuously tracks the preview panel's left edge and repositions #bds-root in real time.  the button now stays just to the left of the panel throughout the entire open/close animation

before:
<img width="1558" height="965" alt="a0a20144fcda7c692ddafd217a6982cd" src="https://github.com/user-attachments/assets/55c38181-2e87-43c4-ad20-9c080cef090d" />
<img width="1445" height="965" alt="55594cdf39ef6a1a11556369ee101543" src="https://github.com/user-attachments/assets/f36bb2b7-f45a-4b23-b3fe-778e67f87680" />
after:
<img width="1452" height="966" alt="PixPin截图_2026-05-04_05-34-41" src="https://github.com/user-attachments/assets/b5000db3-3726-4f6b-9406-183b8eb6a54d" />

