### PR TITLE
Keyboard expands bottom padding without translating the view

### DIFF
--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -35,10 +35,12 @@ import okhttp3.Request
 internal fun applyRootWindowInsets(view: View, windowInsets: WindowInsetsCompat): WindowInsetsCompat {
     val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
     val imeInsets = windowInsets.getInsets(WindowInsetsCompat.Type.ime())
+    val bottomInset = maxOf(systemBars.bottom, imeInsets.bottom)
 
-    view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-    // Edge-to-edge WebViews do not resize reliably for IME insets, so shift the wrapper instead.
-    view.translationY = -imeInsets.bottom.toFloat()
+    // Resize the WebView host from the bottom so the top of the viewport stays anchored like a
+    // normal adjustResize layout, while still preserving the persistent system-bar insets.
+    view.setPadding(systemBars.left, systemBars.top, systemBars.right, bottomInset)
+    view.translationY = 0f
     return WindowInsetsCompat.CONSUMED
 }
 
@@ -122,7 +124,7 @@ class MainActivity : ComponentActivity() {
                     setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
-        // FrameLayout wrapper receives system-bar padding and IME translation.
+        // FrameLayout wrapper receives system-bar padding and expands its bottom inset for IME.
         // WebView.setPadding() does not shift the viewport reliably, so the wrapper is the
         // inset target. Its background fills the padding band behind the system bars.
         val rootLayout = FrameLayout(this).apply {

--- a/android/app/src/test/java/com/betterdeepseek/app/KeyboardInsetTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/KeyboardInsetTest.kt
@@ -37,7 +37,7 @@ class KeyboardInsetTest {
     }
 
     @Test
-    fun `view is pushed up by keyboard height`() {
+    fun `keyboard expands bottom padding without translating the view`() {
         val keyboardHeight = 840
         val insets = WindowInsetsCompat.Builder()
             .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
@@ -46,11 +46,12 @@ class KeyboardInsetTest {
 
         ViewCompat.dispatchApplyWindowInsets(rootLayout, insets)
 
-        assertEquals(-keyboardHeight.toFloat(), rootLayout.translationY, 0f)
+        assertEquals(0f, rootLayout.translationY, 0f)
+        assertEquals(keyboardHeight, rootLayout.paddingBottom)
     }
 
     @Test
-    fun `transition from no keyboard to keyboard updates translation`() {
+    fun `transition from no keyboard to keyboard updates bottom padding`() {
         val noKeyboard = WindowInsetsCompat.Builder()
             .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
             .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 0))
@@ -58,6 +59,7 @@ class KeyboardInsetTest {
 
         ViewCompat.dispatchApplyWindowInsets(rootLayout, noKeyboard)
         assertEquals(0f, rootLayout.translationY, 0f)
+        assertEquals(48, rootLayout.paddingBottom)
 
         val withKeyboard = WindowInsetsCompat.Builder()
             .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(16, 48, 16, 48))
@@ -65,7 +67,20 @@ class KeyboardInsetTest {
             .build()
 
         ViewCompat.dispatchApplyWindowInsets(rootLayout, withKeyboard)
-        assertEquals(-840f, rootLayout.translationY, 0f)
+        assertEquals(0f, rootLayout.translationY, 0f)
+        assertEquals(840, rootLayout.paddingBottom)
+    }
+
+    @Test
+    fun `system bar padding is kept when ime inset is smaller`() {
+        val insets = WindowInsetsCompat.Builder()
+            .setInsets(WindowInsetsCompat.Type.systemBars(), Insets.of(24, 56, 24, 56))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, 20))
+            .build()
+
+        ViewCompat.dispatchApplyWindowInsets(rootLayout, insets)
+
+        assertEquals(56, rootLayout.paddingBottom)
     }
 
     @Test


### PR DESCRIPTION
Previous approach only worked fine for Android emulators. Real phones suffered from the offset being too much. This one fixes it (tested on a real phone this time).