### PR TITLE
Stabilize Android file uploads by forcing single-file picker mode for Upload File

### DIFF
--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -48,11 +48,17 @@ class MainActivity : ComponentActivity() {
     private lateinit var cookieManager: CookieManager
 
     private var pendingFileChooser: ValueCallback<Array<Uri>>? = null
-    private val fileChooserLauncher: ActivityResultLauncher<Array<String>> =
+    private val multipleFileLauncher: ActivityResultLauncher<Array<String>> =
             registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
                 val callback = pendingFileChooser
                 pendingFileChooser = null
                 callback?.onReceiveValue(uris.toTypedArray())
+            }
+    private val singleFileLauncher: ActivityResultLauncher<Array<String>> =
+            registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+                val callback = pendingFileChooser
+                pendingFileChooser = null
+                callback?.onReceiveValue(uri?.let { arrayOf(it) } ?: emptyArray())
             }
 
     private val proxyClient: OkHttpClient by lazy {
@@ -232,7 +238,11 @@ class MainActivity : ComponentActivity() {
                                     ?.takeIf { it.isNotEmpty() }
                                     ?: arrayOf("*/*")
                     return try {
-                        fileChooserLauncher.launch(mimeTypes)
+                        if (fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
+                            multipleFileLauncher.launch(mimeTypes)
+                        } else {
+                            singleFileLauncher.launch(mimeTypes)
+                        }
                         true
                     } catch (t: Throwable) {
                         pendingFileChooser = null

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -48,17 +48,16 @@ class MainActivity : ComponentActivity() {
     private lateinit var cookieManager: CookieManager
 
     private var pendingFileChooser: ValueCallback<Array<Uri>>? = null
-    private val multipleFileLauncher: ActivityResultLauncher<Array<String>> =
-            registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+    private val fileChooserLauncher: ActivityResultLauncher<Intent> =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
                 val callback = pendingFileChooser
                 pendingFileChooser = null
-                callback?.onReceiveValue(uris.toTypedArray())
-            }
-    private val singleFileLauncher: ActivityResultLauncher<Array<String>> =
-            registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-                val callback = pendingFileChooser
-                pendingFileChooser = null
-                callback?.onReceiveValue(uri?.let { arrayOf(it) } ?: emptyArray())
+                callback?.onReceiveValue(
+                        WebChromeClient.FileChooserParams.parseResult(
+                                result.resultCode,
+                                result.data
+                        )
+                )
             }
 
     private val proxyClient: OkHttpClient by lazy {
@@ -230,19 +229,14 @@ class MainActivity : ComponentActivity() {
                 ): Boolean {
                     pendingFileChooser?.onReceiveValue(null)
                     pendingFileChooser = filePathCallback
-                    val mimeTypes =
-                            fileChooserParams
-                                    ?.acceptTypes
-                                    ?.filter { it.isNotBlank() }
-                                    ?.toTypedArray()
-                                    ?.takeIf { it.isNotEmpty() }
-                                    ?: arrayOf("*/*")
                     return try {
-                        if (fileChooserParams?.mode == FileChooserParams.MODE_OPEN_MULTIPLE) {
-                            multipleFileLauncher.launch(mimeTypes)
-                        } else {
-                            singleFileLauncher.launch(mimeTypes)
-                        }
+                        fileChooserLauncher.launch(
+                                fileChooserParams?.createIntent()
+                                        ?: Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                                            addCategory(Intent.CATEGORY_OPENABLE)
+                                            type = "*/*"
+                                        }
+                        )
                         true
                     } catch (t: Throwable) {
                         pendingFileChooser = null

--- a/src/content/files/native-file-input.js
+++ b/src/content/files/native-file-input.js
@@ -1,0 +1,48 @@
+/**
+ * Strategy selection for opening DeepSeek's native `<input type="file">`.
+ *
+ * This lives in the generic file-flow layer because the caller is part of the
+ * web attachment UI, even though one concrete strategy is Android-specific.
+ *
+ * Strategy pattern:
+ * - default strategy: click the input as-is.
+ * - Android single-file strategy: temporarily clear `multiple` so WebView
+ *   requests a single-file chooser instead of the OEM multi-document flow.
+ *
+ * The caller only expresses intent (`preferSingle`); this module chooses the
+ * appropriate native-picker strategy and keeps the platform workaround local.
+ */
+
+function clickNativeInput(nativeInput) {
+  nativeInput.click();
+  return true;
+}
+
+function openWithDefaultStrategy(nativeInput) {
+  return clickNativeInput(nativeInput);
+}
+
+function openWithAndroidSingleFileStrategy(nativeInput) {
+  const previousMultiple = nativeInput.multiple;
+  try {
+    nativeInput.multiple = false;
+    return clickNativeInput(nativeInput);
+  } finally {
+    nativeInput.multiple = previousMultiple;
+  }
+}
+
+function selectNativeFilePickerStrategy(nativeInput, { preferSingle = false } = {}) {
+  if (preferSingle && nativeInput.multiple) {
+    return openWithAndroidSingleFileStrategy;
+  }
+
+  return openWithDefaultStrategy;
+}
+
+export function openNativeFilePicker(nativeInput, options = {}) {
+  if (!nativeInput) return false;
+
+  const strategy = selectNativeFilePickerStrategy(nativeInput, options);
+  return strategy(nativeInput);
+}

--- a/src/content/files/native-file-input.js
+++ b/src/content/files/native-file-input.js
@@ -9,6 +9,11 @@
  * - Android single-file strategy: temporarily clear `multiple` so WebView
  *   requests a single-file chooser instead of the OEM multi-document flow.
  *
+ * Operational rule:
+ * - On Android, all user-facing "Upload File" actions should prefer the
+ *   single-file strategy, even if the backing DOM input is marked `multiple`.
+ *   Multi-file upload remains available on non-Android targets.
+ *
  * The caller only expresses intent (`preferSingle`); this module chooses the
  * appropriate native-picker strategy and keeps the platform workaround local.
  */

--- a/src/content/ui/AttachMenu.svelte
+++ b/src/content/ui/AttachMenu.svelte
@@ -9,6 +9,7 @@
   } from "../files/github-commits.js";
   import { fetchAndConvertWebPage } from "../files/web-reader.js";
   import { projectFilesToFile } from "../files/project-file-builder.js";
+  import { openNativeFilePicker } from "../files/native-file-input.js";
   import {
     getFilesForProject,
     setActiveProject,
@@ -281,7 +282,10 @@
   function handleUploadFile() {
     closeMenu();
     if (nativeInput) {
-      nativeInput.click();
+      // Native picker behavior is selected via a file-flow strategy. Android's
+      // "Upload File" path prefers the single-file strategy so WebView asks the
+      // platform chooser for one file even though DeepSeek's DOM input is `multiple`.
+      openNativeFilePicker(nativeInput, { preferSingle: isAndroidTarget });
     }
   }
 

--- a/src/content/ui/CharacterList.svelte
+++ b/src/content/ui/CharacterList.svelte
@@ -3,6 +3,7 @@
   import { pushConfigToPage } from "../bridge.js";
   import { STORAGE_KEYS } from "../../lib/constants.js";
   import { makeId } from "../../lib/utils/helpers.js";
+  import { openNativeFilePicker } from "../files/native-file-input.js";
 
   let characters = $state([...appState.characters]);
   let fileInput = $state(null);
@@ -29,7 +30,7 @@
   }
 
   function triggerImport() {
-    if (fileInput) fileInput.click();
+    openNativeFilePicker(fileInput, { preferSingle: true });
   }
 
   async function handleImport(event) {

--- a/src/content/ui/MemoryList.svelte
+++ b/src/content/ui/MemoryList.svelte
@@ -2,6 +2,7 @@
   import appState from "../state.js";
   import { STORAGE_KEYS } from "../../lib/constants.js";
   import { normalizeMemories } from "../storage.js";
+  import { openNativeFilePicker } from "../files/native-file-input.js";
 
   let entries = $state(
     Object.entries(appState.memories).sort((a, b) => a[0].localeCompare(b[0]))
@@ -27,7 +28,7 @@
   }
 
   function triggerImport() {
-    if (fileInput) fileInput.click();
+    openNativeFilePicker(fileInput, { preferSingle: true });
   }
 
   async function handleImport(event) {

--- a/src/content/ui/ProjectsManager.svelte
+++ b/src/content/ui/ProjectsManager.svelte
@@ -10,6 +10,7 @@
   } from "../project-manager.js";
   import { pushConfigToPage } from "../bridge.js";
   import { pickFolderSelection } from "../../lib/utils/folder-picker.js";
+  import { openNativeFilePicker } from "../files/native-file-input.js";
 
   let { onback } = $props();
 
@@ -116,7 +117,7 @@
   }
 
   function triggerFileUpload() {
-    fileInput?.click();
+    openNativeFilePicker(fileInput);
   }
 
   async function handleFileUpload(event) {

--- a/src/content/ui/ProjectsManager.svelte
+++ b/src/content/ui/ProjectsManager.svelte
@@ -117,7 +117,7 @@
   }
 
   function triggerFileUpload() {
-    openNativeFilePicker(fileInput);
+    openNativeFilePicker(fileInput, { preferSingle: isAndroidTarget });
   }
 
   async function handleFileUpload(event) {

--- a/src/content/ui/SkillList.svelte
+++ b/src/content/ui/SkillList.svelte
@@ -3,6 +3,7 @@
   import { pushConfigToPage } from "../bridge.js";
   import { STORAGE_KEYS } from "../../lib/constants.js";
   import { makeId } from "../../lib/utils/helpers.js";
+  import { openNativeFilePicker } from "../files/native-file-input.js";
 
   let skills = $state([...appState.skills]);
   let fileInput = $state(null);
@@ -28,7 +29,7 @@
   }
 
   function triggerImport() {
-    if (fileInput) fileInput.click();
+    openNativeFilePicker(fileInput, { preferSingle: true });
   }
 
   async function handleImportSkills(event) {

--- a/tests/e2e-android/android.spec.js
+++ b/tests/e2e-android/android.spec.js
@@ -79,6 +79,29 @@ test("hides the voice prompt mic button on Android", async ({ page }) => {
   await expect(page.locator(".bds-mic-btn")).toHaveCount(0);
 });
 
+test("Upload File requests single-file mode on Android", async ({ page }) => {
+  await page.evaluate(() => {
+    const input = document.querySelector("#native-file-input");
+    window.__mockDeepSeek.uploadFileClickMultiple = null;
+    input.click = () => {
+      window.__mockDeepSeek.uploadFileClickMultiple = input.multiple;
+    };
+  });
+
+  await page.locator(".bds-plus-btn").click({ force: true });
+  await page
+    .locator(".bds-attach-dropdown .bds-attach-item")
+    .filter({ hasText: "Upload File" })
+    .click({ force: true });
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.uploadFileClickMultiple))
+    .toBe(false);
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector("#native-file-input").multiple))
+    .toBe(true);
+});
+
 test("imports a GitHub repository and commit history through the Android bridge", async ({ page }) => {
   await page.evaluate((zipBase64) => {
     window.__bdsBridgeRoute = {

--- a/tests/e2e-android/android.spec.js
+++ b/tests/e2e-android/android.spec.js
@@ -102,6 +102,80 @@ test("Upload File requests single-file mode on Android", async ({ page }) => {
     .toBe(true);
 });
 
+test("drawer import and upload inputs stay single-file on Android", async ({ page }) => {
+  await openDrawer(page);
+  await page.evaluate(() => {
+    const modes = {};
+    window.__mockDeepSeek.drawerFilePickerModes = modes;
+
+    const names = ["skillImport", "characterImport", "memoryImport"];
+    const jsonInputs = Array.from(
+      document.querySelectorAll('#bds-drawer input[type="file"][accept=".json"]'),
+    );
+    jsonInputs.forEach((input, index) => {
+      input.addEventListener("click", (event) => {
+        modes[names[index]] = input.multiple;
+        event.preventDefault();
+      }, { once: true });
+    });
+
+    for (const [key, selector] of [
+      ["skillUpload", "#bds-skill-upload"],
+      ["characterUpload", "#bds-char-upload"],
+    ]) {
+      const input = document.querySelector(selector);
+      input.addEventListener("click", (event) => {
+        modes[key] = input.multiple;
+        event.preventDefault();
+      }, { once: true });
+    }
+  });
+
+  const importButtons = page.locator("#bds-drawer button").filter({ hasText: "Import" });
+  await importButtons.nth(0).click({ force: true });
+  await importButtons.nth(1).click({ force: true });
+  await importButtons.nth(2).click({ force: true });
+  await page.locator("#bds-skill-upload").dispatchEvent("click");
+  await page.locator("#bds-char-upload").dispatchEvent("click");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.drawerFilePickerModes))
+    .toEqual({
+      skillImport: false,
+      characterImport: false,
+      memoryImport: false,
+      skillUpload: false,
+      characterUpload: false,
+    });
+});
+
+test("project Upload File keeps multiple mode on Android", async ({ page }) => {
+  await openDrawer(page);
+  await page.locator("#bds-drawer button").filter({ hasText: "Manage" }).click({ force: true });
+  await page.locator("#bds-drawer button").filter({ hasText: "New Project" }).click({ force: true });
+  await page.locator('#bds-drawer input[placeholder="Project name (required)"]').fill("Regression Project");
+  await page.locator("#bds-drawer button").filter({ hasText: "Create" }).click({ force: true });
+  await page.locator("#bds-drawer .bds-skill-item").filter({ hasText: "Regression Project" }).click({ force: true });
+
+  await page.evaluate(() => {
+    const input = document.querySelector('#bds-drawer input[type="file"][multiple]');
+    window.__mockDeepSeek.projectUploadClickMultiple = null;
+    input.addEventListener("click", (event) => {
+      window.__mockDeepSeek.projectUploadClickMultiple = input.multiple;
+      event.preventDefault();
+    }, { once: true });
+  });
+
+  await page.locator("#bds-drawer button").filter({ hasText: "Upload File" }).click({ force: true });
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.projectUploadClickMultiple))
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector('#bds-drawer input[type="file"][multiple]').multiple))
+    .toBe(true);
+});
+
 test("imports a GitHub repository and commit history through the Android bridge", async ({ page }) => {
   await page.evaluate((zipBase64) => {
     window.__bdsBridgeRoute = {

--- a/tests/e2e-android/android.spec.js
+++ b/tests/e2e-android/android.spec.js
@@ -149,7 +149,7 @@ test("drawer import and upload inputs stay single-file on Android", async ({ pag
     });
 });
 
-test("project Upload File keeps multiple mode on Android", async ({ page }) => {
+test("project Upload File requests single-file mode on Android", async ({ page }) => {
   await openDrawer(page);
   await page.locator("#bds-drawer button").filter({ hasText: "Manage" }).click({ force: true });
   await page.locator("#bds-drawer button").filter({ hasText: "New Project" }).click({ force: true });
@@ -170,7 +170,7 @@ test("project Upload File keeps multiple mode on Android", async ({ page }) => {
 
   await expect
     .poll(() => page.evaluate(() => window.__mockDeepSeek.projectUploadClickMultiple))
-    .toBe(true);
+    .toBe(false);
   await expect
     .poll(() => page.evaluate(() => document.querySelector('#bds-drawer input[type="file"][multiple]').multiple))
     .toBe(true);

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -111,6 +111,30 @@ test("imports a GitHub repository through the attach menu flow", async ({ page }
     .toEqual(["Hello-World_github.txt"]);
 });
 
+test("Upload File keeps multiple mode in the web flow", async ({ page }) => {
+  await page.evaluate(() => {
+    const input = document.querySelector("#native-file-input");
+    window.__mockDeepSeek.uploadFileClickMultiple = null;
+    input.addEventListener("click", (event) => {
+      window.__mockDeepSeek.uploadFileClickMultiple = input.multiple;
+      event.preventDefault();
+    }, { once: true });
+  });
+
+  await page.locator(".bds-plus-btn").click();
+  await page
+    .locator(".bds-attach-dropdown .bds-attach-item")
+    .filter({ hasText: "Upload File" })
+    .click();
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.uploadFileClickMultiple))
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector("#native-file-input").multiple))
+    .toBe(true);
+});
+
 test("imports GitHub commit history as a second attachment when enabled", async ({ page }) => {
   await page.locator(".bds-plus-btn").click();
   await page.locator(".bds-attach-dropdown .bds-attach-item").filter({ hasText: "GitHub Repo" }).click();

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -135,6 +135,80 @@ test("Upload File keeps multiple mode in the web flow", async ({ page }) => {
     .toBe(true);
 });
 
+test("drawer import and upload inputs stay single-file in the web flow", async ({ page }) => {
+  await openDrawer(page);
+  await page.evaluate(() => {
+    const modes = {};
+    window.__mockDeepSeek.drawerFilePickerModes = modes;
+
+    const names = ["skillImport", "characterImport", "memoryImport"];
+    const jsonInputs = Array.from(
+      document.querySelectorAll('#bds-drawer input[type="file"][accept=".json"]'),
+    );
+    jsonInputs.forEach((input, index) => {
+      input.addEventListener("click", (event) => {
+        modes[names[index]] = input.multiple;
+        event.preventDefault();
+      }, { once: true });
+    });
+
+    for (const [key, selector] of [
+      ["skillUpload", "#bds-skill-upload"],
+      ["characterUpload", "#bds-char-upload"],
+    ]) {
+      const input = document.querySelector(selector);
+      input.addEventListener("click", (event) => {
+        modes[key] = input.multiple;
+        event.preventDefault();
+      }, { once: true });
+    }
+  });
+
+  const importButtons = page.locator("#bds-drawer button").filter({ hasText: "Import" });
+  await importButtons.nth(0).click();
+  await importButtons.nth(1).click();
+  await importButtons.nth(2).click();
+  await page.locator("#bds-skill-upload").dispatchEvent("click");
+  await page.locator("#bds-char-upload").dispatchEvent("click");
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.drawerFilePickerModes))
+    .toEqual({
+      skillImport: false,
+      characterImport: false,
+      memoryImport: false,
+      skillUpload: false,
+      characterUpload: false,
+    });
+});
+
+test("project Upload File keeps multiple mode in the web flow", async ({ page }) => {
+  await openDrawer(page);
+  await page.locator("#bds-drawer button").filter({ hasText: "Manage" }).click();
+  await page.locator("#bds-drawer button").filter({ hasText: "New Project" }).click();
+  await page.locator('#bds-drawer input[placeholder="Project name (required)"]').fill("Regression Project");
+  await page.locator("#bds-drawer button").filter({ hasText: "Create" }).click();
+  await page.locator("#bds-drawer .bds-skill-item").filter({ hasText: "Regression Project" }).click();
+
+  await page.evaluate(() => {
+    const input = document.querySelector('#bds-drawer input[type="file"][multiple]');
+    window.__mockDeepSeek.projectUploadClickMultiple = null;
+    input.addEventListener("click", (event) => {
+      window.__mockDeepSeek.projectUploadClickMultiple = input.multiple;
+      event.preventDefault();
+    }, { once: true });
+  });
+
+  await page.locator("#bds-drawer button").filter({ hasText: "Upload File" }).click();
+
+  await expect
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.projectUploadClickMultiple))
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => document.querySelector('#bds-drawer input[type="file"][multiple]').multiple))
+    .toBe(true);
+});
+
 test("imports GitHub commit history as a second attachment when enabled", async ({ page }) => {
   await page.locator(".bds-plus-btn").click();
   await page.locator(".bds-attach-dropdown .bds-attach-item").filter({ hasText: "GitHub Repo" }).click();

--- a/tests/integration/files/native-file-input.test.js
+++ b/tests/integration/files/native-file-input.test.js
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+import { openNativeFilePicker } from "../../../src/content/files/native-file-input.js";
+
+function createNativeInput() {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.multiple = true;
+  return input;
+}
+
+describe("openNativeFilePicker", () => {
+  it("clicks the native input without changing multiple by default", () => {
+    const input = createNativeInput();
+    input.click = vi.fn(() => {
+      expect(input.multiple).toBe(true);
+    });
+
+    openNativeFilePicker(input);
+
+    expect(input.click).toHaveBeenCalledOnce();
+    expect(input.multiple).toBe(true);
+  });
+
+  it("temporarily disables multiple when single-file mode is preferred", () => {
+    const input = createNativeInput();
+    input.click = vi.fn(() => {
+      expect(input.multiple).toBe(false);
+    });
+
+    openNativeFilePicker(input, { preferSingle: true });
+
+    expect(input.click).toHaveBeenCalledOnce();
+    expect(input.multiple).toBe(true);
+  });
+});

--- a/tests/integration/ui/AttachMenu.test.js
+++ b/tests/integration/ui/AttachMenu.test.js
@@ -107,6 +107,22 @@ describe("AttachMenu integration", () => {
     cleanup();
   });
 
+  it("keeps multiple enabled for the web Upload File flow", async () => {
+    const nativeInput = setupNativeInput();
+    nativeInput.click = vi.fn(() => {
+      expect(nativeInput.multiple).toBe(true);
+    });
+    const { target, cleanup } = renderSvelte(AttachMenu, { nativeInput });
+
+    target.querySelector(".bds-plus-btn").click();
+    await flushUi();
+    document.querySelector(".bds-attach-item").click();
+
+    expect(nativeInput.click).toHaveBeenCalledOnce();
+    expect(nativeInput.multiple).toBe(true);
+    cleanup();
+  });
+
   it("fetches a github repo and injects the resulting file", async () => {
     const nativeInput = setupNativeInput();
     const file = new File(["repo"], "repo.txt", { type: "text/plain" });

--- a/tests/integration/ui/ListComponents.test.js
+++ b/tests/integration/ui/ListComponents.test.js
@@ -6,7 +6,12 @@ const bridgeMocks = vi.hoisted(() => ({
   pushConfigToPage: vi.fn(),
 }));
 
+const nativeFileInputMocks = vi.hoisted(() => ({
+  openNativeFilePicker: vi.fn(),
+}));
+
 vi.mock("../../../src/content/bridge.js", () => bridgeMocks);
+vi.mock("../../../src/content/files/native-file-input.js", () => nativeFileInputMocks);
 
 import CharacterList from "../../../src/content/ui/CharacterList.svelte";
 import MemoryList from "../../../src/content/ui/MemoryList.svelte";
@@ -37,6 +42,7 @@ describe("memory, character, and skill components", () => {
       ui: { showToast: vi.fn() },
     });
     bridgeMocks.pushConfigToPage.mockReset();
+    nativeFileInputMocks.openNativeFilePicker.mockReset();
     document.body.innerHTML = "";
   });
 
@@ -76,6 +82,22 @@ describe("memory, character, and skill components", () => {
     cleanup();
   });
 
+  it("MemoryList import button keeps a single-file input", async () => {
+    const { target, cleanup } = renderSvelte(MemoryList);
+    await flushUi();
+    const fileInput = target.querySelector('input[type="file"]');
+
+    getButtonByText(target, "Import").click();
+    await flushUi();
+
+    expect(nativeFileInputMocks.openNativeFilePicker).toHaveBeenCalledWith(
+      fileInput,
+      { preferSingle: true },
+    );
+    expect(fileInput.multiple).toBe(false);
+    cleanup();
+  });
+
   it("CharacterList edits and uploads characters", async () => {
     state.characters = [
       { id: "c1", name: "Mage", usage: "rp", content: "wise", active: true },
@@ -106,6 +128,25 @@ describe("memory, character, and skill components", () => {
     await triggerFileInput(uploadInput, file);
 
     expect(state.characters.some((item) => item.name === "rogue")).toBe(true);
+    cleanup();
+  });
+
+  it("CharacterList keeps import and persona uploads single-file", async () => {
+    const { target, cleanup } = renderSvelte(CharacterList);
+    await flushUi();
+    const importInput = target.querySelector('input[type="file"][accept=".json"]');
+
+    getButtonByText(target, "Import").click();
+    await flushUi();
+
+    expect(nativeFileInputMocks.openNativeFilePicker).toHaveBeenCalledWith(
+      importInput,
+      { preferSingle: true },
+    );
+    expect(importInput.multiple).toBe(false);
+
+    const uploadInput = target.querySelector("#bds-char-upload");
+    expect(uploadInput.multiple).toBe(false);
     cleanup();
   });
 
@@ -140,6 +181,25 @@ describe("memory, character, and skill components", () => {
 
     expect(state.skills.some((item) => item.name === "planner")).toBe(true);
     expect(bridgeMocks.pushConfigToPage).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("SkillList keeps import and skill uploads single-file", async () => {
+    const { target, cleanup } = renderSvelte(SkillList);
+    await flushUi();
+    const importInput = target.querySelector('input[type="file"][accept=".json"]');
+
+    getButtonByText(target, "Import").click();
+    await flushUi();
+
+    expect(nativeFileInputMocks.openNativeFilePicker).toHaveBeenCalledWith(
+      importInput,
+      { preferSingle: true },
+    );
+    expect(importInput.multiple).toBe(false);
+
+    const uploadInput = target.querySelector("#bds-skill-upload");
+    expect(uploadInput.multiple).toBe(false);
     cleanup();
   });
 });

--- a/tests/integration/ui/ProjectsManager.test.js
+++ b/tests/integration/ui/ProjectsManager.test.js
@@ -137,4 +137,22 @@ describe("ProjectsManager integration", () => {
     expect(bridgeMocks.pushConfigToPage).toHaveBeenCalled();
     cleanup();
   });
+
+  it("keeps multiple enabled for the project Upload File flow", async () => {
+    const { target, cleanup } = renderSvelte(ProjectsManager, { onback: vi.fn() });
+    target.querySelector(".bds-skill-item").click();
+    await flushUi();
+
+    const fileInput = target.querySelector('input[type="file"][multiple]');
+    fileInput.click = vi.fn(() => {
+      expect(fileInput.multiple).toBe(true);
+    });
+
+    getButtonByText(target, "Upload File").click();
+    await flushUi();
+
+    expect(fileInput.click).toHaveBeenCalledOnce();
+    expect(fileInput.multiple).toBe(true);
+    cleanup();
+  });
 });


### PR DESCRIPTION
## Summary

Android file uploads were unreliable because our custom upload buttons were driving WebView into the multi-document picker path via hidden `multiple` file inputs. On some Android picker/provider combinations, that flow opens but does not complete selection on a normal tap, which effectively breaks uploads (discovered upon testing on a real device).

This change makes Android `Upload File` actions prefer the single-file picker path while preserving existing multi-file behavior on non-Android targets.

## What changed

- switched `MainActivity` to use WebView's chooser contract via `FileChooserParams.createIntent()` and `FileChooserParams.parseResult()`
- added a shared native file-picker strategy layer for web-driven file inputs
- routed button-triggered upload/import entry points through that strategy
- made Android `Upload File` actions request single-file mode even when the backing DOM input is marked `multiple`
- kept multi-file behavior unchanged for Chrome/Firefox/web builds
- added regression coverage for Android and non-Android upload flows

## Why the Android special case exists

This is not a blanket Android API limitation. Android supports multi-file document picking, but WebView itself delegates file selection to the Android document picker / provider stack, and that multi-select path behaves inconsistently across devices. Single-file requests are the reliable cross-device path, so this change optimizes for a working upload flow on Android.

## Tests

- integration tests for native picker strategy selection
- integration tests for attach menu, project upload, and drawer import/upload flows
- web Playwright regressions proving non-Android flows still keep multi-file mode where expected
- Android Playwright regressions proving `Upload File` now requests single-file mode