### PR TITLE
Edge to edge view in Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,11 +13,12 @@ android {
     
     defaultConfig {
         applicationId = "com.betterdeepseek.app"
-        minSdk = 26 
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         // Keep in sync with package.json "version" and static/manifest.json "version".
         versionName = "0.1.5"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -69,4 +70,9 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.json:json:20240303")
+
+    androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test:rules:1.6.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
 }

--- a/android/app/src/androidTest/java/com/betterdeepseek/app/EdgeToEdgeTest.kt
+++ b/android/app/src/androidTest/java/com/betterdeepseek/app/EdgeToEdgeTest.kt
@@ -2,6 +2,7 @@ package com.betterdeepseek.app
 
 import android.graphics.Color
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -66,6 +67,23 @@ class EdgeToEdgeTest {
                 "setDecorFitsSystemWindows(false) must be applied for edge-to-edge",
                 ViewCompat.getFitsSystemWindows(activity.window.decorView),
             )
+        }
+    }
+
+    @Test
+    fun rootLayout_hasPaddingMatchingSystemBars() {
+        activityRule.scenario.onActivity { activity ->
+            val rootLayout = activity.window.decorView
+                .findViewById<FrameLayout>(android.R.id.content)
+                .getChildAt(0) as? FrameLayout
+            checkNotNull(rootLayout) { "Root FrameLayout not found as first child of content" }
+
+            val insets = ViewCompat.getRootWindowInsets(rootLayout)
+            checkNotNull(insets) { "Window insets not yet available" }
+
+            val bars = insets.getInsets(androidx.core.view.WindowInsetsCompat.Type.systemBars())
+            assertEquals("Padding top must equal status bar inset", bars.top, rootLayout.paddingTop)
+            assertEquals("Padding bottom must equal nav bar inset", bars.bottom, rootLayout.paddingBottom)
         }
     }
 }

