### PR TITLE
Hide `Get App` buttons on Android

### DIFF
--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -367,10 +367,54 @@ class MainActivity : ComponentActivity() {
             })();
         """.trimIndent()
 
+        // Hides the "Download mobile App" (or equivalent) item from the settings drawer
+        // (.ds-floating-position-wrapper). Detection is text-based (/download.*app|get.*app/i)
+        // so it survives class-name renames. The observer stays alive for the page lifetime.
+        // NodeFilter.SHOW_TEXT = 4.
+        // Hides the "Download mobile App" item from DeepSeek's settings dropdown.
+        // Uses the same .ds-dropdown-menu / .ds-dropdown-menu-option__label structure
+        // as SidebarMenuInjector. Update TARGET if DeepSeek renames the item (e.g. i18n).
+        val hideDrawerItem =
+                """
+            (function () {
+                if (window.__bdsDrawerItemObserver) return;
+                var TARGET = 'Download mobile App';
+                function hideItem(menu) {
+                    var options = menu.querySelectorAll('.ds-dropdown-menu-option');
+                    for (var i = 0; i < options.length; i++) {
+                        var label = options[i].querySelector('.ds-dropdown-menu-option__label');
+                        if (label && label.textContent.trim().includes(TARGET)) {
+                            options[i].style.display = 'none';
+                            console.log('[BDS] Hidden drawer app item');
+                        }
+                    }
+                }
+                document.querySelectorAll('.ds-dropdown-menu').forEach(hideItem);
+                var observer = new MutationObserver(function (mutations) {
+                    for (var m = 0; m < mutations.length; m++) {
+                        var added = mutations[m].addedNodes;
+                        for (var n = 0; n < added.length; n++) {
+                            var node = added[n];
+                            if (node.nodeType !== 1) continue;
+                            if (node.classList.contains('ds-dropdown-menu')) {
+                                hideItem(node);
+                            } else {
+                                var menu = node.querySelector && node.querySelector('.ds-dropdown-menu');
+                                if (menu) hideItem(menu);
+                            }
+                        }
+                    }
+                });
+                observer.observe(document.body, { childList: true, subtree: true });
+                window.__bdsDrawerItemObserver = observer;
+            })();
+        """.trimIndent()
+
         view.evaluateJavascript(injected, null)
         view.evaluateJavascript(bootstrap, null)
         view.evaluateJavascript(content, null)
         view.evaluateJavascript(hideGetApp, null)
+        view.evaluateJavascript(hideDrawerItem, null)
     }
 
     private fun readAsset(path: String): String? =

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -341,12 +341,13 @@ class MainActivity : ComponentActivity() {
 
         // Hides the "Get App" promotional button shown on mobile viewports.
         // Detection is text-based so it survives DeepSeek's dynamic class renames.
-        // A MutationObserver retries if the element is not yet present at injection time.
+        // The observer stays alive for the lifetime of the page so SPA navigations that
+        // re-insert the button are caught automatically.
         val hideGetApp =
                 """
             (function () {
-                if (window.__bdsGetAppHidden) return;
-                function attempt() {
+                if (window.__bdsGetAppObserver) return;
+                function hideButton() {
                     var spans = document.querySelectorAll('span');
                     for (var i = 0; i < spans.length; i++) {
                         var span = spans[i];
@@ -355,20 +356,14 @@ class MainActivity : ComponentActivity() {
                         while (el && el.tagName !== 'BUTTON') { el = el.parentElement; }
                         if (el && el.parentElement) {
                             el.parentElement.style.display = 'none';
-                            window.__bdsGetAppHidden = true;
                             console.log('[BDS] Hidden Get App container');
-                            return true;
                         }
                     }
-                    return false;
                 }
-                if (attempt()) return;
-                var timeout;
-                var observer = new MutationObserver(function () {
-                    if (attempt()) { observer.disconnect(); clearTimeout(timeout); }
-                });
+                hideButton();
+                var observer = new MutationObserver(hideButton);
                 observer.observe(document.body, { subtree: true, childList: true });
-                timeout = setTimeout(function () { observer.disconnect(); }, 10000);
+                window.__bdsGetAppObserver = observer;
             })();
         """.trimIndent()
 

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -339,9 +339,43 @@ class MainActivity : ComponentActivity() {
             })();
         """.trimIndent()
 
+        // Hides the "Get App" promotional button shown on mobile viewports.
+        // Detection is text-based so it survives DeepSeek's dynamic class renames.
+        // A MutationObserver retries if the element is not yet present at injection time.
+        val hideGetApp =
+                """
+            (function () {
+                if (window.__bdsGetAppHidden) return;
+                function attempt() {
+                    var spans = document.querySelectorAll('span');
+                    for (var i = 0; i < spans.length; i++) {
+                        var span = spans[i];
+                        if (span.textContent.trim() !== 'Get App') continue;
+                        var el = span.parentElement;
+                        while (el && el.tagName !== 'BUTTON') { el = el.parentElement; }
+                        if (el && el.parentElement) {
+                            el.parentElement.style.display = 'none';
+                            window.__bdsGetAppHidden = true;
+                            console.log('[BDS] Hidden Get App container');
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+                if (attempt()) return;
+                var timeout;
+                var observer = new MutationObserver(function () {
+                    if (attempt()) { observer.disconnect(); clearTimeout(timeout); }
+                });
+                observer.observe(document.body, { subtree: true, childList: true });
+                timeout = setTimeout(function () { observer.disconnect(); }, 10000);
+            })();
+        """.trimIndent()
+
         view.evaluateJavascript(injected, null)
         view.evaluateJavascript(bootstrap, null)
         view.evaluateJavascript(content, null)
+        view.evaluateJavascript(hideGetApp, null)
     }
 
     private fun readAsset(path: String): String? =

--- a/src/android/hide-drawer-app-item.js
+++ b/src/android/hide-drawer-app-item.js
@@ -1,0 +1,49 @@
+/**
+ * Hides the "Download mobile App" item from DeepSeek's settings dropdown
+ * (.ds-dropdown-menu). The menu uses the same DOM structure as per-chat context
+ * menus: items are .ds-dropdown-menu-option elements with a child
+ * .ds-dropdown-menu-option__label holding the text.
+ *
+ * Mirrors SidebarMenuInjector's observer pattern so both run on the same menu
+ * instance without conflict.
+ *
+ * Update DRAWER_APP_ITEM_TEXT if DeepSeek renames the item.
+ */
+
+/** Exact trimmed text of the settings menu item to hide. */
+export const DRAWER_APP_ITEM_TEXT = "Download mobile App";
+
+export function hideDrawerAppItem() {
+  if (window.__bdsDrawerItemObserver) return;
+
+  function hideItem(menu) {
+    const options = menu.querySelectorAll(".ds-dropdown-menu-option");
+    for (const opt of options) {
+      const label = opt.querySelector(".ds-dropdown-menu-option__label");
+      if (label?.textContent.trim().includes(DRAWER_APP_ITEM_TEXT)) {
+        opt.style.display = "none";
+        console.log("[BDS] Hidden drawer app item");
+      }
+    }
+  }
+
+  // Handle any menus already in the DOM at injection time.
+  document.querySelectorAll(".ds-dropdown-menu").forEach(hideItem);
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (node.classList.contains("ds-dropdown-menu")) {
+          hideItem(node);
+        } else {
+          const menu = node.querySelector?.(".ds-dropdown-menu");
+          if (menu) hideItem(menu);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+  window.__bdsDrawerItemObserver = observer;
+}

--- a/src/android/hide-get-app.js
+++ b/src/android/hide-get-app.js
@@ -3,12 +3,13 @@
  * Called by MainActivity.injectBdsScripts() on every page finish.
  *
  * Detection is text-based ("Get App" span) so it survives DeepSeek's dynamic class renames.
- * A MutationObserver retries if the element is not yet in the DOM at call time.
+ * The MutationObserver stays alive for the lifetime of the page so SPA navigations that
+ * re-insert the button are caught automatically.
  */
 export function hideGetAppButton() {
-  if (window.__bdsGetAppHidden) return;
+  if (window.__bdsGetAppObserver) return;
 
-  function attempt() {
+  function hideButton() {
     const spans = document.querySelectorAll("span");
     for (const span of spans) {
       if (span.textContent.trim() !== "Get App") continue;
@@ -18,25 +19,14 @@ export function hideGetAppButton() {
       }
       if (el && el.parentElement) {
         el.parentElement.style.display = "none";
-        window.__bdsGetAppHidden = true;
         console.log("[BDS] Hidden Get App container");
-        return true;
       }
     }
-    return false;
   }
 
-  if (attempt()) return;
+  hideButton();
 
-  // Element not yet in DOM — watch for it.
-  let timeout;
-  const observer = new MutationObserver(() => {
-    if (attempt()) {
-      observer.disconnect();
-      clearTimeout(timeout);
-    }
-  });
+  const observer = new MutationObserver(hideButton);
   observer.observe(document.body, { subtree: true, childList: true });
-  // Safety disconnect after 10 s to avoid leaking the observer.
-  timeout = setTimeout(() => observer.disconnect(), 10_000);
+  window.__bdsGetAppObserver = observer;
 }

--- a/src/android/hide-get-app.js
+++ b/src/android/hide-get-app.js
@@ -1,0 +1,42 @@
+/**
+ * Hides the "Get App" promotional button injected by chat.deepseek.com on mobile viewports.
+ * Called by MainActivity.injectBdsScripts() on every page finish.
+ *
+ * Detection is text-based ("Get App" span) so it survives DeepSeek's dynamic class renames.
+ * A MutationObserver retries if the element is not yet in the DOM at call time.
+ */
+export function hideGetAppButton() {
+  if (window.__bdsGetAppHidden) return;
+
+  function attempt() {
+    const spans = document.querySelectorAll("span");
+    for (const span of spans) {
+      if (span.textContent.trim() !== "Get App") continue;
+      let el = span.parentElement;
+      while (el && el.tagName !== "BUTTON") {
+        el = el.parentElement;
+      }
+      if (el && el.parentElement) {
+        el.parentElement.style.display = "none";
+        window.__bdsGetAppHidden = true;
+        console.log("[BDS] Hidden Get App container");
+        return true;
+      }
+    }
+    return false;
+  }
+
+  if (attempt()) return;
+
+  // Element not yet in DOM — watch for it.
+  let timeout;
+  const observer = new MutationObserver(() => {
+    if (attempt()) {
+      observer.disconnect();
+      clearTimeout(timeout);
+    }
+  });
+  observer.observe(document.body, { subtree: true, childList: true });
+  // Safety disconnect after 10 s to avoid leaking the observer.
+  timeout = setTimeout(() => observer.disconnect(), 10_000);
+}

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -249,6 +249,35 @@ test("exports a chat as markdown from the sidebar menu", async ({ page }) => {
   expect(artifact.suggestedFilename()).toMatch(/\.md$/);
 });
 
+test("hides the Get App promotional button when the Android hide script runs", async ({ page }) => {
+  const container = page.locator('[data-testid="get-app-container"]');
+  await expect(container).toBeVisible();
+
+  // Simulate MainActivity.injectBdsScripts() evaluating the hide-get-app snippet.
+  await page.evaluate(() => {
+    if (window.__bdsGetAppHidden) return;
+    function attempt() {
+      const spans = document.querySelectorAll("span");
+      for (const span of spans) {
+        if (span.textContent.trim() !== "Get App") continue;
+        let el = span.parentElement;
+        while (el && el.tagName !== "BUTTON") {
+          el = el.parentElement;
+        }
+        if (el && el.parentElement) {
+          el.parentElement.style.display = "none";
+          window.__bdsGetAppHidden = true;
+          return true;
+        }
+      }
+      return false;
+    }
+    attempt();
+  });
+
+  await expect(container).not.toBeVisible();
+});
+
 test("creates the PDF export iframe from the sidebar menu", async ({ page }) => {
   await page.goto("https://chat.deepseek.com/chat/s/mock-chat-1");
   await page.waitForSelector("#bds-toggle");

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -321,6 +321,65 @@ test("re-hides Get App button after SPA re-render (observer stays alive)", async
   await expect(page.locator('[data-testid="get-app-container-spa"]')).not.toBeVisible();
 });
 
+function installDrawerHideScript(page) {
+  return page.evaluate(() => {
+    if (window.__bdsDrawerItemObserver) return;
+    const TARGET = "Download mobile App";
+    function hideItem(menu) {
+      const options = menu.querySelectorAll(".ds-dropdown-menu-option");
+      for (const opt of options) {
+        const label = opt.querySelector(".ds-dropdown-menu-option__label");
+        if (label?.textContent.trim().includes(TARGET)) {
+          opt.style.display = "none";
+        }
+      }
+    }
+    document.querySelectorAll(".ds-dropdown-menu").forEach(hideItem);
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.nodeType !== 1) continue;
+          if (node.classList.contains("ds-dropdown-menu")) {
+            hideItem(node);
+          } else {
+            const menu = node.querySelector?.(".ds-dropdown-menu");
+            if (menu) hideItem(menu);
+          }
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    window.__bdsDrawerItemObserver = observer;
+  });
+}
+
+test("hides Download mobile App item in settings drawer when Android hide script runs", async ({ page }) => {
+  await installDrawerHideScript(page);
+
+  // Open the settings drawer (fixture builds a real .ds-dropdown-menu on click).
+  await page.locator('[data-testid="settings-trigger"]').click();
+  await expect(page.locator('[data-testid="settings-drawer"]')).toBeVisible();
+
+  // Download item must be hidden; other items must remain visible.
+  await expect(page.locator('[data-testid="drawer-item-download"]')).not.toBeVisible();
+  await expect(page.locator('[data-testid="drawer-item-settings"]')).toBeVisible();
+  await expect(page.locator('[data-testid="drawer-item-logout"]')).toBeVisible();
+});
+
+test("re-hides drawer download item when settings menu is reopened (SPA nav)", async ({ page }) => {
+  await installDrawerHideScript(page);
+
+  // Open → verify hidden.
+  await page.locator('[data-testid="settings-trigger"]').click();
+  await expect(page.locator('[data-testid="drawer-item-download"]')).not.toBeVisible();
+
+  // Close by clicking elsewhere, then reopen — fixture creates a fresh .ds-dropdown-menu.
+  await page.locator("h1").click();
+  await page.locator('[data-testid="settings-trigger"]').click();
+  await expect(page.locator('[data-testid="drawer-item-download"]')).not.toBeVisible();
+  await expect(page.locator('[data-testid="drawer-item-settings"]')).toBeVisible();
+});
+
 test("creates the PDF export iframe from the sidebar menu", async ({ page }) => {
   await page.goto("https://chat.deepseek.com/chat/s/mock-chat-1");
   await page.waitForSelector("#bds-toggle");

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -255,8 +255,8 @@ test("hides the Get App promotional button when the Android hide script runs", a
 
   // Simulate MainActivity.injectBdsScripts() evaluating the hide-get-app snippet.
   await page.evaluate(() => {
-    if (window.__bdsGetAppHidden) return;
-    function attempt() {
+    if (window.__bdsGetAppObserver) return;
+    function hideButton() {
       const spans = document.querySelectorAll("span");
       for (const span of spans) {
         if (span.textContent.trim() !== "Get App") continue;
@@ -266,16 +266,59 @@ test("hides the Get App promotional button when the Android hide script runs", a
         }
         if (el && el.parentElement) {
           el.parentElement.style.display = "none";
-          window.__bdsGetAppHidden = true;
-          return true;
         }
       }
-      return false;
     }
-    attempt();
+    hideButton();
+    const observer = new MutationObserver(hideButton);
+    observer.observe(document.body, { subtree: true, childList: true });
+    window.__bdsGetAppObserver = observer;
   });
 
   await expect(container).not.toBeVisible();
+});
+
+test("re-hides Get App button after SPA re-render (observer stays alive)", async ({ page }) => {
+  // Install the hide script.
+  await page.evaluate(() => {
+    if (window.__bdsGetAppObserver) return;
+    function hideButton() {
+      const spans = document.querySelectorAll("span");
+      for (const span of spans) {
+        if (span.textContent.trim() !== "Get App") continue;
+        let el = span.parentElement;
+        while (el && el.tagName !== "BUTTON") {
+          el = el.parentElement;
+        }
+        if (el && el.parentElement) {
+          el.parentElement.style.display = "none";
+        }
+      }
+    }
+    hideButton();
+    const observer = new MutationObserver(hideButton);
+    observer.observe(document.body, { subtree: true, childList: true });
+    window.__bdsGetAppObserver = observer;
+  });
+
+  // Simulate SPA transition: remove original node and inject a fresh "Get App" button.
+  await page.evaluate(() => {
+    const old = document.querySelector('[data-testid="get-app-container"]');
+    if (old) old.remove();
+
+    const container = document.createElement("div");
+    container.dataset.testid = "get-app-container-spa";
+    const button = document.createElement("button");
+    button.type = "button";
+    const label = document.createElement("span");
+    label.textContent = "Get App";
+    button.appendChild(label);
+    container.appendChild(button);
+    document.body.prepend(container);
+  });
+
+  // Observer must auto-hide the re-inserted button.
+  await expect(page.locator('[data-testid="get-app-container-spa"]')).not.toBeVisible();
 });
 
 test("creates the PDF export iframe from the sidebar menu", async ({ page }) => {

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -249,6 +249,30 @@
         cursor: pointer;
         font-size: 13px;
       }
+
+      .mock-settings-trigger {
+        position: fixed;
+        bottom: 16px;
+        left: 16px;
+        width: 36px;
+        height: 36px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        background: #ffffff;
+        cursor: pointer;
+        font-size: 16px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 100;
+      }
+
+      .mock-settings-menu {
+        position: fixed;
+        bottom: 60px;
+        left: 16px;
+        z-index: 200;
+      }
     </style>
     <script>
       (() => {
@@ -381,6 +405,47 @@
 
           wireHistoryMenus();
 
+          // Settings menu: builds a real .ds-dropdown-menu on each open (same structure
+          // as per-chat menus) so the hide-drawer-app-item MutationObserver fires.
+          const SETTINGS_ITEMS = [
+            { text: "Settings", testid: "drawer-item-settings" },
+            { text: "Report issue", testid: "drawer-item-report" },
+            { text: "Download mobile App", testid: "drawer-item-download" },
+            { text: "Log out", testid: "drawer-item-logout" },
+          ];
+
+          function buildSettingsMenu() {
+            document.querySelectorAll(".mock-settings-menu").forEach((m) => m.remove());
+            const wrapper = document.createElement("div");
+            wrapper.className = "mock-settings-menu";
+            const menu = document.createElement("div");
+            menu.className = "ds-dropdown-menu";
+            menu.dataset.testid = "settings-drawer";
+            for (const { text, testid } of SETTINGS_ITEMS) {
+              const opt = document.createElement("div");
+              opt.className = "ds-dropdown-menu-option";
+              if (testid) opt.dataset.testid = testid;
+              opt.innerHTML = `
+                <div class="ds-dropdown-menu-option__icon"></div>
+                <div class="ds-dropdown-menu-option__label">${text}</div>
+              `;
+              menu.appendChild(opt);
+            }
+            wrapper.appendChild(menu);
+            document.body.appendChild(wrapper);
+          }
+
+          const settingsTrigger = document.getElementById("mock-settings-trigger");
+          settingsTrigger.addEventListener("click", (event) => {
+            event.stopPropagation();
+            buildSettingsMenu();
+          });
+          document.addEventListener("click", (event) => {
+            if (!event.target.closest(".mock-settings-menu") && !event.target.closest("#mock-settings-trigger")) {
+              document.querySelectorAll(".mock-settings-menu").forEach((m) => m.remove());
+            }
+          });
+
           window.__mockDeepSeek = {
             addAssistantMessage(text) {
               return appendMessage(createTextMessage("assistant", text));
@@ -405,6 +470,8 @@
     </script>
   </head>
   <body>
+    <button id="mock-settings-trigger" class="mock-settings-trigger" data-testid="settings-trigger" title="Settings">&#8943;</button>
+
     <div class="mock-get-app-bar" data-testid="get-app-container">
       <button type="button">
         <span aria-hidden="true">&#128241;</span>

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -228,6 +228,27 @@
       .ds-dropdown-menu-option__label {
         font-size: 13px;
       }
+
+      .mock-get-app-bar {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        padding: 8px 16px;
+        background: #ffffff;
+        border-bottom: 1px solid #e5e7eb;
+      }
+
+      .mock-get-app-bar button {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border: 1px solid #d1d5db;
+        border-radius: 8px;
+        background: #f9fafb;
+        cursor: pointer;
+        font-size: 13px;
+      }
     </style>
     <script>
       (() => {
@@ -384,6 +405,12 @@
     </script>
   </head>
   <body>
+    <div class="mock-get-app-bar" data-testid="get-app-container">
+      <button type="button">
+        <span aria-hidden="true">&#128241;</span>
+        <span>Get App</span>
+      </button>
+    </div>
     <div class="app-shell">
       <aside class="dc04ec1d">
         <div class="mock-sidebar-title">History</div>

--- a/tests/integration/hide-drawer-app-item.test.js
+++ b/tests/integration/hide-drawer-app-item.test.js
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DRAWER_APP_ITEM_TEXT,
+  hideDrawerAppItem,
+} from "../../src/android/hide-drawer-app-item.js";
+
+/** Creates a .ds-dropdown-menu matching DeepSeek's real DOM structure. */
+function makeMenu(items = []) {
+  const menu = document.createElement("div");
+  menu.className = "ds-dropdown-menu";
+  for (const { text, testid } of items) {
+    const opt = document.createElement("div");
+    opt.className = "ds-dropdown-menu-option";
+    if (testid) opt.dataset.testid = testid;
+    opt.innerHTML = `
+      <div class="ds-dropdown-menu-option__icon"></div>
+      <div class="ds-dropdown-menu-option__label">${text}</div>
+    `;
+    menu.appendChild(opt);
+  }
+  document.body.appendChild(menu);
+  return menu;
+}
+
+const STANDARD_ITEMS = [
+  { text: "Settings", testid: "item-settings" },
+  { text: "Report issue", testid: "item-report" },
+  { text: DRAWER_APP_ITEM_TEXT, testid: "item-download" },
+  { text: "Log out", testid: "item-logout" },
+];
+
+describe("hideDrawerAppItem", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete window.__bdsDrawerItemObserver;
+  });
+
+  afterEach(() => {
+    window.__bdsDrawerItemObserver?.disconnect();
+    delete window.__bdsDrawerItemObserver;
+  });
+
+  // ── DRAWER_APP_ITEM_TEXT constant ─────────────────────────────────────
+
+  it("DRAWER_APP_ITEM_TEXT is the exact target string", () => {
+    expect(DRAWER_APP_ITEM_TEXT).toBe("Download mobile App");
+  });
+
+  // ── immediate detection ────────────────────────────────────────────────
+
+  it("hides the Download mobile App option", () => {
+    makeMenu(STANDARD_ITEMS);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item-download"]').style.display).toBe("none");
+  });
+
+  it("leaves unrelated options visible", () => {
+    makeMenu(STANDARD_ITEMS);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item-settings"]').style.display).not.toBe("none");
+    expect(document.querySelector('[data-testid="item-report"]').style.display).not.toBe("none");
+    expect(document.querySelector('[data-testid="item-logout"]').style.display).not.toBe("none");
+  });
+
+  it("hides the option when label has surrounding whitespace", () => {
+    makeMenu([{ text: `  ${DRAWER_APP_ITEM_TEXT}  `, testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).toBe("none");
+  });
+
+  it("does nothing when no .ds-dropdown-menu is present", () => {
+    expect(() => hideDrawerAppItem()).not.toThrow();
+  });
+
+  // ── exact match required ───────────────────────────────────────────────
+
+  it("does not hide options with only partial text", () => {
+    makeMenu([{ text: "Download App", testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).not.toBe("none");
+  });
+
+  it("does not hide options with different casing", () => {
+    makeMenu([{ text: "download mobile app", testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).not.toBe("none");
+  });
+
+  it("does not hide options with alternate phrasing (Get the App)", () => {
+    makeMenu([{ text: "Get the App", testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).not.toBe("none");
+  });
+
+  it("hides the option when label has a leading icon before the target text", () => {
+    makeMenu([{ text: "📱 Download mobile App", testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).toBe("none");
+  });
+
+  it("does not hide options with unrelated text", () => {
+    makeMenu([{ text: "Mobile settings", testid: "item" }]);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item"]').style.display).not.toBe("none");
+  });
+
+  // ── idempotency ────────────────────────────────────────────────────────
+
+  it("skips when __bdsDrawerItemObserver already set", () => {
+    const sentinel = { disconnect: () => {} };
+    window.__bdsDrawerItemObserver = sentinel;
+    makeMenu(STANDARD_ITEMS);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item-download"]').style.display).not.toBe("none");
+    expect(window.__bdsDrawerItemObserver).toBe(sentinel);
+  });
+
+  it("sets __bdsDrawerItemObserver on window", () => {
+    hideDrawerAppItem();
+    expect(window.__bdsDrawerItemObserver).toBeTruthy();
+  });
+
+  // ── MutationObserver: menu added after call ────────────────────────────
+
+  it("hides option when .ds-dropdown-menu added after initial call", async () => {
+    hideDrawerAppItem();
+    makeMenu(STANDARD_ITEMS);
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="item-download"]').style.display).toBe("none"),
+    );
+  });
+
+  it("leaves unrelated options visible after deferred detection", async () => {
+    hideDrawerAppItem();
+    makeMenu(STANDARD_ITEMS);
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="item-download"]').style.display).toBe("none"),
+    );
+    expect(document.querySelector('[data-testid="item-settings"]').style.display).not.toBe("none");
+    expect(document.querySelector('[data-testid="item-logout"]').style.display).not.toBe("none");
+  });
+
+  it("does not affect per-chat menus that have no matching option", async () => {
+    hideDrawerAppItem();
+    // Simulate a chat context menu (Rename/Pin/Share/Delete — no download item).
+    makeMenu([
+      { text: "Rename", testid: "chat-rename" },
+      { text: "Pin", testid: "chat-pin" },
+      { text: "Delete", testid: "chat-delete" },
+    ]);
+    await vi.waitFor(() => expect(document.querySelector('[data-testid="chat-rename"]')).toBeTruthy());
+    expect(document.querySelector('[data-testid="chat-rename"]').style.display).not.toBe("none");
+    expect(document.querySelector('[data-testid="chat-delete"]').style.display).not.toBe("none");
+  });
+
+  // ── SPA persistence ───────────────────────────────────────────────────
+
+  it("re-hides option when menu is removed and re-added (SPA nav)", async () => {
+    const menu = makeMenu(STANDARD_ITEMS);
+    hideDrawerAppItem();
+    expect(document.querySelector('[data-testid="item-download"]').style.display).toBe("none");
+
+    menu.remove();
+    makeMenu(STANDARD_ITEMS);
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="item-download"]').style.display).toBe("none"),
+    );
+  });
+});

--- a/tests/integration/hide-get-app.test.js
+++ b/tests/integration/hide-get-app.test.js
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hideGetAppButton } from "../../src/android/hide-get-app.js";
+
+function makeGetAppButton() {
+  const container = document.createElement("div");
+  const button = document.createElement("button");
+  button.type = "button";
+  const icon = document.createElement("span");
+  icon.textContent = "phone-icon";
+  const label = document.createElement("span");
+  label.textContent = "Get App";
+  button.append(icon, label);
+  container.appendChild(button);
+  document.body.appendChild(container);
+  return { container, button, label };
+}
+
+describe("hideGetAppButton", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete window.__bdsGetAppHidden;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── immediate detection ────────────────────────────────────────────────
+
+  it("hides the container div that wraps the button", () => {
+    const { container } = makeGetAppButton();
+    hideGetAppButton();
+    expect(container.style.display).toBe("none");
+  });
+
+  it("sets __bdsGetAppHidden flag on window", () => {
+    makeGetAppButton();
+    hideGetAppButton();
+    expect(window.__bdsGetAppHidden).toBe(true);
+  });
+
+  it("ignores spans whose text does not match 'Get App'", () => {
+    const container = document.createElement("div");
+    const button = document.createElement("button");
+    const span = document.createElement("span");
+    span.textContent = "Download App";
+    button.appendChild(span);
+    container.appendChild(button);
+    document.body.appendChild(container);
+    hideGetAppButton();
+    expect(container.style.display).not.toBe("none");
+  });
+
+  it("does nothing when 'Get App' span has no button ancestor", () => {
+    const container = document.createElement("div");
+    const span = document.createElement("span");
+    span.textContent = "Get App";
+    container.appendChild(span);
+    document.body.appendChild(container);
+    expect(() => hideGetAppButton()).not.toThrow();
+    expect(container.style.display).not.toBe("none");
+  });
+
+  it("does not throw when no Get App span exists at all", () => {
+    expect(() => hideGetAppButton()).not.toThrow();
+  });
+
+  // ── idempotency ────────────────────────────────────────────────────────
+
+  it("skips hiding when __bdsGetAppHidden flag is already set", () => {
+    window.__bdsGetAppHidden = true;
+    const { container } = makeGetAppButton();
+    hideGetAppButton();
+    expect(container.style.display).not.toBe("none");
+  });
+
+  // ── MutationObserver fallback ──────────────────────────────────────────
+
+  it("hides container added to DOM after initial call", async () => {
+    hideGetAppButton();
+    const { container } = makeGetAppButton();
+    await vi.waitFor(() => expect(container.style.display).toBe("none"));
+  });
+
+  it("sets __bdsGetAppHidden flag after deferred detection", async () => {
+    hideGetAppButton();
+    makeGetAppButton();
+    await vi.waitFor(() => expect(window.__bdsGetAppHidden).toBe(true));
+  });
+
+  it("stops watching after 10-second safety timeout", async () => {
+    hideGetAppButton();
+    vi.advanceTimersByTime(10_000);
+    // Element added after observer disconnects — must NOT be hidden.
+    const { container } = makeGetAppButton();
+    // Flush any pending microtasks — observer is disconnected so nothing fires.
+    await Promise.resolve();
+    expect(container.style.display).not.toBe("none");
+  });
+
+  // ── text-content resilience ────────────────────────────────────────────
+
+  it("trims whitespace when matching span text", () => {
+    const container = document.createElement("div");
+    const button = document.createElement("button");
+    const span = document.createElement("span");
+    span.textContent = "  Get App  ";
+    button.appendChild(span);
+    container.appendChild(button);
+    document.body.appendChild(container);
+    hideGetAppButton();
+    expect(container.style.display).toBe("none");
+  });
+
+  it("does not hide when text is 'Get App' cased differently", () => {
+    const container = document.createElement("div");
+    const button = document.createElement("button");
+    const span = document.createElement("span");
+    span.textContent = "get app";
+    button.appendChild(span);
+    container.appendChild(button);
+    document.body.appendChild(container);
+    hideGetAppButton();
+    expect(container.style.display).not.toBe("none");
+  });
+});

--- a/tests/integration/hide-get-app.test.js
+++ b/tests/integration/hide-get-app.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { hideGetAppButton } from "../../src/android/hide-get-app.js";
 
 function makeGetAppButton() {
@@ -20,12 +20,13 @@ function makeGetAppButton() {
 describe("hideGetAppButton", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
-    delete window.__bdsGetAppHidden;
-    vi.useFakeTimers();
+    delete window.__bdsGetAppObserver;
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    // Disconnect live observer so it doesn't bleed between tests.
+    window.__bdsGetAppObserver?.disconnect();
+    delete window.__bdsGetAppObserver;
   });
 
   // ── immediate detection ────────────────────────────────────────────────
@@ -36,10 +37,10 @@ describe("hideGetAppButton", () => {
     expect(container.style.display).toBe("none");
   });
 
-  it("sets __bdsGetAppHidden flag on window", () => {
+  it("sets __bdsGetAppObserver on window", () => {
     makeGetAppButton();
     hideGetAppButton();
-    expect(window.__bdsGetAppHidden).toBe(true);
+    expect(window.__bdsGetAppObserver).toBeTruthy();
   });
 
   it("ignores spans whose text does not match 'Get App'", () => {
@@ -70,14 +71,18 @@ describe("hideGetAppButton", () => {
 
   // ── idempotency ────────────────────────────────────────────────────────
 
-  it("skips hiding when __bdsGetAppHidden flag is already set", () => {
-    window.__bdsGetAppHidden = true;
+  it("skips setup when __bdsGetAppObserver already set", () => {
+    const sentinel = { disconnect: vi.fn() };
+    window.__bdsGetAppObserver = sentinel;
     const { container } = makeGetAppButton();
     hideGetAppButton();
+    // Container should not be hidden — the early-return fired.
     expect(container.style.display).not.toBe("none");
+    // Sentinel must be untouched.
+    expect(window.__bdsGetAppObserver).toBe(sentinel);
   });
 
-  // ── MutationObserver fallback ──────────────────────────────────────────
+  // ── MutationObserver: deferred detection ──────────────────────────────
 
   it("hides container added to DOM after initial call", async () => {
     hideGetAppButton();
@@ -85,20 +90,30 @@ describe("hideGetAppButton", () => {
     await vi.waitFor(() => expect(container.style.display).toBe("none"));
   });
 
-  it("sets __bdsGetAppHidden flag after deferred detection", async () => {
+  it("observer is set immediately (not deferred)", () => {
     hideGetAppButton();
-    makeGetAppButton();
-    await vi.waitFor(() => expect(window.__bdsGetAppHidden).toBe(true));
+    expect(window.__bdsGetAppObserver).toBeTruthy();
   });
 
-  it("stops watching after 10-second safety timeout", async () => {
-    hideGetAppButton();
-    vi.advanceTimersByTime(10_000);
-    // Element added after observer disconnects — must NOT be hidden.
+  // ── SPA persistence: observer stays alive after first hide ────────────
+
+  it("re-hides button when removed and re-inserted (SPA nav)", async () => {
     const { container } = makeGetAppButton();
-    // Flush any pending microtasks — observer is disconnected so nothing fires.
-    await Promise.resolve();
-    expect(container.style.display).not.toBe("none");
+    hideGetAppButton();
+    expect(container.style.display).toBe("none");
+
+    // Simulate SPA transition: remove old node, add fresh one.
+    container.remove();
+    const { container: container2 } = makeGetAppButton();
+    await vi.waitFor(() => expect(container2.style.display).toBe("none"));
+  });
+
+  it("hides all matching instances if multiple exist simultaneously", () => {
+    const { container: c1 } = makeGetAppButton();
+    const { container: c2 } = makeGetAppButton();
+    hideGetAppButton();
+    expect(c1.style.display).toBe("none");
+    expect(c2.style.display).toBe("none");
   });
 
   // ── text-content resilience ────────────────────────────────────────────


### PR DESCRIPTION
Simple PR that persistently hides the `Get App` buttons on Android in 1) the DeepSeek settings drawer and 2) the landing page at the top-right for better UX in the BDS app.