### PR TITLE
Fix message duplication

### DIFF
--- a/src/content/index.js
+++ b/src/content/index.js
@@ -29,9 +29,14 @@ import { initPricing } from "../lib/pricing.js";
 import { startStatusMonitor } from "./status-monitor.js";
 import { startThemeWatcher } from "./theme.js";
 
-init().catch((error) => {
-  console.error("[BetterDeepSeek] Init error:", error);
-});
+const CONTENT_BOOTSTRAP_KEY = "__bdsContentBootstrapped";
+
+if (!window[CONTENT_BOOTSTRAP_KEY]) {
+  window[CONTENT_BOOTSTRAP_KEY] = true;
+  init().catch((error) => {
+    console.error("[BetterDeepSeek] Init error:", error);
+  });
+}
 
 async function init() {
   await waitForBody();

--- a/src/content/message-processor.svelte.js
+++ b/src/content/message-processor.svelte.js
@@ -304,6 +304,7 @@ export function processMessageNode(node) {
         existing.props.loadingIndex = loadingIndex;
       } else {
         const host = getOrCreateHost(node, "bds-overlay-host");
+        removeStaleMessageOverlays(host);
         
         // Create reactive props object
         const props = $state({
@@ -340,6 +341,12 @@ export function processMessageNode(node) {
         overlayHost.replaceChildren();
       }
     }
+  }
+}
+
+function removeStaleMessageOverlays(host) {
+  for (const overlay of host.querySelectorAll(".bds-message-overlay")) {
+    overlay.remove();
   }
 }
 

--- a/tests/e2e-android/android.spec.js
+++ b/tests/e2e-android/android.spec.js
@@ -6,7 +6,7 @@
  * They guard the parity contract between Chrome and Android so a future shim
  * regression is caught without needing a device farm.
  */
-import { test, expect } from "./helpers/android.js";
+import { test, expect, reinjectAndroidContentBundle } from "./helpers/android.js";
 import { strToU8, zipSync } from "fflate";
 
 const githubZipBase64 = Buffer.from(
@@ -249,6 +249,24 @@ test("renders standalone create_file download cards", async ({ page }) => {
     '<BDS:create_file fileName="notes.txt">android body</BDS:create_file>',
   );
   await expect(page.locator(".bds-download-card")).toContainText("notes.txt");
+});
+
+test("does not duplicate tagged reply overlays after repeated Android content injection", async ({ page }) => {
+  await reinjectAndroidContentBundle(page);
+  await reinjectAndroidContentBundle(page);
+
+  await addAssistantMessage(
+    page,
+    [
+      "Android dedupe lead.",
+      '<BDS:VISUALIZER><div class="v-card"><h2 class="v-title">Android Dedupe</h2></div></BDS:VISUALIZER>',
+    ].join("\n"),
+  );
+
+  await expect(page.locator(".bds-message-overlay")).toHaveCount(1);
+  await expect(page.locator(".bds-sanitized-text")).toHaveCount(1);
+  await expect(page.locator(".bds-sanitized-text")).toContainText("Android dedupe lead");
+  await expect(page.locator(".bds-visualizer-card")).toHaveCount(1);
 });
 
 test("does NOT inject duplicate Run buttons on re-scan", async ({ page }) => {

--- a/tests/e2e-android/helpers/android.js
+++ b/tests/e2e-android/helpers/android.js
@@ -27,6 +27,12 @@ function ensureBuildExists() {
   }
 }
 
+export async function reinjectAndroidContentBundle(page) {
+  ensureBuildExists();
+  const contentJs = fs.readFileSync(contentJsPath, "utf8");
+  await page.evaluate(contentJs);
+}
+
 /**
  * Init script (runs in every page before any frame script). Installs an
  * in-memory mock of window.AndroidBridge that mirrors the @JavascriptInterface

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -65,6 +65,49 @@ test("renders visualizer and HTML tool cards from tagged assistant messages", as
   await expect(page.locator(".bds-tool-card h4")).toContainText("HTML");
 });
 
+test("does not duplicate tagged reply overlays after rescans and updates", async ({ page }) => {
+  await addAssistantMessage(
+    page,
+    [
+      "Initial dedupe lead.",
+      '<BDS:VISUALIZER><div class="v-card"><h2 class="v-title">Dedupe Chart</h2></div></BDS:VISUALIZER>',
+    ].join("\n"),
+  );
+
+  await expect(page.locator(".bds-message-overlay")).toHaveCount(1);
+  await expect(page.locator(".bds-sanitized-text")).toHaveCount(1);
+  await expect(page.locator(".bds-visualizer-card")).toHaveCount(1);
+
+  await page.evaluate(() => {
+    for (let i = 0; i < 5; i += 1) {
+      const marker = document.createElement("span");
+      marker.className = "bds-test-rescan-marker";
+      marker.textContent = String(i);
+      document.body.appendChild(marker);
+    }
+  });
+  await page.waitForTimeout(500);
+
+  await updateLastAssistantMessage(
+    page,
+    [
+      "Updated dedupe lead.",
+      '<BDS:VISUALIZER><div class="v-card"><h2 class="v-title">Dedupe Chart</h2></div></BDS:VISUALIZER>',
+    ].join("\n"),
+  );
+  await page.evaluate(() => {
+    const marker = document.createElement("span");
+    marker.className = "bds-test-rescan-marker";
+    marker.textContent = "after-update";
+    document.body.appendChild(marker);
+  });
+
+  await expect(page.locator(".bds-sanitized-text")).toContainText("Updated dedupe lead");
+  await expect(page.locator(".bds-message-overlay")).toHaveCount(1);
+  await expect(page.locator(".bds-sanitized-text")).toHaveCount(1);
+  await expect(page.locator(".bds-visualizer-card")).toHaveCount(1);
+});
+
 test("renders PPTX, Excel, and Docx cards for office-generation tags", async ({ page }) => {
   await addAssistantMessage(
     page,

--- a/tests/integration/message-processor.test.js
+++ b/tests/integration/message-processor.test.js
@@ -131,6 +131,41 @@ describe("message processor integration", () => {
     expect(node.querySelector(".ds-markdown").classList.contains("bds-hidden-message")).toBe(true);
   });
 
+  it("updates an existing tool overlay without mounting a duplicate", () => {
+    const node = createMessageNode(
+      "Intro\n<BDS:VISUALIZER><div>viz</div></BDS:VISUALIZER>",
+    );
+
+    processMessageNode(node);
+    node.dataset.rawText = "Updated intro\n<BDS:VISUALIZER><div>viz</div></BDS:VISUALIZER>";
+    processMessageNode(node);
+
+    expect(mocks.mount).toHaveBeenCalledOnce();
+    expect(mocks.mount.mock.calls[0][1].props.text).toBe("Updated intro");
+    expect(document.querySelectorAll(".mock-overlay")).toHaveLength(1);
+  });
+
+  it("removes stale DOM overlays before mounting a replacement", () => {
+    const node = createMessageNode(
+      "Intro\n<BDS:VISUALIZER><div>viz</div></BDS:VISUALIZER>",
+    );
+    const wrapper = document.createElement("div");
+    wrapper.className = "bds-host-wrapper";
+    const host = document.createElement("div");
+    host.className = "bds-overlay-host";
+    const staleOverlay = document.createElement("div");
+    staleOverlay.className = "bds-message-overlay";
+    staleOverlay.textContent = "stale duplicate";
+    host.appendChild(staleOverlay);
+    wrapper.appendChild(host);
+    node.insertAdjacentElement("afterend", wrapper);
+
+    processMessageNode(node);
+
+    expect(document.querySelector(".bds-message-overlay")).toBeNull();
+    expect(document.querySelectorAll(".mock-overlay")).toHaveLength(1);
+  });
+
   it("collects standalone files outside long work", () => {
     const node = createMessageNode(
       '<BDS:create_file fileName="README.md">```markdown\n# Demo\n```</BDS:create_file>',


### PR DESCRIPTION
Sometimes messages would appear twice in the same chat block from DeepSeek. This bug is particularly consistent on Android. The PR addresses this by hardening the bootstrap process and adding a subroutine to clean stale overlays.