### PR TITLE
Better BDS Widget for Mobile

### DIFF
--- a/src/content/ui/App.svelte
+++ b/src/content/ui/App.svelte
@@ -66,7 +66,10 @@
   });
 </script>
 
-<button id="bds-toggle" type="button" onclick={toggleDrawer}>BDS</button>
+<button id="bds-toggle" type="button" onclick={toggleDrawer} aria-label="Better DeepSeek">
+  <span class="bds-toggle-full" aria-hidden="true">BDS</span>
+  <span class="bds-toggle-short" aria-hidden="true">B</span>
+</button>
 
 <Drawer bind:this={drawerRef} open={drawerOpen} onclose={closeDrawer} />
 

--- a/src/content/ui/mount.js
+++ b/src/content/ui/mount.js
@@ -51,22 +51,47 @@ export function mountUi() {
  * follows the panel's left edge in real time during open/close animations.
  * @param {HTMLElement} root
  */
+/**
+ * Compute the right offset for the BDS root element.
+ * Returns null on mobile so CSS media query handles positioning.
+ * @param {number} innerWidth
+ * @param {number} mobileBreakpoint
+ * @param {DOMRect|null} panelRect bounding rect of the file-preview panel, or null
+ * @param {number} defaultRight
+ * @param {number} gap
+ * @returns {number|null}
+ */
+export function computePreviewRight(innerWidth, mobileBreakpoint, panelRect, defaultRight, gap) {
+  if (innerWidth < mobileBreakpoint) return null;
+  if (!panelRect) return defaultRight;
+  return Math.max(innerWidth - panelRect.left + gap, defaultRight);
+}
+
 function initPreviewAvoidance(root) {
   const PANEL_SELECTOR = "._519be07";
   const DEFAULT_RIGHT = 16;
   const GAP = 8;
+  const MOBILE_BREAKPOINT = 768;
 
   let lastRight = DEFAULT_RIGHT;
 
   function tick() {
     const panel = document.querySelector(PANEL_SELECTOR);
-    const targetRight = panel
-      ? Math.max(window.innerWidth - panel.getBoundingClientRect().left + GAP, DEFAULT_RIGHT)
-      : DEFAULT_RIGHT;
+    const right = computePreviewRight(
+      window.innerWidth,
+      MOBILE_BREAKPOINT,
+      panel ? panel.getBoundingClientRect() : null,
+      DEFAULT_RIGHT,
+      GAP,
+    );
 
-    if (targetRight !== lastRight) {
-      root.style.right = targetRight === DEFAULT_RIGHT ? "" : `${targetRight}px`;
-      lastRight = targetRight;
+    if (right === null) {
+      // Mobile: clear any inline override so CSS media query handles positioning.
+      if (root.style.right !== "") root.style.right = "";
+      lastRight = DEFAULT_RIGHT;
+    } else if (right !== lastRight) {
+      root.style.right = right === DEFAULT_RIGHT ? "" : `${right}px`;
+      lastRight = right;
     }
 
     requestAnimationFrame(tick);

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -75,6 +75,10 @@ html.dark, body.dark, .dark :root {
   font-family: inherit;
 }
 
+/* ── Toggle Text Visibility ── */
+.bds-toggle-full { display: inline; }
+.bds-toggle-short { display: none; }
+
 /* ── Toggle Pill ── */
 #bds-toggle {
   border: 0;
@@ -1376,6 +1380,39 @@ textarea.bds-input,
   overflow: visible !important; /* Önerilerin görünmesi için şart */
 }
 
+/* ══════════════════════════════════
+   Toast Stack
+   ══════════════════════════════════ */
+#bds-toast-stack {
+  position: fixed;
+  bottom: 80px;
+  right: 24px;
+  z-index: 2147483647;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+  max-width: 320px;
+}
+
+.bds-toast {
+  background: var(--bds-bg-elevated);
+  border: 1px solid var(--bds-border);
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--bds-text-primary);
+  box-shadow: var(--bds-shadow);
+  pointer-events: auto;
+  animation: bds-toast-in 0.2s ease;
+}
+
+@keyframes bds-toast-in {
+  from { transform: translateY(8px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
 /* ── Sidebar Tag Bar ── */
 .bds-tag-chips-wrapper {
   display: flex;
@@ -1477,6 +1514,71 @@ textarea.bds-input,
   background: var(--bds-bg-hover);
   border-radius: 10px;
   color: var(--bds-text-tertiary);
+}
+
+/* ══════════════════════════════════
+   Mobile Layout (viewport < 768px)
+   ══════════════════════════════════ */
+@media (max-width: 767px) {
+  /* Root: full-width, bottom-anchored, items stack upward */
+  #bds-root {
+    right: 0;
+    left: 0;
+    top: auto;
+    bottom: 0;
+    width: 100%;
+    align-items: center;
+    flex-direction: column-reverse;
+    /* Lower than portal overlays (.bds-attach-dropdown: 999999,
+       .bds-github-overlay: 9999999) so they paint above on mobile. */
+    z-index: 999990;
+  }
+
+  /* Toggle: compact 44x44 circle (meets 44pt touch target) */
+  #bds-toggle {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border-radius: 50%;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0;
+    margin-bottom: 8px;
+  }
+
+  .bds-toggle-full { display: none; }
+  .bds-toggle-short { display: inline; }
+
+  /* Drawer: full-width bottom sheet, slides up */
+  #bds-drawer {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    border-radius: 16px 16px 0 0;
+    border-bottom: none;
+    border-left: none;
+    border-right: none;
+    max-height: 80dvh;
+  }
+
+  #bds-drawer.bds-open {
+    animation: bds-slide-up 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @keyframes bds-slide-up {
+    from { transform: translateY(40px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+
+  /* Toast: bottom-center above the toggle button */
+  #bds-toast-stack {
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 80px;
+    width: calc(100% - 32px);
+    max-width: 400px;
+  }
 }
 
 

--- a/src/styles/content.css
+++ b/src/styles/content.css
@@ -1520,62 +1520,69 @@ textarea.bds-input,
    Mobile Layout (viewport < 768px)
    ══════════════════════════════════ */
 @media (max-width: 767px) {
-  /* Root: full-width, bottom-anchored, items stack upward */
+  /* Root: full-width, top-anchored, items stack downward */
   #bds-root {
     right: 0;
     left: 0;
-    top: auto;
-    bottom: 0;
+    top: 8px;
+    bottom: auto;
     width: 100%;
     align-items: center;
-    flex-direction: column-reverse;
+    flex-direction: column;
     /* Lower than portal overlays (.bds-attach-dropdown: 999999,
        .bds-github-overlay: 9999999) so they paint above on mobile. */
     z-index: 999990;
   }
 
-  /* Toggle: compact 44x44 circle (meets 44pt touch target) */
+  /* Toggle: small semi-transparent circle — unintrusive at top-center */
   #bds-toggle {
-    width: 44px;
-    height: 44px;
+    width: 22px;
+    height: 22px;
     padding: 0;
     border-radius: 50%;
-    font-size: 14px;
+    font-size: 9px;
     font-weight: 700;
     letter-spacing: 0;
-    margin-bottom: 8px;
+    margin-bottom: 0;
+    opacity: 0.4;
+    transition: opacity 0.2s ease;
+  }
+
+  #bds-toggle:hover,
+  #bds-toggle:active {
+    opacity: 1;
   }
 
   .bds-toggle-full { display: none; }
   .bds-toggle-short { display: inline; }
 
-  /* Drawer: full-width bottom sheet, slides up */
+  /* Drawer: full-width top sheet, slides down */
   #bds-drawer {
     width: 100%;
     max-width: 100%;
     margin: 0;
-    border-radius: 16px 16px 0 0;
-    border-bottom: none;
+    border-radius: 0 0 16px 16px;
+    border-top: none;
     border-left: none;
     border-right: none;
     max-height: 80dvh;
   }
 
   #bds-drawer.bds-open {
