### PR TITLE
Improve Android typing by pushing viewport up if keyboard active

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.json:json:20240303")
+    testImplementation("org.robolectric:robolectric:4.13")
 
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -7,6 +7,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
@@ -30,6 +31,16 @@ import java.io.ByteArrayInputStream
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import okhttp3.Request
+
+internal fun applyRootWindowInsets(view: View, windowInsets: WindowInsetsCompat): WindowInsetsCompat {
+    val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+    val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+
+    view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+    // Edge-to-edge WebViews do not resize reliably for IME insets, so shift the wrapper instead.
+    view.translationY = -imeInsets.bottom.toFloat()
+    return WindowInsetsCompat.CONSUMED
+}
 
 /**
  * Single-activity host. Loads chat.deepseek.com inside a full-screen WebView and injects the BDS
@@ -111,9 +122,9 @@ class MainActivity : ComponentActivity() {
                     setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
-        // FrameLayout wrapper receives system-bar insets and applies them as padding.
-        // WebView.setPadding() does not shift the WebView viewport reliably, so the wrapper
-        // is the inset target. Its background fills the padding band behind the system bars.
+        // FrameLayout wrapper receives system-bar padding and IME translation.
+        // WebView.setPadding() does not shift the viewport reliably, so the wrapper is the
+        // inset target. Its background fills the padding band behind the system bars.
         val rootLayout = FrameLayout(this).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -123,11 +134,7 @@ class MainActivity : ComponentActivity() {
             addView(webView)
         }
 
-        ViewCompat.setOnApplyWindowInsetsListener(rootLayout) { view, windowInsets ->
-            val bars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(bars.left, bars.top, bars.right, bars.bottom)
-            WindowInsetsCompat.CONSUMED
-        }
+        ViewCompat.setOnApplyWindowInsetsListener(rootLayout, ::applyRootWindowInsets)
 
         WindowInsetsControllerCompat(window, window.decorView).apply {
             isAppearanceLightStatusBars = !isPageDark

--- a/android/app/src/test/java/com/betterdeepseek/app/KeyboardInsetTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/KeyboardInsetTest.kt
@@ -1,0 +1,85 @@
+package com.betterdeepseek.app
+
+import android.widget.FrameLayout
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class KeyboardInsetTest {
+
+    private lateinit var rootLayout: FrameLayout
+
+    @Before
+    fun setUp() {
+        rootLayout = FrameLayout(RuntimeEnvironment.getApplication())
+        ViewCompat.setOnApplyWindowInsetsListener(rootLayout, ::applyRootWindowInsets)
+    }
+
+    @Test
+    fun `translation is zero when no keyboard is open`() {
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 0))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, insets)
+
+        assertEquals(0f, rootLayout.translationY, 0f)
+    }
+
+    @Test
+    fun `view is pushed up by keyboard height`() {
+        val keyboardHeight = 840
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, keyboardHeight))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, insets)
+
+        assertEquals(-keyboardHeight.toFloat(), rootLayout.translationY, 0f)
+    }
+
+    @Test
+    fun `transition from no keyboard to keyboard updates translation`() {
+        val noKeyboard = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 0))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, noKeyboard)
+        assertEquals(0f, rootLayout.translationY, 0f)
+
+        val withKeyboard = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 840))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, withKeyboard)
+        assertEquals(-840f, rootLayout.translationY, 0f)
+    }
+
+    @Test
+    fun `system bar insets are applied as padding`() {
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(24, 56, 24, 56))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 0))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, insets)
+
+        assertEquals(24, rootLayout.paddingLeft)
+        assertEquals(56, rootLayout.paddingTop)
+        assertEquals(24, rootLayout.paddingRight)
+        assertEquals(56, rootLayout.paddingBottom)
+    }
+}


### PR DESCRIPTION
This pushes viewport up on Android if the keyboard is active, allowing the user to see what they're typing, like other native apps.