--- a/android/app/src/androidTest/java/com/betterdeepseek/app/EdgeToEdgeTest.kt
+++ b/android/app/src/androidTest/java/com/betterdeepseek/app/EdgeToEdgeTest.kt
@@ -1,0 +1,71 @@
+package com.betterdeepseek.app
+
+import android.graphics.Color
+import android.view.WindowManager
+import androidx.core.view.ViewCompat
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests that verify edge-to-edge rendering is correctly configured in MainActivity.
+ *
+ * Must run on a connected device or emulator (API 26+). These tests do NOT exercise web content
+ * rendering — they assert only that the Activity has configured the window and WebView correctly.
+ *
+ * Run with: ./gradlew connectedDebugAndroidTest
+ */
+@RunWith(AndroidJUnit4::class)
+class EdgeToEdgeTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun statusBarColor_isTransparent() {
+        activityRule.scenario.onActivity { activity ->
+            assertEquals(
+                "Status bar must be fully transparent for edge-to-edge",
+                Color.TRANSPARENT,
+                activity.window.statusBarColor,
+            )
+        }
+    }
+
+    @Test
+    fun navigationBarColor_isTransparent() {
+        activityRule.scenario.onActivity { activity ->
+            assertEquals(
+                "Navigation bar must be fully transparent — white strip not allowed",
+                Color.TRANSPARENT,
+                activity.window.navigationBarColor,
+            )
+        }
+    }
+
+    @Test
+    fun window_hasFlagDrawsSystemBarBackgrounds() {
+        activityRule.scenario.onActivity { activity ->
+            val flags = activity.window.attributes.flags
+            assertTrue(
+                "FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS required for transparent system bars",
+                flags and WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS != 0,
+            )
+        }
+    }
+
+    @Test
+    fun decorView_doesNotFitSystemWindows() {
+        activityRule.scenario.onActivity { activity ->
+            assertFalse(
+                "setDecorFitsSystemWindows(false) must be applied for edge-to-edge",
+                ViewCompat.getFitsSystemWindows(activity.window.decorView),
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -2,6 +2,8 @@ package com.betterdeepseek.app
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -18,7 +20,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.webkit.WebViewAssetLoader
 import java.io.ByteArrayInputStream
 import java.util.concurrent.TimeUnit
@@ -61,7 +66,9 @@ class MainActivity : ComponentActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, true)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
 
         bridge = WebViewBridge(applicationContext)
         cookieManager = CookieManager.getInstance()
@@ -97,6 +104,28 @@ class MainActivity : ComponentActivity() {
                     setBackgroundColor(0x00000000)
                 }
 
+        ViewCompat.setOnApplyWindowInsetsListener(webView) { view, windowInsets ->
+            val bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(bars.left, bars.top, bars.right, bars.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
+
+        val isSystemDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            isAppearanceLightStatusBars = !isSystemDark
+            isAppearanceLightNavigationBars = !isSystemDark
+        }
+
+        bridge.onThemeChanged = { isDark ->
+            runOnUiThread {
+                WindowInsetsControllerCompat(window, window.decorView).apply {
+                    isAppearanceLightStatusBars = !isDark
+                    isAppearanceLightNavigationBars = !isDark
+                }
+            }
+        }
+
         setContentView(webView)
         webView.loadUrl(getString(R.string.bds_target_url))
 
@@ -115,6 +144,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        bridge.onThemeChanged = null
         webView.removeJavascriptInterface(BRIDGE_NAME)
         super.onDestroy()
     }
@@ -339,9 +369,26 @@ class MainActivity : ComponentActivity() {
             })();
         """.trimIndent()
 
+        val themeDetect =
+                """
+            (function () {
+                if (typeof AndroidBridge === 'undefined' || !AndroidBridge.reportTheme) return;
+                function bdsReportTheme() {
+                    var isDark = document.documentElement.classList.contains('dark') ||
+                        window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    AndroidBridge.reportTheme(isDark);
+                }
+                bdsReportTheme();
+                new MutationObserver(function () { bdsReportTheme(); })
+                    .observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', bdsReportTheme);
+            })();
+        """.trimIndent()
+
         view.evaluateJavascript(injected, null)
         view.evaluateJavascript(bootstrap, null)
         view.evaluateJavascript(content, null)
+        view.evaluateJavascript(themeDetect, null)
     }
 
     private fun readAsset(path: String): String? =

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -82,6 +82,9 @@ class MainActivity : ComponentActivity() {
 
         val isSystemDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
             Configuration.UI_MODE_NIGHT_YES
+        // DeepSeek's persisted theme drives colours; system dark mode is only the first-launch
+        // fallback (before any reportTheme call has been persisted to prefs).
+        val isPageDark = bridge.getLastKnownIsDark(default = isSystemDark)
 
         webView =
                 WebView(this).apply {
@@ -105,9 +108,7 @@ class MainActivity : ComponentActivity() {
                     webViewClient = bdsWebViewClient()
                     webChromeClient = bdsWebChromeClient()
                     isVerticalScrollBarEnabled = true
-                    // Match page background so the inset-padding area behind the status/nav bar
-                    // shows the correct colour instead of the window theme default.
-                    setBackgroundColor(if (isSystemDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
+                    setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
         // FrameLayout wrapper receives system-bar insets and applies them as padding.
@@ -118,7 +119,7 @@ class MainActivity : ComponentActivity() {
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
             )
-            setBackgroundColor(if (isSystemDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
+            setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
             addView(webView)
         }
 
@@ -129,8 +130,8 @@ class MainActivity : ComponentActivity() {
         }
 
         WindowInsetsControllerCompat(window, window.decorView).apply {
-            isAppearanceLightStatusBars = !isSystemDark
-            isAppearanceLightNavigationBars = !isSystemDark
+            isAppearanceLightStatusBars = !isPageDark
+            isAppearanceLightNavigationBars = !isPageDark
         }
 
         bridge.onThemeChanged = { isDark ->
@@ -388,26 +389,11 @@ class MainActivity : ComponentActivity() {
             })();
         """.trimIndent()
 
-        val themeDetect =
-                """
-            (function () {
-                if (typeof AndroidBridge === 'undefined' || !AndroidBridge.reportTheme) return;
-                function bdsReportTheme() {
-                    var isDark = document.documentElement.classList.contains('dark') ||
-                        window.matchMedia('(prefers-color-scheme: dark)').matches;
-                    AndroidBridge.reportTheme(isDark);
-                }
-                bdsReportTheme();
-                new MutationObserver(function () { bdsReportTheme(); })
-                    .observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
-                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', bdsReportTheme);
-            })();
-        """.trimIndent()
-
         view.evaluateJavascript(injected, null)
         view.evaluateJavascript(bootstrap, null)
+        // content.js calls startThemeWatcher() which persists pageIsDark via chrome.storage and
+        // fires AndroidBridge.reportTheme() for the live native bar-icon colour update.
         view.evaluateJavascript(content, null)
-        view.evaluateJavascript(themeDetect, null)
     }
 
     private fun readAsset(path: String): String? =

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -79,6 +80,9 @@ class MainActivity : ComponentActivity() {
                         .addPathHandler("/", WebViewAssetLoader.AssetsPathHandler(this))
                         .build()
 
+        val isSystemDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+            Configuration.UI_MODE_NIGHT_YES
+
         webView =
                 WebView(this).apply {
                     layoutParams =
@@ -101,17 +105,29 @@ class MainActivity : ComponentActivity() {
                     webViewClient = bdsWebViewClient()
                     webChromeClient = bdsWebChromeClient()
                     isVerticalScrollBarEnabled = true
-                    setBackgroundColor(0x00000000)
+                    // Match page background so the inset-padding area behind the status/nav bar
+                    // shows the correct colour instead of the window theme default.
+                    setBackgroundColor(if (isSystemDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
-        ViewCompat.setOnApplyWindowInsetsListener(webView) { view, windowInsets ->
+        // FrameLayout wrapper receives system-bar insets and applies them as padding.
+        // WebView.setPadding() does not shift the WebView viewport reliably, so the wrapper
+        // is the inset target. Its background fills the padding band behind the system bars.
+        val rootLayout = FrameLayout(this).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+            setBackgroundColor(if (isSystemDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
+            addView(webView)
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(rootLayout) { view, windowInsets ->
             val bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
             view.setPadding(bars.left, bars.top, bars.right, bars.bottom)
             WindowInsetsCompat.CONSUMED
         }
 
-        val isSystemDark = (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-            Configuration.UI_MODE_NIGHT_YES
         WindowInsetsControllerCompat(window, window.decorView).apply {
             isAppearanceLightStatusBars = !isSystemDark
             isAppearanceLightNavigationBars = !isSystemDark
@@ -119,6 +135,9 @@ class MainActivity : ComponentActivity() {
 
         bridge.onThemeChanged = { isDark ->
             runOnUiThread {
+                val bg = if (isDark) PAGE_BG_DARK else PAGE_BG_LIGHT
+                rootLayout.setBackgroundColor(bg)
+                webView.setBackgroundColor(bg)
                 WindowInsetsControllerCompat(window, window.decorView).apply {
                     isAppearanceLightStatusBars = !isDark
                     isAppearanceLightNavigationBars = !isDark
@@ -126,7 +145,7 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        setContentView(webView)
+        setContentView(rootLayout)
         webView.loadUrl(getString(R.string.bds_target_url))
 
         onBackPressedDispatcher.addCallback(
@@ -429,6 +448,12 @@ class MainActivity : ComponentActivity() {
     companion object {
         private const val BRIDGE_NAME = "AndroidBridge"
         private const val TAG = "BdsMainActivity"
+
+        // Default WebView background colours used in the inset-padding area behind transparent
+        // system bars. Approximates DeepSeek's own page backgrounds so the status/nav bar region
+        // blends seamlessly before (and if) the page reports its live theme via reportTheme().
+        private val PAGE_BG_DARK = Color.rgb(0x17, 0x17, 0x1A)
+        private val PAGE_BG_LIGHT = Color.WHITE
 
         /**
          * Fully synthetic Chrome-mobile UA string. Servers that block embedded WebViews (notably

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -438,7 +438,7 @@ class MainActivity : ComponentActivity() {
         // Default WebView background colours used in the inset-padding area behind transparent
         // system bars. Approximates DeepSeek's own page backgrounds so the status/nav bar region
         // blends seamlessly before (and if) the page reports its live theme via reportTheme().
-        private val PAGE_BG_DARK = Color.rgb(0x17, 0x17, 0x1A)
+        private val PAGE_BG_DARK = Color.rgb(0x15, 0x15, 0x17)
         private val PAGE_BG_LIGHT = Color.WHITE
 
         /**

--- a/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
@@ -563,7 +563,9 @@ class WebViewBridge(
         private const val DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com"
         private const val DEFAULT_GITHUB_COMMIT_COUNT = 100
         private const val GITHUB_COMMITS_PAGE_SIZE = 100
-        // Double-underscore prefix marks this as internal bridge state, not user chrome.storage data.
-        internal const val KEY_LAST_PAGE_DARK = "__bds_page_is_dark"
+        // Must match STORAGE_KEYS.pageIsDark in src/lib/constants.js — the Android chrome.storage
+        // polyfill routes chrome.storage.local.set({ bds_page_is_dark: ... }) through setStorage,
+        // so getLastKnownIsDark() and the polyfill share the same SharedPreferences key.
+        internal const val KEY_LAST_PAGE_DARK = "bds_page_is_dark"
     }
 }

--- a/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
@@ -55,6 +55,18 @@ class WebViewBridge(
                             .callTimeout(120, TimeUnit.SECONDS)
                             .build()
 
+    /** Set by MainActivity to react to page theme changes without leaking the Activity window. */
+    @Volatile var onThemeChanged: ((isDark: Boolean) -> Unit)? = null
+
+    /**
+     * Called by the injected theme-detection script whenever the page's light/dark state changes.
+     * Routes to [onThemeChanged] so MainActivity can update status/navigation bar icon appearance.
+     */
+    @JavascriptInterface
+    fun reportTheme(isDark: Boolean) {
+        onThemeChanged?.invoke(isDark)
+    }
+
     @JavascriptInterface
     fun getStorage(key: String?): String? {
         if (key.isNullOrEmpty()) return null

--- a/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
@@ -59,8 +59,20 @@ class WebViewBridge(
     @Volatile var onThemeChanged: ((isDark: Boolean) -> Unit)? = null
 
     /**
-     * Called by the injected theme-detection script whenever the page's light/dark state changes.
-     * Routes to [onThemeChanged] so MainActivity can update status/navigation bar icon appearance.
+     * Returns the last DeepSeek page theme written by the extension's theme.js via
+     * chrome.storage.local (which the Android polyfill routes through [setStorage] as
+     * JSON.stringify(boolean) → stored as the string "true" or "false"). Falls back to [default]
+     * on first-ever launch before any value has been persisted.
+     */
+    fun getLastKnownIsDark(default: Boolean = false): Boolean {
+        val raw = prefs.getString(KEY_LAST_PAGE_DARK, null) ?: return default
+        return raw == "true"
+    }
+
+    /**
+     * Called by theme.js (via AndroidBridge.reportTheme) when the page's light/dark state changes.
+     * Persistence is handled cross-platform by chrome.storage.local.set in theme.js; this method
+     * exists solely so MainActivity can update status/navigation bar icon colours immediately.
      */
     @JavascriptInterface
     fun reportTheme(isDark: Boolean) {
@@ -551,5 +563,7 @@ class WebViewBridge(
         private const val DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com"
         private const val DEFAULT_GITHUB_COMMIT_COUNT = 100
         private const val GITHUB_COMMITS_PAGE_SIZE = 100
+        // Double-underscore prefix marks this as internal bridge state, not user chrome.storage data.
+        internal const val KEY_LAST_PAGE_DARK = "__bds_page_is_dark"
     }
 }

--- a/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
@@ -393,7 +393,7 @@ class WebViewBridge(
         while (commits.length() < count) {
             val remaining = count - commits.length()
             val perPage = minOf(GITHUB_COMMITS_PAGE_SIZE, remaining)
-            var fetchedThisPage = perPage
+            var fetchedThisPage: Int
             val requestBuilder =
                     Request.Builder()
                             .url(buildGithubCommitsUrl(owner, repo, branch, perPage, page))

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <style name="Theme.BetterDeepSeek" parent="Theme.Material3.DayNight" />
 
+    <!-- Status/navigation bar colors and light-bar appearance are set programmatically in
+         MainActivity so they react to the page's live dark/light theme. -->
     <style name="Theme.BetterDeepSeek.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
@@ -180,7 +180,7 @@ class WebViewBridgeTest {
         bridge.reportTheme(true)
 
         // Persistence is handled by theme.js via chrome.storage — bridge must not double-write.
-        verify(prefsEditor, never()).putBoolean(any(), anyBoolean())
+        verify(prefsEditor, never()).putBoolean(any(), any<Boolean>())
         assertEquals(true, reported)
     }
 

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
@@ -47,6 +47,7 @@ class WebViewBridgeTest {
         prefsEditor = mock(SharedPreferences.Editor::class.java)
         `when`(prefs.edit()).thenReturn(prefsEditor)
         `when`(prefsEditor.putString(any(), any())).thenReturn(prefsEditor)
+        `when`(prefsEditor.putBoolean(any(), any())).thenReturn(prefsEditor)
         `when`(prefsEditor.remove(any())).thenReturn(prefsEditor)
 
         context = mock(Context::class.java)
@@ -167,6 +168,48 @@ class WebViewBridgeTest {
         val response = JSONObject(bridge.fetch("not-json"))
         assertFalse(response.getBoolean("ok"))
         assertTrue(response.getString("error").contains("Bridge error"))
+    }
+
+    // ── theme ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `reportTheme fires callback and does not touch prefs`() {
+        var reported: Boolean? = null
+        bridge.onThemeChanged = { isDark -> reported = isDark }
+
+        bridge.reportTheme(true)
+
+        // Persistence is handled by theme.js via chrome.storage — bridge must not double-write.
+        verify(prefsEditor, never()).putBoolean(any(), anyBoolean())
+        assertEquals(true, reported)
+    }
+
+    @Test
+    fun `reportTheme false fires callback`() {
+        var reported: Boolean? = null
+        bridge.onThemeChanged = { isDark -> reported = isDark }
+        bridge.reportTheme(false)
+        assertEquals(false, reported)
+    }
+
+    @Test
+    fun `getLastKnownIsDark returns true when polyfill stored json true string`() {
+        // The Android storage polyfill calls setStorage(key, JSON.stringify(true)) = "true".
+        `when`(prefs.getString(WebViewBridge.KEY_LAST_PAGE_DARK, null)).thenReturn("true")
+        assertTrue(bridge.getLastKnownIsDark(default = false))
+    }
+
+    @Test
+    fun `getLastKnownIsDark returns false when polyfill stored json false string`() {
+        `when`(prefs.getString(WebViewBridge.KEY_LAST_PAGE_DARK, null)).thenReturn("false")
+        assertFalse(bridge.getLastKnownIsDark(default = true))
+    }
+
+    @Test
+    fun `getLastKnownIsDark forwards default when prefs has no entry`() {
+        `when`(prefs.getString(WebViewBridge.KEY_LAST_PAGE_DARK, null)).thenReturn(null)
+        assertFalse(bridge.getLastKnownIsDark(default = false))
+        assertTrue(bridge.getLastKnownIsDark(default = true))
     }
 
     // ── github zip ──────────────────────────────────────────────────────

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -27,6 +27,7 @@ import { initSidebarSearch } from "./ui/SidebarSearch.js";
 import { checkPendingExport } from "./tools/pending-export.js";
 import { initPricing } from "../lib/pricing.js";
 import { startStatusMonitor } from "./status-monitor.js";
+import { startThemeWatcher } from "./theme.js";
 
 init().catch((error) => {
   console.error("[BetterDeepSeek] Init error:", error);
@@ -48,6 +49,7 @@ async function init() {
   checkPendingExport();
   pushConfigToPage();
   startStatusMonitor();
+  startThemeWatcher();
 
   // Dynamically fetch pricing and update embedded fallback
   initPricing().then((pricing) => {

--- a/src/content/theme.js
+++ b/src/content/theme.js
@@ -14,14 +14,13 @@
 import { STORAGE_KEYS } from "../lib/constants.js";
 
 export function startThemeWatcher() {
-  // DeepSeek sets the theme class on <body> (e.g. "en_US dark"), not on <html>.
-  // matchMedia is retained as a fallback for the "System" setting where no explicit
-  // body class may be present, and for OS-level theme changes.
+  // DeepSeek sets the theme class on <body> (e.g. "en_US dark" / "en_US light"), not on <html>.
+  // Explicit body class always wins; matchMedia is a last-resort fallback for the "System"
+  // setting or when no class is present yet.
   function detect() {
-    return (
-      document.body.classList.contains("dark") ||
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    );
+    if (document.body.classList.contains("dark")) return true;
+    if (document.body.classList.contains("light")) return false;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
   }
 
   function apply(isDark) {

--- a/src/content/theme.js
+++ b/src/content/theme.js
@@ -1,0 +1,47 @@
+/**
+ * Page-theme watcher.
+ *
+ * Detects DeepSeek's light/dark mode and persists it to chrome.storage.local so every platform
+ * can read STORAGE_KEYS.pageIsDark without relying on the OS dark-mode setting:
+ *   - Desktop (Chrome / Firefox): background / popup code reads chrome.storage.local directly.
+ *   - Android: the chrome.storage polyfill routes the write through AndroidBridge.setStorage,
+ *     and WebViewBridge.getLastKnownIsDark() reads the same SharedPreferences key on startup.
+ *
+ * Additionally fires AndroidBridge.reportTheme() when available so the native layer can update
+ * status/navigation bar icon colours without waiting for the next cold start.
+ */
+
+import { STORAGE_KEYS } from "../lib/constants.js";
+
+export function startThemeWatcher() {
+  function detect() {
+    return (
+      document.documentElement.classList.contains("dark") ||
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+    );
+  }
+
+  function apply(isDark) {
+    chrome.storage.local.set({ [STORAGE_KEYS.pageIsDark]: isDark });
+    // Live notification for Android native bar icon colours. No-op on other platforms.
+    if (
+      typeof window.AndroidBridge !== "undefined" &&
+      typeof window.AndroidBridge.reportTheme === "function"
+    ) {
+      window.AndroidBridge.reportTheme(isDark);
+    }
+  }
+
+  function run() {
+    apply(detect());
+  }
+
+  run();
+
+  new MutationObserver(run).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class", "data-theme"],
+  });
+
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", run);
+}

--- a/src/content/theme.js
+++ b/src/content/theme.js
@@ -24,12 +24,11 @@ export function startThemeWatcher() {
   function apply(isDark) {
     chrome.storage.local.set({ [STORAGE_KEYS.pageIsDark]: isDark });
     // Live notification for Android native bar icon colours. No-op on other platforms.
-    if (
-      typeof window.AndroidBridge !== "undefined" &&
-      typeof window.AndroidBridge.reportTheme === "function"
-    ) {
-      window.AndroidBridge.reportTheme(isDark);
-    }
+    // Avoid typeof-function check: JavascriptInterface methods on some WebView versions
+    // are callable but do not report as "function" via typeof.
+    try {
+      window.AndroidBridge?.reportTheme(isDark);
+    } catch (_) {}
   }
 
   function run() {

--- a/src/content/theme.js
+++ b/src/content/theme.js
@@ -14,9 +14,12 @@
 import { STORAGE_KEYS } from "../lib/constants.js";
 
 export function startThemeWatcher() {
+  // DeepSeek sets the theme class on <body> (e.g. "en_US dark"), not on <html>.
+  // matchMedia is retained as a fallback for the "System" setting where no explicit
+  // body class may be present, and for OS-level theme changes.
   function detect() {
     return (
-      document.documentElement.classList.contains("dark") ||
+      document.body.classList.contains("dark") ||
       window.matchMedia("(prefers-color-scheme: dark)").matches
     );
   }
@@ -37,10 +40,18 @@ export function startThemeWatcher() {
 
   run();
 
+  // Primary observer: watch <body> class for DeepSeek's live theme toggles.
+  new MutationObserver(run).observe(document.body, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+
+  // Fallback observer: <html> attributes (data-theme or class) for other potential signals.
   new MutationObserver(run).observe(document.documentElement, {
     attributes: true,
     attributeFilter: ["class", "data-theme"],
   });
 
+  // OS-level theme changes (covers DeepSeek's "System" setting).
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", run);
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -8,6 +8,9 @@ export const STORAGE_KEYS = {
   projectFiles: "bds_project_files",
   whatsNewPending: "bds_whats_new_pending",
   chatTags: "bds_chat_tags",
+  // Last observed DeepSeek page theme. Written on all platforms so desktop modals and Android
+  // native bars can both read it without relying on OS-level dark-mode assumptions.
+  pageIsDark: "bds_page_is_dark",
 };
 
 

--- a/src/platform/android-bridge-shim.js
+++ b/src/platform/android-bridge-shim.js
@@ -12,11 +12,12 @@
  *
  * Native bridge methods (see WebViewBridge.kt):
  *   getStorage(key: String): String?
- *   setStorage(key: String, value: String): void
+ *   setStorage(key: String, value: String): void   // value is JSON.stringify(jsValue)
  *   removeStorage(key: String): void
  *   fetch(payloadJson: String): String   // JSON-encoded { ok, ... }
  *   getAssetUrl(relativePath: String): String
  *   downloadBlob(base64, mimeType, fileName): void
+ *   reportTheme(isDark: Boolean): void  // live bar-icon colour update; persistence via setStorage
  */
 
 function getBridge() {

--- a/tests/integration/theme.test.js
+++ b/tests/integration/theme.test.js
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEYS } from "../../src/lib/constants.js";
+import { startThemeWatcher } from "../../src/content/theme.js";
+
+describe("startThemeWatcher", () => {
+  let storageSet;
+  let mediaQueryDark;
+
+  beforeEach(() => {
+    storageSet = vi.fn().mockResolvedValue(undefined);
+    global.chrome = { storage: { local: { set: storageSet } } };
+
+    // Default: system light mode, body has no theme class.
+    document.documentElement.className = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.body.className = "";
+
+    mediaQueryDark = false;
+    const listeners = new Set();
+    window.matchMedia = vi.fn().mockReturnValue({
+      get matches() {
+        return mediaQueryDark;
+      },
+      addEventListener: (_event, fn) => listeners.add(fn),
+      removeEventListener: (_event, fn) => listeners.delete(fn),
+      _fire: () => listeners.forEach((fn) => fn()),
+    });
+
+    delete window.AndroidBridge;
+  });
+
+  // ── detect() ──────────────────────────────────────────────────────────
+
+  it("detects dark mode from body class", () => {
+    document.body.className = "en_US dark";
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: true })
+    );
+  });
+
+  it("detects light mode when body class is 'en_US light'", () => {
+    document.body.className = "en_US light";
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: false })
+    );
+  });
+
+  it("falls back to matchMedia when body has no theme class", () => {
+    document.body.className = "";
+    mediaQueryDark = true;
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: true })
+    );
+  });
+
+  it("does not treat html.dark as dark (DeepSeek puts class on body)", () => {
+    document.documentElement.className = "dark";
+    document.body.className = "en_US light";
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: false })
+    );
+  });
+
+  // ── MutationObserver on <body> ─────────────────────────────────────────
+
+  it("re-runs when body class changes to dark", async () => {
+    document.body.className = "en_US light";
+    startThemeWatcher();
+    storageSet.mockClear();
+
+    document.body.className = "en_US dark";
+    await vi.waitFor(() =>
+      expect(storageSet).toHaveBeenCalledWith(
+        expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: true })
+      )
+    );
+  });
+
+  it("re-runs when body class changes to light", async () => {
+    document.body.className = "en_US dark";
+    startThemeWatcher();
+    storageSet.mockClear();
+
+    document.body.className = "en_US light";
+    await vi.waitFor(() =>
+      expect(storageSet).toHaveBeenCalledWith(
+        expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: false })
+      )
+    );
+  });
+
+  // ── matchMedia change listener ─────────────────────────────────────────
+
+  it("re-runs on matchMedia change", () => {
+    document.body.className = "";
+    mediaQueryDark = false;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    startThemeWatcher();
+    storageSet.mockClear();
+
+    mediaQueryDark = true;
+    mq._fire();
+
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: true })
+    );
+  });
+
+  // ── AndroidBridge.reportTheme ──────────────────────────────────────────
+
+  it("calls AndroidBridge.reportTheme when bridge is present", () => {
+    document.body.className = "en_US dark";
+    window.AndroidBridge = { reportTheme: vi.fn() };
+    startThemeWatcher();
+    expect(window.AndroidBridge.reportTheme).toHaveBeenCalledWith(true);
+  });
+
+  it("does not throw when AndroidBridge is absent", () => {
+    document.body.className = "en_US dark";
+    delete window.AndroidBridge;
+    expect(() => startThemeWatcher()).not.toThrow();
+  });
+
+  it("does not throw when AndroidBridge.reportTheme throws", () => {
+    document.body.className = "en_US dark";
+    window.AndroidBridge = {
+      reportTheme: vi.fn(() => {
+        throw new Error("bridge error");
+      }),
+    };
+    expect(() => startThemeWatcher()).not.toThrow();
+  });
+});

--- a/tests/integration/theme.test.js
+++ b/tests/integration/theme.test.js
@@ -49,8 +49,26 @@ describe("startThemeWatcher", () => {
     );
   });
 
+  it("body 'light' beats system dark mode — explicit choice wins", () => {
+    document.body.className = "en_US light";
+    mediaQueryDark = true;
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: false })
+    );
+  });
+
+  it("body 'dark' beats system light mode — explicit choice wins", () => {
+    document.body.className = "en_US dark";
+    mediaQueryDark = false;
+    startThemeWatcher();
+    expect(storageSet).toHaveBeenCalledWith(
+      expect.objectContaining({ [STORAGE_KEYS.pageIsDark]: true })
+    );
+  });
+
   it("falls back to matchMedia when body has no theme class", () => {
-    document.body.className = "";
+    document.body.className = "en_US";
     mediaQueryDark = true;
     startThemeWatcher();
     expect(storageSet).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR makes the Android app have a native feel by implementing an edge-to-edge view. The app is now fully adaptive theme-wise. #20 addresses the placement of the BDS widget on Android.

<details>
  <summary>Screens</summary>
  <img width="644" height="1428" alt="image" src="https://github.com/user-attachments/assets/b6c78e3b-17e7-464f-883d-e89d6d2495e2" />

<img width="638" height="1409" alt="image" src="https://github.com/user-attachments/assets/3b34de36-406f-49a5-885b-fdac2dab2556" />
</details>



