### PR TITLE
Implement native multifile picker and folder picker integration for Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
 
     implementation("com.google.android.material:material:1.12.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("androidx.documentfile:documentfile:1.0.1")
 
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito:mockito-core:5.12.0")

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -73,6 +73,37 @@ class MainActivity : ComponentActivity() {
                 )
             }
 
+    // Correlation key for in-flight native file/folder pick requests.
+    @Volatile private var pendingPickFilesRequestId: String? = null
+
+    private val multiFileLauncher: ActivityResultLauncher<Array<String>> =
+            registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+                val requestId = pendingPickFilesRequestId ?: return@registerForActivityResult
+                pendingPickFilesRequestId = null
+                if (uris.isNullOrEmpty()) {
+                    bridge.deliverPickError(requestId, "cancelled")
+                    return@registerForActivityResult
+                }
+                Thread {
+                    val files = uris.mapNotNull { uri -> bridge.readPickedContentUri(uri) }
+                    bridge.deliverPickedFiles(requestId, files, null)
+                }.start()
+            }
+
+    private val folderPickerLauncher: ActivityResultLauncher<Uri?> =
+            registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { treeUri ->
+                val requestId = pendingPickFilesRequestId ?: return@registerForActivityResult
+                pendingPickFilesRequestId = null
+                if (treeUri == null) {
+                    bridge.deliverPickError(requestId, "cancelled")
+                    return@registerForActivityResult
+                }
+                Thread {
+                    val (files, folderName) = bridge.readPickedFolderTree(treeUri)
+                    bridge.deliverPickedFiles(requestId, files, folderName)
+                }.start()
+            }
+
     private val proxyClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
                 .connectTimeout(20, TimeUnit.SECONDS)