-    animation: bds-slide-up 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+    animation: bds-slide-down 0.25s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
-  @keyframes bds-slide-up {
-    from { transform: translateY(40px); opacity: 0; }
+  @keyframes bds-slide-down {
+    from { transform: translateY(-40px); opacity: 0; }
     to { transform: translateY(0); opacity: 1; }
   }
 
-  /* Toast: bottom-center above the toggle button */
+  /* Toast: bottom-center, clear of input bar */
   #bds-toast-stack {
     right: auto;
     left: 50%;
     transform: translateX(-50%);
-    bottom: 80px;
+    bottom: 24px;
     width: calc(100% - 32px);
     max-width: 400px;
   }

--- a/tests/e2e/widget-layout.spec.js
+++ b/tests/e2e/widget-layout.spec.js
@@ -1,0 +1,60 @@
+/**
+ * E2E tests for BDS widget layout on large (desktop >= 768px) viewports.
+ * Companion to the mobile-specific checks in tests/e2e-android/android.spec.js.
+ * All tests run against the 1440x1100 Chrome viewport defined in the extension helper.
+ */
+import { test, expect } from "./helpers/extension.js";
+
+test("toggle is visible in the top-right area on desktop", async ({ page }) => {
+  const box = await page.locator("#bds-toggle").boundingBox();
+  const vp = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(box.x).toBeGreaterThan(vp.width / 2);
+  expect(box.y).toBeLessThan(200);
+});
+
+test("toggle shows full BDS label and hides short label on desktop", async ({ page }) => {
+  const { fullDisplay, shortDisplay } = await page.evaluate(() => ({
+    fullDisplay: getComputedStyle(document.querySelector("#bds-toggle .bds-toggle-full")).display,
+    shortDisplay: getComputedStyle(document.querySelector("#bds-toggle .bds-toggle-short")).display,
+  }));
+  expect(fullDisplay).not.toBe("none");
+  expect(shortDisplay).toBe("none");
+});
+
+test("toggle is fully opaque on desktop", async ({ page }) => {
+  const opacity = await page.evaluate(() =>
+    parseFloat(getComputedStyle(document.querySelector("#bds-toggle")).opacity),
+  );
+  expect(opacity).toBe(1);
+});
+
+test("bds-root is not full-width on desktop", async ({ page }) => {
+  const rootWidth = await page.evaluate(() => document.querySelector("#bds-root").offsetWidth);
+  const vp = page.viewportSize();
+  expect(rootWidth).toBeLessThan(vp.width / 2);
+});
+
+test("bds-root uses fixed top-right positioning on desktop", async ({ page }) => {
+  const { position, top, right } = await page.evaluate(() => {
+    const cs = getComputedStyle(document.querySelector("#bds-root"));
+    return { position: cs.position, top: cs.top, right: cs.right };
+  });
+  expect(position).toBe("fixed");
+  expect(parseInt(top)).toBeLessThanOrEqual(32);
+  expect(parseInt(right)).toBeLessThanOrEqual(32);
+});
+
+test("drawer is right-anchored when opened on desktop", async ({ page }) => {
+  await page.locator("#bds-toggle").click();
+  await expect(page.locator("#bds-drawer")).toHaveClass(/bds-open/);
+
+  const drawerBox = await page.locator("#bds-drawer").boundingBox();
+  const vp = page.viewportSize();
+  expect(drawerBox).not.toBeNull();
+  expect(drawerBox.x).toBeGreaterThan(vp.width / 2);
+});
+
+test("toggle carries correct aria-label on desktop", async ({ page }) => {
+  await expect(page.locator("#bds-toggle")).toHaveAttribute("aria-label", "Better DeepSeek");
+});

--- a/tests/integration/mount.test.js
+++ b/tests/integration/mount.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { computePreviewRight } from "../../src/content/ui/mount.js";
+
+const MOBILE = 768;
+const DEFAULT_RIGHT = 16;
+const GAP = 8;
+
+describe("computePreviewRight", () => {
+  it("returns null below mobile breakpoint (portrait phone)", () => {
+    expect(computePreviewRight(375, MOBILE, null, DEFAULT_RIGHT, GAP)).toBeNull();
+  });
+
+  it("returns null at the top of the mobile range (767px)", () => {
+    expect(computePreviewRight(767, MOBILE, null, DEFAULT_RIGHT, GAP)).toBeNull();
+  });
+
+  it("returns null even when panel is present on mobile", () => {
+    const panelRect = { left: 200 };
+    expect(computePreviewRight(375, MOBILE, panelRect, DEFAULT_RIGHT, GAP)).toBeNull();
+  });
+
+  it("returns defaultRight at exactly the breakpoint (768px = desktop threshold)", () => {
+    expect(computePreviewRight(768, MOBILE, null, DEFAULT_RIGHT, GAP)).toBe(DEFAULT_RIGHT);
+  });
+
+  it("returns defaultRight on desktop with no preview panel", () => {
+    expect(computePreviewRight(1440, MOBILE, null, DEFAULT_RIGHT, GAP)).toBe(DEFAULT_RIGHT);
+  });
+
+  it("returns offset based on panel position when panel is open on desktop", () => {
+    // innerWidth=1200, panel.left=900 → 1200 - 900 + 8 = 308
+    const panelRect = { left: 900 };
+    expect(computePreviewRight(1200, MOBILE, panelRect, DEFAULT_RIGHT, GAP)).toBe(308);
+  });
+
+  it("clamps to defaultRight when panel is flush with the right edge", () => {
+    // innerWidth=1200, panel.left=1185 → 1200 - 1185 + 8 = 23 > 16 → 23
+    const panelRect = { left: 1185 };
+    expect(computePreviewRight(1200, MOBILE, panelRect, DEFAULT_RIGHT, GAP)).toBe(23);
+  });
+
+  it("clamps to defaultRight when panel is beyond the right edge", () => {
+    // innerWidth=1200, panel.left=1200 → 1200 - 1200 + 8 = 8, clamped to 16
+    const panelRect = { left: 1200 };
+    expect(computePreviewRight(1200, MOBILE, panelRect, DEFAULT_RIGHT, GAP)).toBe(DEFAULT_RIGHT);
+  });
+
+  it("returns defaultRight on wide desktop with no panel (1440px)", () => {
+    expect(computePreviewRight(1440, MOBILE, null, DEFAULT_RIGHT, GAP)).toBe(DEFAULT_RIGHT);
+  });
+
+  it("returns null on 414px (large phone) with panel present", () => {
+    expect(computePreviewRight(414, MOBILE, { left: 200 }, DEFAULT_RIGHT, GAP)).toBeNull();
+  });
+});