@@ -91,6 +122,18 @@ class MainActivity : ComponentActivity() {
 
         bridge = WebViewBridge(applicationContext)
         cookieManager = CookieManager.getInstance()
+
+        // Wire native file/folder picker callbacks. pickFiles() is invoked on the JS thread;
+        // the launcher must be called on the UI thread, so we use runOnUiThread.
+        bridge.onPickFiles = { mode, requestId ->
+            pendingPickFilesRequestId = requestId
+            runOnUiThread {
+                when (mode) {
+                    "folder" -> folderPickerLauncher.launch(null)
+                    else -> multiFileLauncher.launch(arrayOf("*/*"))
+                }
+            }
+        }
 
         assetLoader =
                 WebViewAssetLoader.Builder()
@@ -125,6 +168,9 @@ class MainActivity : ComponentActivity() {
                     addJavascriptInterface(bridge, BRIDGE_NAME)
                     webViewClient = bdsWebViewClient()
                     webChromeClient = bdsWebChromeClient()
+                    // evaluateJavascript must be called on the main thread; bridge.deliverPickResult
+                    // already posts to mainHandler before invoking this lambda.
+                    bridge.evaluateJs = { script -> evaluateJavascript(script, null) }
                     isVerticalScrollBarEnabled = true
                     setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
@@ -179,6 +225,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onDestroy() {
         bridge.onThemeChanged = null
+        bridge.evaluateJs = null
+        bridge.onPickFiles = null
         webView.removeJavascriptInterface(BRIDGE_NAME)
         super.onDestroy()
     }

--- a/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/WebViewBridge.kt
@@ -10,11 +10,13 @@ import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import android.util.Base64
 import android.util.Log
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import androidx.core.content.FileProvider
+import androidx.documentfile.provider.DocumentFile
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.TimeUnit
@@ -24,6 +26,9 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONArray
 import org.json.JSONObject
+
+/** File entry returned by the native file/folder picker to JavaScript. */
+internal data class PickedFile(val name: String, val content: String)
 
 /**
  * @JavascriptInterface object exposed to the WebView as `window.AndroidBridge`.
@@ -59,9 +64,22 @@ class WebViewBridge(
     @Volatile var onThemeChanged: ((isDark: Boolean) -> Unit)? = null
 
     /**
+     * Set by MainActivity to forward a JS script to the WebView's JS context. Must be called on
+     * the main thread; [deliverPickResult] already posts to [mainHandler] before invoking this.
+     */
+    @Volatile var evaluateJs: ((script: String) -> Unit)? = null
+
+    /**
+     * Set by MainActivity to launch the native file or folder picker. Invoked on the
+     * @JavascriptInterface thread; the implementation must marshal to the UI thread before
+     * calling an ActivityResultLauncher.
+     */
+    @Volatile var onPickFiles: ((mode: String, requestId: String) -> Unit)? = null
+
+    /**
      * Returns the last DeepSeek page theme written by the extension's theme.js via
      * chrome.storage.local (which the Android polyfill routes through [setStorage] as
-     * JSON.stringify(boolean) → stored as the string "true" or "false"). Falls back to [default]
+     * JSON.stringify(boolean) -> stored as the string "true" or "false"). Falls back to [default]
      * on first-ever launch before any value has been persisted.
      */
     fun getLastKnownIsDark(default: Boolean = false): Boolean {
@@ -78,6 +96,161 @@ class WebViewBridge(
     fun reportTheme(isDark: Boolean) {
         onThemeChanged?.invoke(isDark)
     }
+
+    /**
+     * Called by JS (android-file-picker.js) to open the native multi-file or folder picker.
+     *
+     * [mode] is "files" or "folder". [requestId] is a UUID from the JS side used as a
+     * correlation key — the Kotlin side fires `__bds_native_files_picked_<requestId>` via
+     * [evaluateJs] when the Activity result arrives.
+     *
+     * If [onPickFiles] is null (old APK version), the method immediately delivers a "cancelled"
+     * result so the JS Promise resolves without hanging.
+     */
+    @JavascriptInterface
+    fun pickFiles(mode: String?, requestId: String?) {
+        val safeId = requestId
+            ?.filter { it.isLetterOrDigit() || it == '-' }
+            ?.take(64)
+        if (safeId.isNullOrEmpty()) return
+
+        val safeMode = if (mode == "folder") "folder" else "files"
+        val handler = onPickFiles
+        if (handler == null) {
+            deliverPickError(safeId, "cancelled")
+            return
+        }
+        handler.invoke(safeMode, safeId)
+    }
+
+    /**
+     * Called by MainActivity after the ActivityResult delivers files. Serialises [files] to JSON
+     * and dispatches a `__bds_native_files_picked_<requestId>` CustomEvent in the page.
+     */
+    internal fun deliverPickedFiles(requestId: String, files: List<PickedFile>, folderName: String?) {
+        val filesArr = JSONArray()
+        for (f in files) {
+            filesArr.put(JSONObject().apply {
+                put("name", f.name)
+                put("content", f.content)
+            })
+        }
+        val payload = JSONObject().apply {
+            put("files", filesArr)
+            if (folderName != null) put("folderName", folderName)
+        }
+        deliverPickResult(requestId, payload)
+    }
+
+    /** Deliver an error result (e.g. "cancelled") to the waiting JS Promise. */
+    internal fun deliverPickError(requestId: String, error: String) {
+        val payload = JSONObject().apply {
+            put("error", error)
+            put("files", JSONArray())
+        }
+        deliverPickResult(requestId, payload)
+    }
+
+    private fun deliverPickResult(requestId: String, payload: JSONObject) {
+        val safeId = requestId.filter { it.isLetterOrDigit() || it == '-' }.take(64)
+        if (safeId.isEmpty()) return
+        // JSONObject.quote wraps in double-quotes and escapes special chars — safe as JS string literal
+        val jsLiteral = JSONObject.quote(payload.toString())
+        val js = "(function(){try{var d=JSON.parse($jsLiteral);" +
+                "window.dispatchEvent(new CustomEvent('__bds_native_files_picked_$safeId'," +
+                "{detail:d}));}catch(e){}})();"
+        mainHandler.post { evaluateJs?.invoke(js) }
+    }
+
+    /**
+     * Read a single content URI (returned by OpenMultipleDocuments) into a [PickedFile].
+     * Returns null when the URI is not a readable text file or exceeds [MAX_FILE_SIZE].
+     */
+    internal fun readPickedContentUri(uri: Uri): PickedFile? {
+        return try {
+            val name = getDisplayName(uri) ?: return null
+            if (!isTextFileExtension(name)) return null
+            if (getContentLength(uri) > MAX_FILE_SIZE) return null
+            val content = context.contentResolver.openInputStream(uri)?.use { stream ->
+                stream.bufferedReader(Charsets.UTF_8).readText()
+            } ?: return null
+            if (content.any { it.code == 0 }) return null // null bytes indicate binary
+            PickedFile(name, content)
+        } catch (t: Throwable) {
+            Log.w(TAG, "readPickedContentUri failed for $uri", t)
+            null
+        }
+    }
+
+    /**
+     * Recursively read all text files under a document tree URI (returned by OpenDocumentTree).
+     * Returns a pair of (files, folderName). Respects [MAX_FILE_SIZE], [MAX_FOLDER_DEPTH], and
+     * [SKIP_DIRS], mirroring the JS folder-reader.js behaviour.
+     */
+    internal fun readPickedFolderTree(treeUri: Uri): Pair<List<PickedFile>, String> {
+        val docTree = DocumentFile.fromTreeUri(context, treeUri)
+            ?: return Pair(emptyList(), "folder")
+        val folderName = docTree.name ?: "folder"
+        val files = mutableListOf<PickedFile>()
+        traverseDocumentTree(docTree, "", files, 0)
+        return Pair(files, folderName)
+    }
+
+    private fun traverseDocumentTree(
+        dir: DocumentFile,
+        pathPrefix: String,
+        out: MutableList<PickedFile>,
+        depth: Int,
+    ) {
+        if (depth > MAX_FOLDER_DEPTH) return
+        for (child in dir.listFiles()) {
+            val name = child.name ?: continue
+            val relPath = if (pathPrefix.isEmpty()) name else "$pathPrefix/$name"
+            if (isSkippedPath(relPath)) continue
+            if (child.isDirectory) {
+                traverseDocumentTree(child, relPath, out, depth + 1)
+            } else if (child.isFile) {
+                val picked = readDocumentFile(child, relPath) ?: continue
+                out.add(picked)
+            }
+        }
+    }
+
+    private fun readDocumentFile(file: DocumentFile, relPath: String): PickedFile? {
+        if (!isTextFileExtension(file.name ?: return null)) return null
+        if (file.length() > MAX_FILE_SIZE) return null
+        return try {
+            val content = context.contentResolver.openInputStream(file.uri)?.use { stream ->
+                stream.bufferedReader(Charsets.UTF_8).readText()
+            } ?: return null
+            if (content.any { it.code == 0 }) return null // null bytes indicate binary
+            PickedFile(relPath, content)
+        } catch (t: Throwable) {
+            Log.w(TAG, "readDocumentFile failed for $relPath", t)
+            null
+        }
+    }
+
+    private fun getDisplayName(uri: Uri): String? =
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (!cursor.moveToFirst() || idx < 0) null else cursor.getString(idx)
+        }
+
+    private fun getContentLength(uri: Uri): Long =
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val idx = cursor.getColumnIndex(OpenableColumns.SIZE)
+            if (!cursor.moveToFirst() || idx < 0 || cursor.isNull(idx)) Long.MAX_VALUE
+            else cursor.getLong(idx)
+        } ?: Long.MAX_VALUE
+
+    private fun isTextFileExtension(filename: String): Boolean {
+        val ext = filename.substringAfterLast('.', "").lowercase()
+        return ext.isNotEmpty() && ext in TEXT_EXTENSIONS
+    }
+
+    private fun isSkippedPath(relPath: String): Boolean =
+        relPath.split("/").any { it in SKIP_DIRS }
 
     @JavascriptInterface
     fun getStorage(key: String?): String? {
@@ -567,5 +740,25 @@ class WebViewBridge(
         // polyfill routes chrome.storage.local.set({ bds_page_is_dark: ... }) through setStorage,
         // so getLastKnownIsDark() and the polyfill share the same SharedPreferences key.
         internal const val KEY_LAST_PAGE_DARK = "bds_page_is_dark"
+
+        /** Max bytes per file — mirrors the 2 MB cap in folder-reader.js. */
+        internal const val MAX_FILE_SIZE = 2L * 1024 * 1024
+
+        /** Max directory nesting depth during folder traversal. */
+        private const val MAX_FOLDER_DEPTH = 15
+
+        /** Text-file extensions considered readable — mirrors isTextFile() in folder-reader.js. */
+        private val TEXT_EXTENSIONS = setOf(
+            "js", "ts", "jsx", "tsx", "svelte", "vue", "html", "css", "scss", "json",
+            "md", "txt", "py", "c", "cpp", "h", "hpp", "java", "go", "rs", "rb", "php",
+            "sh", "yml", "yaml", "toml", "ini", "csv", "sql", "xml", "env",
+            "cs", "csproj", "sln", "fs", "fsproj", "razor", "swift", "kt", "dart",
+        )
+
+        /** Directory names skipped during folder traversal to avoid large generated trees. */
+        private val SKIP_DIRS = setOf(
+            "node_modules", ".git", ".svn", "dist", "build", "__pycache__",
+            ".gradle", ".idea", "vendor", ".next", ".cache",
+        )
     }
 }

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewBridgeTest.kt
@@ -361,4 +361,97 @@ class WebViewBridgeTest {
         assertEquals(401, response.getInt("status"))
         assertTrue(response.getBoolean("authRejected"))
     }
+
+    // ── pickFiles ───────────────────────────────────────────────────────
+
+    @Test
+    fun `pickFiles invokes onPickFiles with files mode and sanitized requestId`() {
+        var capturedMode: String? = null
+        var capturedId: String? = null
+        bridge.onPickFiles = { mode, id -> capturedMode = mode; capturedId = id }
+
+        bridge.pickFiles("files", "abc-123")
+
+        assertEquals("files", capturedMode)
+        assertEquals("abc-123", capturedId)
+    }
+
+    @Test
+    fun `pickFiles normalizes unknown mode to files`() {
+        var capturedMode: String? = null
+        bridge.onPickFiles = { mode, _ -> capturedMode = mode }
+
+        bridge.pickFiles("banana", "abc-123")
+
+        assertEquals("files", capturedMode)
+    }
+
+    @Test
+    fun `pickFiles passes folder mode unchanged`() {
+        var capturedMode: String? = null
+        bridge.onPickFiles = { mode, _ -> capturedMode = mode }
+
+        bridge.pickFiles("folder", "abc-123")
+
+        assertEquals("folder", capturedMode)
+    }
+
+    @Test
+    fun `pickFiles strips injection characters from requestId`() {
+        var capturedId: String? = null
+        bridge.onPickFiles = { _, id -> capturedId = id }
+
+        bridge.pickFiles("files", "ab!@#cd--12")
+
+        assertEquals("abcd--12", capturedId)
+    }
+
+    @Test
+    fun `pickFiles truncates requestId to 64 characters`() {
+        val longId = "a".repeat(80)
+        var capturedId: String? = null
+        bridge.onPickFiles = { _, id -> capturedId = id }
+
+        bridge.pickFiles("files", longId)
+
+        assertEquals(64, capturedId?.length)
+    }
+
+    @Test
+    fun `pickFiles returns immediately for null requestId without invoking handler`() {
+        var called = false
+        bridge.onPickFiles = { _, _ -> called = true }
+
+        bridge.pickFiles("files", null)
+
+        assertFalse(called)
+    }
+
+    @Test
+    fun `pickFiles returns immediately for empty requestId without invoking handler`() {
+        var called = false
+        bridge.onPickFiles = { _, _ -> called = true }
+
+        bridge.pickFiles("files", "")
+
+        assertFalse(called)
+    }
+
+    @Test
+    fun `pickFiles returns immediately when requestId contains only invalid characters`() {
+        var called = false
+        bridge.onPickFiles = { _, _ -> called = true }
+
+        bridge.pickFiles("files", "!@#\$%^")
+
+        assertFalse(called)
+    }
+
+    @Test
+    fun `pickFiles does not throw when onPickFiles is null`() {
+        // Old APK: handler not wired. Bridge must not crash; it delivers a
+        // "cancelled" result asynchronously via mainHandler — covered by E2E.
+        bridge.onPickFiles = null
+        bridge.pickFiles("files", "abc-123")
+    }
 }

--- a/src/content/ui/AttachMenu.svelte
+++ b/src/content/ui/AttachMenu.svelte
@@ -11,6 +11,11 @@
   import { projectFilesToFile } from "../files/project-file-builder.js";
   import { openNativeFilePicker } from "../files/native-file-input.js";
   import {
+    isNativeFilePickerAvailable,
+    nativePickFiles,
+    buildFolderFileFromNative,
+  } from "../../platform/android-file-picker.js";
+  import {
     getFilesForProject,
     setActiveProject,
     clearActiveProject,
@@ -68,12 +73,9 @@
   const BDS_TARGET = process.env.BDS_TARGET || "chrome";
   const isAndroidTarget = BDS_TARGET === "android";
 
-  // Folder upload uses window.showDirectoryPicker — unavailable in Android
-  // WebView. Voice input is hidden on Android because SpeechRecognition isn't
-  // wired up in WebView; the on-screen keyboard mic is always reachable.
-  // On non-Android targets we keep the buttons visible and let the existing
-  // runtime fallbacks (toast on missing API) handle older Chromium variants.
-  const supportsFolderUpload = !isAndroidTarget;
+  // Folder upload: web uses showDirectoryPicker; Android uses the native bridge when available.
+  // Voice input is hidden on Android because SpeechRecognition is not wired up in the WebView.
+  const supportsFolderUpload = !isAndroidTarget || isNativeFilePickerAvailable();
   const supportsVoiceInput = !isAndroidTarget;
 
   function hasGithubToken() {
@@ -279,8 +281,24 @@
     }
   }
 
-  function handleUploadFile() {
+  async function handleUploadFile() {
     closeMenu();
+    // On Android with native bridge: launch multi-file picker, then inject results.
+    if (isAndroidTarget && isNativeFilePickerAvailable()) {
+      try {
+        const result = await nativePickFiles("files");
+        if (!result.cancelled && result.files && result.files.length > 0) {
+          for (const f of result.files) {
+            const blob = new Blob([f.content], { type: "text/plain" });
+            injectFile(new File([blob], f.name, { type: "text/plain" }));
+          }
+        }
+      } catch (err) {
+        if (appState.ui) appState.ui.showToast(err?.message || "File pick failed.");
+      }
+      return;
+    }
+    // Fallback: use the DOM file input (web or old Android app without pickFiles).
     if (nativeInput) {
       // Native picker behavior is selected via a file-flow strategy. Android's
       // "Upload File" path prefers the single-file strategy so WebView asks the
@@ -292,11 +310,22 @@
   async function handleUploadFolder() {
     closeMenu();
 
-    if (!supportsFolderUpload) {
-      if (appState.ui) {
-        appState.ui.showToast(
-          "Folder upload is not supported on Android yet.",
-        );
+    // On Android with native bridge: launch folder picker, build workspace file.
+    if (isAndroidTarget) {
+      if (isNativeFilePickerAvailable()) {
+        try {
+          const result = await nativePickFiles("folder");
+          if (!result.cancelled && result.files && result.files.length > 0) {
+            const fakeFile = buildFolderFileFromNative(result.files, result.folderName);
+            if (fakeFile) injectFile(fakeFile);
+          }
+        } catch (err) {
+          if (appState.ui) appState.ui.showToast(err?.message || "Folder pick failed.");
+        }
+      } else {
+        if (appState.ui) {
+          appState.ui.showToast("Folder upload requires a newer version of the app.");
+        }
       }
       return;
     }

--- a/src/content/ui/ProjectsManager.svelte
+++ b/src/content/ui/ProjectsManager.svelte
@@ -11,12 +11,16 @@
   import { pushConfigToPage } from "../bridge.js";
   import { pickFolderSelection } from "../../lib/utils/folder-picker.js";
   import { openNativeFilePicker } from "../files/native-file-input.js";
+  import {
+    isNativeFilePickerAvailable,
+    nativePickFiles,
+  } from "../../platform/android-file-picker.js";
 
   let { onback } = $props();
 
   const BDS_TARGET = process.env.BDS_TARGET || "chrome";
   const isAndroidTarget = BDS_TARGET === "android";
-  const supportsFolderUpload = !isAndroidTarget;
+  const supportsFolderUpload = !isAndroidTarget || isNativeFilePickerAvailable();
 
   // view: "list" | "detail"
   let view = $state("list");
@@ -116,7 +120,26 @@
     goBack();
   }
 
-  function triggerFileUpload() {
+  async function triggerFileUpload() {
+    // On Android with native bridge: launch multi-file picker then inject via DataTransfer so
+    // the existing handleFileUpload() processes the files without duplication.
+    if (isAndroidTarget && isNativeFilePickerAvailable()) {
+      try {
+        const result = await nativePickFiles("files");
+        if (result.cancelled || !result.files || result.files.length === 0) return;
+        if (!fileInput) return;
+        const dt = new DataTransfer();
+        for (const f of result.files) {
+          const blob = new Blob([f.content], { type: "text/plain" });
+          dt.items.add(new File([blob], f.name, { type: "text/plain" }));
+        }
+        fileInput.files = dt.files;
+        fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+      } catch (err) {
+        if (appState.ui) appState.ui.showToast(err?.message || "File pick failed.");
+      }
+      return;
+    }
     openNativeFilePicker(fileInput, { preferSingle: isAndroidTarget });
   }
 
@@ -180,12 +203,49 @@
   }
 
   async function handleFolderUpload() {
-    if (!supportsFolderUpload) {
-      if (appState.ui) {
-        appState.ui.showToast(
-          "Folder upload is not supported on Android yet.",
-        );
+    // On Android with native bridge: launch folder picker, process files directly into storage.
+    if (isAndroidTarget) {
+      if (isNativeFilePickerAvailable()) {
+        uploading = true;
+        fileError = "";
+        try {
+          const result = await nativePickFiles("folder");
+          if (!result.cancelled && result.files && result.files.length > 0) {
+            const MAX_SIZE = 500 * 1024;
+            const filesToAdd = [];
+            let skippedCount = 0;
+            for (const f of result.files) {
+              if (f.content.length > MAX_SIZE) { skippedCount++; continue; }
+              if (!f.content.trim()) { skippedCount++; continue; }
+              filesToAdd.push({ name: f.name, content: f.content });
+            }
+            if (filesToAdd.length > 0) {
+              try {
+                await addProjectFilesBatch(selectedProject.id, filesToAdd);
+              } catch (err) {
+                fileError = "Storage error: " + (err?.message || String(err));
+              }
+            }
+            if (skippedCount > 0) {
+              fileError = filesToAdd.length + " file" + (filesToAdd.length !== 1 ? "s" : "") +
+                " uploaded, " + skippedCount + " skipped (too large or empty).";
+            }
+          }
+        } catch (err) {
+          fileError = err?.message || "Folder pick failed.";
+        } finally {
+          uploading = false;
+          projectFiles = getFilesForProject(selectedProject.id);
+        }
+      } else {
+        if (appState.ui) {
+          appState.ui.showToast("Folder upload requires a newer version of the app.");
+        }
       }
+      return;
+    }
+
+    if (!supportsFolderUpload) {
       return;
     }
 

--- a/src/platform/android-bridge-shim.js
+++ b/src/platform/android-bridge-shim.js
@@ -18,6 +18,9 @@
  *   getAssetUrl(relativePath: String): String
  *   downloadBlob(base64, mimeType, fileName): void
  *   reportTheme(isDark: Boolean): void  // live bar-icon colour update; persistence via setStorage
+ *   pickFiles(mode: String, requestId: String): void
+ *     // mode: "files" | "folder"; result delivered as CustomEvent '__bds_native_files_picked_<requestId>'
+ *     // See android-file-picker.js for the Promise wrapper (nativePickFiles).
  */
 
 function getBridge() {

--- a/src/platform/android-file-picker.js
+++ b/src/platform/android-file-picker.js
@@ -1,0 +1,136 @@
+/**
+ * Native Android file/folder picker bridge.
+ *
+ * Wraps window.AndroidBridge.pickFiles (when available) into a Promise-based API.
+ * Safe to import on all build targets — returns false/rejects when the bridge method is absent.
+ *
+ * Native bridge contract (WebViewBridge.kt):
+ *   pickFiles(mode: String, requestId: String): void
+ *     mode:      "files" | "folder"
+ *     requestId: UUID-style string ([a-z0-9-], max 64 chars)
+ *   Result delivered as CustomEvent '__bds_native_files_picked_<requestId>' with detail:
+ *     { files: [{name, content}], folderName?: string }   on success
+ *     { error: "cancelled", files: [] }                   on user cancellation
+ *     { error: "<message>",  files: [] }                  on error
+ */
+
+/**
+ * Returns true when AndroidBridge.pickFiles is available (Android 11+ native app with bridge
+ * registered). Safe to call on any platform.
+ */
+export function isNativeFilePickerAvailable() {
+  return (
+    typeof window !== "undefined" &&
+    window.AndroidBridge != null &&
+    typeof window.AndroidBridge.pickFiles === "function"
+  );
+}
+
+/**
+ * Launch the native file or folder picker and resolve with the selected files.
+ *
+ * @param {"files"|"folder"} mode
+ * @returns {Promise<{files: Array<{name:string, content:string}>, folderName?: string, cancelled?: boolean}>}
+ */
+export function nativePickFiles(mode) {
+  return new Promise((resolve, reject) => {
+    if (!isNativeFilePickerAvailable()) {
+      reject(new Error("[BDS] AndroidBridge.pickFiles not available"));
+      return;
+    }
+
+    const requestId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : Date.now().toString(36) + Math.random().toString(36).slice(2);
+
+    const eventName = "__bds_native_files_picked_" + requestId;
+
+    const handler = (e) => {
+      window.removeEventListener(eventName, handler);
+      const data = e.detail;
+      if (!data) {
+        resolve({ files: [] });
+        return;
+      }
+      if (data.error === "cancelled") {
+        resolve({ files: [], cancelled: true });
+      } else if (data.error) {
+        reject(new Error(data.error));
+      } else {
+        resolve(data);
+      }
+    };
+
+    window.addEventListener(eventName, handler);
+
+    try {
+      window.AndroidBridge.pickFiles(String(mode || "files"), requestId);
+    } catch (err) {
+      window.removeEventListener(eventName, handler);
+      reject(err);
+    }
+  });
+}
+
+/**
+ * Convert native-picked files into a single concatenated File, matching the format produced by
+ * pickFolderAndConcatenate in folder-reader.js. All files are assumed to be text (already
+ * filtered by the Kotlin side).
+ *
+ * @param {Array<{name:string, content:string}>} files
+ * @param {string} folderName
+ * @returns {File|null}
+ */
+export function buildFolderFileFromNative(files, folderName) {
+  if (!files || files.length === 0) return null;
+
+  const tree = buildPathTree(files.map((f) => f.name));
+  let content =
+    "Directory Tree:\n" +
+    renderPathTree(tree) +
+    "\n\n========================================\n\n";
+
+  for (const f of files) {
+    content += "\n\n--- [FILE: " + f.name + "] ---\n\n";
+    content += f.content;
+  }
+
+  const blob = new Blob([content], { type: "text/plain" });
+  const name = (folderName || "folder") + "_workspace.txt";
+  return new File([blob], name, { type: "text/plain" });
+}
+
+function buildPathTree(paths) {
+  const tree = {};
+  for (const p of paths) {
+    const parts = p.split("/");
+    let cur = tree;
+    for (const part of parts) {
+      if (!cur[part]) cur[part] = {};
+      cur = cur[part];
+    }
+  }
+  return tree;
+}
+
+function renderPathTree(tree, prefix) {
+  if (prefix === undefined) prefix = "";
+  const keys = Object.keys(tree).sort(function (a, b) {
+    const aIsDir = Object.keys(tree[a]).length > 0;
+    const bIsDir = Object.keys(tree[b]).length > 0;
+    if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
+    return a.localeCompare(b);
+  });
+  let out = "";
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const isLast = i === keys.length - 1;
+    // Use ASCII box-drawing approximations to avoid non-ASCII chars in source.
+    out += prefix + (isLast ? "`-- " : "|-- ") + key + "\n";
+    if (Object.keys(tree[key]).length > 0) {
+      out += renderPathTree(tree[key], prefix + (isLast ? "    " : "|   "));
+    }
+  }
+  return out;
+}

--- a/tests/e2e-android/android.spec.js
+++ b/tests/e2e-android/android.spec.js
@@ -33,59 +33,42 @@ test("loads the bundle and surfaces the BDS toggle inside the WebView simulator"
   await expect(page.locator("#bds-toggle")).toBeVisible();
 });
 
-test("hides the folder upload menu item on Android", async ({ page }) => {
+test("shows the folder upload menu item on Android when native pickFiles is available", async ({ page }) => {
   await page.locator(".bds-plus-btn").click({ force: true });
   await expect(page.locator(".bds-attach-dropdown")).toBeVisible();
+  // Native bridge mock includes pickFiles, so supportsFolderUpload is true.
   await expect(
     page.locator(".bds-attach-dropdown .bds-attach-item").filter({ hasText: "Upload Folder" }),
-  ).toHaveCount(0);
+  ).toBeVisible();
   await expect(
     page.locator(".bds-attach-dropdown .bds-attach-item").filter({ hasText: "GitHub Repo" }),
   ).toBeVisible();
 });
 
-test("Upload Folder button is hidden in Projects panel on Android", async ({ page }) => {
-  // Verify via Evaluate that the built content.js carries the Android
-  // target check and calls handleFolderUpload()'s toast path.
-  // The ProjectsManager.svelte mounts inside the drawer; we assert
-  // the Build-time define baked "android" into the module.
-  const builtForAndroid = await page.evaluate(() => {
-    // The AttachMenu and ProjectsManager both gate on BDS_TARGET.
-    // The Vite define inlines the string, so in dist-android/content.js
-    // the expression `process.env.BDS_TARGET || "chrome"` evaluates to
-    // `"android" || "chrome"` → `"android"`. We probe via the folder
-    // upload button on the attach menu — already verified hidden above.
-    // Here we additionally verify that the drawer's project management
-    // button exists and the built bundle has the correct target.
-    return typeof document !== "undefined";
-  });
-  expect(builtForAndroid).toBe(true);
+test("Upload Folder button is visible in Projects panel on Android when native bridge available", async ({ page }) => {
+  await openDrawer(page);
+  await page.locator("#bds-drawer button").filter({ hasText: "Manage" }).click({ force: true });
+  await page.locator("#bds-drawer button").filter({ hasText: "New Project" }).click({ force: true });
+  await page.locator('#bds-drawer input[placeholder="Project name (required)"]').fill("Folder Test");
+  await page.locator("#bds-drawer button").filter({ hasText: "Create" }).click({ force: true });
+  await page.locator("#bds-drawer .bds-skill-item").filter({ hasText: "Folder Test" }).click({ force: true });
 
-  // A direct check: since BDS_TARGET is "android" in this build, the
-  // `supportsFolderUpload` flag in ProjectsManager.svelte is false,
-  // so no "+ Upload Folder" button is ever rendered. We confirm that
-  // the `handleFolderUpload` function's guard is reachable by checking
-  // that the module pattern matches the expected built output.
-  const folderUploadCalls = await page.evaluate(() => {
-    // The AttachMenu's handleUploadFolder logs via toast when called
-    // on Android. The toast module is window-accessible. We assert
-    // that the folder upload menu item was hidden (confirmed above).
-    return true;
-  });
-  expect(folderUploadCalls).toBe(true);
+  // With native pickFiles available, Upload Folder should be visible.
+  await expect(
+    page.locator("#bds-drawer button").filter({ hasText: "Upload Folder" }),
+  ).toBeVisible();
 });
 
 test("hides the voice prompt mic button on Android", async ({ page }) => {
   await expect(page.locator(".bds-mic-btn")).toHaveCount(0);
 });
 
-test("Upload File requests single-file mode on Android", async ({ page }) => {
+test("Upload File on Android uses native pickFiles bridge and injects result", async ({ page }) => {
+  // Set up native picker mock to return one file.
   await page.evaluate(() => {
-    const input = document.querySelector("#native-file-input");
-    window.__mockDeepSeek.uploadFileClickMultiple = null;
-    input.click = () => {
-      window.__mockDeepSeek.uploadFileClickMultiple = input.multiple;
-    };
+    window.__bdsNativeFilePicker = (_mode) => ({
+      files: [{ name: "picked.txt", content: "native content" }],
+    });
   });
 
   await page.locator(".bds-plus-btn").click({ force: true });
@@ -95,11 +78,49 @@ test("Upload File requests single-file mode on Android", async ({ page }) => {
     .click({ force: true });
 
   await expect
-    .poll(() => page.evaluate(() => window.__mockDeepSeek.uploadFileClickMultiple))
-    .toBe(false);
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.getAttachedFiles()))
+    .toContain("picked.txt");
+});
+
+test("Upload Folder on Android uses native folder pickFiles bridge and builds workspace file", async ({ page }) => {
+  await page.evaluate(() => {
+    window.__bdsNativeFilePicker = (_mode) => ({
+      files: [
+        { name: "src/index.js", content: 'console.log("hello");' },
+        { name: "README.md", content: "# Project" },
+      ],
+      folderName: "myProject",
+    });
+  });
+
+  await page.locator(".bds-plus-btn").click({ force: true });
+  await page
+    .locator(".bds-attach-dropdown .bds-attach-item")
+    .filter({ hasText: "Upload Folder" })
+    .click({ force: true });
+
   await expect
-    .poll(() => page.evaluate(() => document.querySelector("#native-file-input").multiple))
-    .toBe(true);
+    .poll(() => page.evaluate(() => window.__mockDeepSeek.getAttachedFiles()))
+    .toContain("myProject_workspace.txt");
+});
+
+test("Upload File cancellation on Android leaves input unchanged", async ({ page }) => {
+  // Default mock returns cancelled; no files should be injected.
+  await page.evaluate(() => {
+    window.__bdsNativeFilePicker = (_mode) => ({ files: [], cancelled: true });
+  });
+
+  const initialFiles = await page.evaluate(() => window.__mockDeepSeek.getAttachedFiles());
+
+  await page.locator(".bds-plus-btn").click({ force: true });
+  await page
+    .locator(".bds-attach-dropdown .bds-attach-item")
+    .filter({ hasText: "Upload File" })
+    .click({ force: true });
+
+  await page.waitForTimeout(300);
+  const afterFiles = await page.evaluate(() => window.__mockDeepSeek.getAttachedFiles());
+  expect(afterFiles).toHaveLength(initialFiles.length);
 });
 
 test("drawer import and upload inputs stay single-file on Android", async ({ page }) => {
@@ -149,7 +170,7 @@ test("drawer import and upload inputs stay single-file on Android", async ({ pag
     });
 });
 
-test("project Upload File requests single-file mode on Android", async ({ page }) => {
+test("project Upload File on Android uses native pickFiles bridge", async ({ page }) => {
   await openDrawer(page);
   await page.locator("#bds-drawer button").filter({ hasText: "Manage" }).click({ force: true });
   await page.locator("#bds-drawer button").filter({ hasText: "New Project" }).click({ force: true });
@@ -157,23 +178,25 @@ test("project Upload File requests single-file mode on Android", async ({ page }
   await page.locator("#bds-drawer button").filter({ hasText: "Create" }).click({ force: true });
   await page.locator("#bds-drawer .bds-skill-item").filter({ hasText: "Regression Project" }).click({ force: true });
 
+  // Set up native picker to return one file.
   await page.evaluate(() => {
+    window.__bdsNativeFilePicker = (_mode) => ({
+      files: [{ name: "project-file.txt", content: "project content" }],
+    });
+    // Track whether the DOM file input was clicked directly (it should NOT be on Android).
     const input = document.querySelector('#bds-drawer input[type="file"][multiple]');
-    window.__mockDeepSeek.projectUploadClickMultiple = null;
-    input.addEventListener("click", (event) => {
-      window.__mockDeepSeek.projectUploadClickMultiple = input.multiple;
-      event.preventDefault();
+    window.__mockDeepSeek.projectInputClickedDirectly = false;
+    input.addEventListener("click", () => {
+      window.__mockDeepSeek.projectInputClickedDirectly = true;
     }, { once: true });
   });
 
   await page.locator("#bds-drawer button").filter({ hasText: "Upload File" }).click({ force: true });
 
-  await expect
-    .poll(() => page.evaluate(() => window.__mockDeepSeek.projectUploadClickMultiple))
-    .toBe(false);
-  await expect
-    .poll(() => page.evaluate(() => document.querySelector('#bds-drawer input[type="file"][multiple]').multiple))
-    .toBe(true);
+  // Native bridge should have been called, not the DOM input.
+  await page.waitForTimeout(500);
+  const clickedDirectly = await page.evaluate(() => window.__mockDeepSeek.projectInputClickedDirectly);
+  expect(clickedDirectly).toBe(false);
 });
 
 test("imports a GitHub repository and commit history through the Android bridge", async ({ page }) => {

--- a/tests/e2e-android/helpers/android.js
+++ b/tests/e2e-android/helpers/android.js
@@ -75,6 +75,26 @@ function buildAndroidBridgeBootstrap() {
         downloadBlob(base64, mimeType, fileName) {
           downloads.push({ base64, mimeType, fileName });
         },
+        pickFiles(mode, requestId) {
+          // Per-test override: set window.__bdsNativeFilePicker = (mode) => result.
+          // Default: simulate cancellation after a short delay.
+          const handler = window.__bdsNativeFilePicker;
+          setTimeout(function () {
+            let detail;
+            if (typeof handler === "function") {
+              try {
+                detail = handler(mode);
+              } catch (err) {
+                detail = { error: String(err), files: [] };
+              }
+            } else {
+              detail = { files: [], cancelled: true };
+            }
+            window.dispatchEvent(
+              new CustomEvent("__bds_native_files_picked_" + requestId, { detail: detail }),
+            );
+          }, 10);
+        },
       };
     })();
   `;

--- a/tests/integration/platform/android-file-picker.test.js
+++ b/tests/integration/platform/android-file-picker.test.js
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildFolderFileFromNative,
+  isNativeFilePickerAvailable,
+  nativePickFiles,
+} from "../../../src/platform/android-file-picker.js";
+
+// ── isNativeFilePickerAvailable ───────────────────────────────────────────────
+
+describe("isNativeFilePickerAvailable", () => {
+  afterEach(() => {
+    delete window.AndroidBridge;
+  });
+
+  it("returns false when AndroidBridge is absent", () => {
+    expect(isNativeFilePickerAvailable()).toBe(false);
+  });
+
+  it("returns false when AndroidBridge lacks pickFiles", () => {
+    window.AndroidBridge = { getStorage: () => null };
+    expect(isNativeFilePickerAvailable()).toBe(false);
+  });
+
+  it("returns false when pickFiles is not a function", () => {
+    window.AndroidBridge = { pickFiles: "not-a-function" };
+    expect(isNativeFilePickerAvailable()).toBe(false);
+  });
+
+  it("returns true when AndroidBridge.pickFiles is a function", () => {
+    window.AndroidBridge = { pickFiles: vi.fn() };
+    expect(isNativeFilePickerAvailable()).toBe(true);
+  });
+});
+
+// ── nativePickFiles ───────────────────────────────────────────────────────────
+
+describe("nativePickFiles", () => {
+  function installBridgeMock(handler) {
+    window.AndroidBridge = {
+      pickFiles: vi.fn((mode, requestId) => {
+        setTimeout(() => {
+          const result = handler(mode, requestId);
+          window.dispatchEvent(
+            new CustomEvent("__bds_native_files_picked_" + requestId, {
+              detail: result,
+            }),
+          );
+        }, 0);
+      }),
+    };
+  }
+
+  afterEach(() => {
+    delete window.AndroidBridge;
+  });
+
+  it("rejects immediately when bridge is unavailable", async () => {
+    await expect(nativePickFiles("files")).rejects.toThrow(
+      "AndroidBridge.pickFiles not available",
+    );
+  });
+
+  it("resolves with files on success", async () => {
+    installBridgeMock(() => ({
+      files: [{ name: "hello.txt", content: "hello" }],
+    }));
+    const result = await nativePickFiles("files");
+    expect(result.files).toEqual([{ name: "hello.txt", content: "hello" }]);
+  });
+
+  it("resolves with cancelled:true on user cancellation", async () => {
+    installBridgeMock(() => ({ error: "cancelled", files: [] }));
+    const result = await nativePickFiles("files");
+    expect(result.cancelled).toBe(true);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it("rejects on non-cancellation error", async () => {
+    installBridgeMock(() => ({ error: "permission denied", files: [] }));
+    await expect(nativePickFiles("files")).rejects.toThrow("permission denied");
+  });
+
+  it("resolves with empty files when detail is null", async () => {
+    installBridgeMock(() => null);
+    const result = await nativePickFiles("files");
+    expect(result.files).toHaveLength(0);
+  });
+
+  it("calls bridge with the provided mode", async () => {
+    installBridgeMock(() => ({ files: [] }));
+    await nativePickFiles("folder");
+    expect(window.AndroidBridge.pickFiles).toHaveBeenCalledWith(
+      "folder",
+      expect.any(String),
+    );
+  });
+
+  it("calls bridge with 'files' when mode is omitted", async () => {
+    installBridgeMock(() => ({ files: [] }));
+    await nativePickFiles();
+    expect(window.AndroidBridge.pickFiles).toHaveBeenCalledWith(
+      "files",
+      expect.any(String),
+    );
+  });
+
+  it("includes folderName from folder mode result", async () => {
+    installBridgeMock(() => ({
+      files: [{ name: "a.txt", content: "a" }],
+      folderName: "myRepo",
+    }));
+    const result = await nativePickFiles("folder");
+    expect(result.folderName).toBe("myRepo");
+  });
+});
+
+// ── buildFolderFileFromNative ─────────────────────────────────────────────────
+
+describe("buildFolderFileFromNative", () => {
+  // jsdom 26 exposes FileReader but not Blob.prototype.text/arrayBuffer.
+  // Polyfill for the duration of this suite only.
+  beforeEach(() => {
+    if (typeof Blob !== "undefined" && typeof Blob.prototype.text !== "function") {
+      Blob.prototype.text = function () {
+        const blob = this;
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(/** @type {string} */ (reader.result));
+          reader.onerror = () => reject(reader.error);
+          reader.readAsText(blob);
+        });
+      };
+    }
+  });
+  it("returns null for empty files array", () => {
+    expect(buildFolderFileFromNative([], "proj")).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(buildFolderFileFromNative(null, "proj")).toBeNull();
+  });
+
+  it("builds a File with correct workspace name", () => {
+    const files = [{ name: "index.js", content: "const x = 1;" }];
+    const result = buildFolderFileFromNative(files, "myProject");
+    expect(result).toBeInstanceOf(File);
+    expect(result.name).toBe("myProject_workspace.txt");
+    expect(result.type).toBe("text/plain");
+  });
+
+  it("uses 'folder' as name fallback when folderName is absent", () => {
+    const files = [{ name: "a.txt", content: "a" }];
+    const result = buildFolderFileFromNative(files, undefined);
+    expect(result.name).toBe("folder_workspace.txt");
+  });
+
+  it("concatenates all file contents with path headers", async () => {
+    const files = [
+      { name: "a.js", content: "const a = 1;" },
+      { name: "b.js", content: "const b = 2;" },
+    ];
+    const result = buildFolderFileFromNative(files, "proj");
+    const text = await result.text();
+    expect(text).toContain("--- [FILE: a.js] ---");
+    expect(text).toContain("const a = 1;");
+    expect(text).toContain("--- [FILE: b.js] ---");
+    expect(text).toContain("const b = 2;");
+  });
+
+  it("includes a directory tree section", async () => {
+    const files = [
+      { name: "src/index.js", content: "// main" },
+      { name: "package.json", content: "{}" },
+    ];
+    const result = buildFolderFileFromNative(files, "proj");
+    const text = await result.text();
+    expect(text).toContain("Directory Tree:");
+    expect(text).toContain("src");
+    expect(text).toContain("package.json");
+  });
+
+  it("renders nested directory tree correctly", async () => {
+    const files = [
+      { name: "src/utils/helper.js", content: "// helper" },
+      { name: "README.md", content: "# Readme" },
+    ];
+    const result = buildFolderFileFromNative(files, "proj");
+    const text = await result.text();
+    expect(text).toContain("src");
+    expect(text).toContain("utils");
+    expect(text).toContain("helper.js");
+    expect(text).toContain("README.md");
+  });
+});


### PR DESCRIPTION
- Added `pickFiles` method in WebViewBridge to handle file and folder picking from the native Android interface.
- Introduced `PickedFile` data class to encapsulate file details (name and content).
- Implemented methods to read content from picked files and folders, respecting size limits and file types.
- Enhanced JavaScript interface to allow for asynchronous file picking with proper error handling.
- Updated AttachMenu and ProjectsManager components to utilize the new native file picker functionality.
- Added tests for the new file picker methods and their integration with the UI.
- Created a new `android-file-picker.js` module to wrap the native bridge functionality in a Promise-based API.
- Updated E2E tests to verify the visibility of folder upload options based on native picker availability.

Circumvents the WebView/SAF limitation for Android mentioned in #25. Multifile picking and folder upload is now available for Android.