--- a/tests/integration/ui/App.test.js
+++ b/tests/integration/ui/App.test.js
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridgeMocks = vi.hoisted(() => ({
+  pushConfigToPage: vi.fn(),
+}));
+
+const projectManagerMocks = vi.hoisted(() => ({
+  getActiveProject: vi.fn(() => null),
+  updateProject: vi.fn(),
+  createProject: vi.fn(),
+  deleteProject: vi.fn(),
+  addProjectFilesBatch: vi.fn(),
+  deleteProjectFile: vi.fn(),
+  getFilesForProject: vi.fn(() => []),
+  setActiveProject: vi.fn(),
+  clearActiveProject: vi.fn(),
+  tickFile: vi.fn(),
+  untickFile: vi.fn(),
+  clearActiveFiles: vi.fn(),
+}));
+
+const scannerMocks = vi.hoisted(() => ({
+  scheduleScan: vi.fn(),
+  collectMessageNodes: vi.fn(() => []),
+  detectMessageRole: vi.fn(),
+}));
+
+const exporterMocks = vi.hoisted(() => ({
+  exportSession: vi.fn(),
+  collectMessages: vi.fn(() => []),
+}));
+
+const folderPickerMocks = vi.hoisted(() => ({
+  pickFolderSelection: vi.fn(),
+  pickFolderAndConcatenate: vi.fn(),
+}));
+
+vi.mock("../../../src/content/bridge.js", () => bridgeMocks);
+vi.mock("../../../src/content/project-manager.js", () => projectManagerMocks);
+vi.mock("../../../src/content/scanner.js", () => scannerMocks);
+vi.mock("../../../src/content/tools/exporter.js", () => exporterMocks);
+vi.mock("../../../src/lib/utils/folder-picker.js", () => folderPickerMocks);
+
+import App from "../../../src/content/ui/App.svelte";
+import { resetAppState } from "../../helpers/app-state.js";
+import { renderSvelte, flushUi } from "../../helpers/svelte.js";
+
+describe("App toggle button", () => {
+  beforeEach(() => {
+    resetAppState({ ui: { showToast: vi.fn() } });
+    bridgeMocks.pushConfigToPage.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  it("renders #bds-toggle with aria-label", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    const toggle = target.querySelector("#bds-toggle");
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute("aria-label")).toBe("Better DeepSeek");
+
+    cleanup();
+  });
+
+  it("toggle contains .bds-toggle-full span with text BDS", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    const fullSpan = target.querySelector("#bds-toggle .bds-toggle-full");
+    expect(fullSpan).not.toBeNull();
+    expect(fullSpan.textContent).toBe("BDS");
+    expect(fullSpan.getAttribute("aria-hidden")).toBe("true");
+
+    cleanup();
+  });
+
+  it("toggle contains .bds-toggle-short span with text B", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    const shortSpan = target.querySelector("#bds-toggle .bds-toggle-short");
+    expect(shortSpan).not.toBeNull();
+    expect(shortSpan.textContent).toBe("B");
+    expect(shortSpan.getAttribute("aria-hidden")).toBe("true");
+
+    cleanup();
+  });
+
+  it("clicking toggle opens the drawer", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    const drawer = target.querySelector("#bds-drawer");
+    expect(drawer.className).toContain("bds-closed");
+
+    target.querySelector("#bds-toggle").click();
+    await flushUi();
+
+    expect(drawer.className).toContain("bds-open");
+    expect(drawer.className).not.toContain("bds-closed");
+
+    cleanup();
+  });
+
+  it("clicking toggle twice closes the drawer", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    const toggle = target.querySelector("#bds-toggle");
+    const drawer = target.querySelector("#bds-drawer");
+
+    toggle.click();
+    await flushUi();
+    expect(drawer.className).toContain("bds-open");
+
+    toggle.click();
+    await flushUi();
+    expect(drawer.className).toContain("bds-closed");
+
+    cleanup();
+  });
+
+  it("close button inside drawer closes it", async () => {
+    const { target, cleanup } = renderSvelte(App);
+    await flushUi();
+
+    target.querySelector("#bds-toggle").click();
+    await flushUi();
+    expect(target.querySelector("#bds-drawer").className).toContain("bds-open");
+
+    target.querySelector("#bds-close").click();
+    await flushUi();
+    expect(target.querySelector("#bds-drawer").className).toContain("bds-closed");
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
This PR repositions the BDS widget to the top-center of the page and makes it small and transparent, to make it unobtrusive on smaller viewports. This is purely a styling change for Android, and is opinionated, but comes with tests to validate behavior on both large and small viewports. BDS positioning and style is unchanged on large viewports.