### PR TITLE
Fix question panel input focus handling

### DIFF
--- a/src/content/ui/QuestionPanel.svelte
+++ b/src/content/ui/QuestionPanel.svelte
@@ -149,6 +149,53 @@
     return Boolean(editableParent && editableParent.getAttribute("contenteditable") !== "false");
   }
 
+  function stopNativeEvent(event) {
+    event?.stopPropagation?.();
+    event?.stopImmediatePropagation?.();
+  }
+
+  function focusInputInContainer(container) {
+    const input = container?.querySelector?.("input");
+    if (input) setTimeout(() => input.focus(), 0);
+  }
+
+  function stopPanelPointerEvents(node) {
+    const events = ["pointerdown", "mousedown"];
+    events.forEach((eventName) => node.addEventListener(eventName, stopNativeEvent));
+
+    return {
+      destroy() {
+        events.forEach((eventName) => node.removeEventListener(eventName, stopNativeEvent));
+      },
+    };
+  }
+
+  function focusContainerInputAction(node, options = {}) {
+    const handlePointerDown = (event) => {
+      stopNativeEvent(event);
+      if (event?.target?.closest?.("input, button")) return;
+      focusInputInContainer(node);
+    };
+    const handleClick = (event) => {
+      if (event?.target?.closest?.("button")) return;
+      stopNativeEvent(event);
+      focusInputInContainer(node);
+      if (options.selectOther) selectSingleOption("Other");
+    };
+
+    node.addEventListener("pointerdown", handlePointerDown);
+    node.addEventListener("mousedown", stopNativeEvent);
+    node.addEventListener("click", handleClick);
+
+    return {
+      destroy() {
+        node.removeEventListener("pointerdown", handlePointerDown);
+        node.removeEventListener("mousedown", stopNativeEvent);
+        node.removeEventListener("click", handleClick);
+      },
+    };
+  }
+
   function prevQuestion() {
     if (currentQuestionIndex > 0) {
       currentQuestionIndex--;
@@ -310,7 +357,11 @@
   {@const q = questions[currentQuestionIndex]}
   {@const key = q.id || `q_${currentQuestionIndex}`}
   
-  <div class="bds-question-panel" bind:this={panelElement}>
+  <div
+    class="bds-question-panel"
+    bind:this={panelElement}
+    use:stopPanelPointerEvents
+  >
     <div class="bds-question-header">
       <h3>{q.question}</h3>
       <div class="bds-header-controls">
@@ -348,11 +399,7 @@
               class="bds-option-item custom-item {answers[key] === 'Other' ? 'selected' : ''} {focusedOptionIndex === (q.options?.length || 0) ? 'focused' : ''}"
               role="button"
               tabindex="0"
-              onclick={(e) => {
-                const input = e.currentTarget.querySelector('input');
-                if (input) input.focus();
-                selectSingleOption("Other");
-              }}
+              use:focusContainerInputAction={{ selectOther: true }}
               onkeydown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
@@ -375,10 +422,11 @@
                 placeholder={t('questionPanel.somethingElse')} 
                 bind:value={customAnswers[key]}
                 oninput={() => answers[key] = "Other"}
-                onmousedown={(e) => e.stopPropagation()}
-                onclick={(e) => e.stopPropagation()}
+                onpointerdown={stopNativeEvent}
+                onmousedown={stopNativeEvent}
+                onclick={stopNativeEvent}
                 onkeydown={(e) => {
-                  e.stopPropagation();
+                  stopNativeEvent(e);
                   if (e.key === 'Enter') {
                     e.preventDefault();
                     if (customAnswers[key].trim()) {
@@ -387,7 +435,7 @@
                     }
                   }
                 }}
-                onkeyup={(e) => e.stopPropagation()}
+                onkeyup={stopNativeEvent}
               />
               {#if answers[key] === "Other" && customAnswers[key].trim()}
                 <button class="bds-custom-confirm" onclick={() => { answers[key] = "Other"; nextOrSubmit(); }}>→</button>
@@ -414,10 +462,7 @@
               class="bds-option-item custom-item {focusedOptionIndex === (q.options?.length || 0) ? 'focused' : ''}"
               role="button"
               tabindex="0"
-              onclick={(e) => {
-                const input = e.currentTarget.querySelector('input');
-                if (input) input.focus();
-              }}
+              use:focusContainerInputAction
               onkeydown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
@@ -438,39 +483,38 @@
                 class="bds-custom-text-input" 
                 placeholder={t('questionPanel.somethingElse')} 
                 bind:value={customAnswers[key]}
-                onmousedown={(e) => e.stopPropagation()}
-                onclick={(e) => e.stopPropagation()}
-                onkeydown={(e) => e.stopPropagation()}
-                onkeyup={(e) => e.stopPropagation()}
+                onpointerdown={stopNativeEvent}
+                onmousedown={stopNativeEvent}
+                onclick={stopNativeEvent}
+                onkeydown={stopNativeEvent}
+                onkeyup={stopNativeEvent}
               />
             </div>
           {/if}
         </div>
 
       {:else}
-        <div 
+        <div
           class="bds-free-input-wrapper"
-          onclick={(e) => {
-            const input = e.currentTarget.querySelector('input');
-            if (input) input.focus();
-          }}
+          use:focusContainerInputAction
         >
           <input 
             type="text" 
             use:focusOnMount
             class="bds-text-input" 
-            placeholder={t('questionPanel.typeAnswer')} 
-            bind:value={customAnswers[key]} 
-            onmousedown={(e) => e.stopPropagation()}
-            onclick={(e) => e.stopPropagation()}
+            placeholder={t('questionPanel.typeAnswer')}
+            bind:value={customAnswers[key]}
+            onpointerdown={stopNativeEvent}
+            onmousedown={stopNativeEvent}
+            onclick={stopNativeEvent}
             onkeydown={(e) => {
-              e.stopPropagation();
+              stopNativeEvent(e);
               if (e.key === 'Enter') {
                 e.preventDefault();
                 nextOrSubmit();
               }
             }}
-            onkeyup={(e) => e.stopPropagation()}
+            onkeyup={stopNativeEvent}
             autofocus
           />
         </div>
@@ -696,6 +740,8 @@
     color: var(--bds-text-primary, #ececec);
     font-size: 14px;
     flex-grow: 1;
+    width: 100%;
+    min-width: 0;
     outline: none;
     padding: 0;
     font-family: inherit;
@@ -721,6 +767,7 @@
     border: 1px solid var(--bds-border, #3a3b3f);
     border-radius: var(--bds-radius, 14px);
     padding: 12px;
+    cursor: text;
   }
 
   .bds-text-input {
@@ -729,6 +776,7 @@
     color: var(--bds-text-primary, #ececec);
     font-size: 14px;
     width: 100%;
+    min-width: 0;
     outline: none;
     font-family: inherit;
   }

--- a/tests/integration/ui/QuestionPanel.test.js
+++ b/tests/integration/ui/QuestionPanel.test.js
@@ -54,6 +54,35 @@ describe("QuestionPanel integration", () => {
     cleanup();
   });
 
+  it("keeps option button clicks working", async () => {
+    const { cleanup } = renderSvelte(QuestionPanel);
+    await flushUi();
+
+    window.dispatchEvent(
+      new CustomEvent("bds-ask-questions", {
+        detail: {
+          questions: [
+            {
+              id: "q1",
+              question: "Pick one",
+              type: "single",
+              options: ["Alpha", "Beta"],
+            },
+          ],
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    await flushUi();
+
+    document.querySelectorAll(".bds-option-item")[1].dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(document.querySelector("#chat-input").value).toContain("Beta");
+    expect(document.querySelector('button[title="Send message"]').click).toHaveBeenCalled();
+    cleanup();
+  });
+
   it("attaches to a contenteditable composer when no textarea is present", async () => {
     document.body.innerHTML = `
       <div class="composer-shell">
@@ -120,6 +149,86 @@ describe("QuestionPanel integration", () => {
     window.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(false);
+    cleanup();
+  });
+
+  it("focuses free text input from wrapper clicks without leaking to composer", async () => {
+    const { cleanup } = renderSvelte(QuestionPanel);
+    await flushUi();
+
+    window.dispatchEvent(
+      new CustomEvent("bds-ask-questions", {
+        detail: {
+          questions: [
+            {
+              id: "q1",
+              question: "Explain",
+              type: "input",
+            },
+          ],
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    await flushUi();
+
+    const composerPointerDown = vi.fn();
+    document.querySelector(".ds-textarea").addEventListener("pointerdown", composerPointerDown);
+    const wrapper = document.querySelector(".bds-free-input-wrapper");
+    const input = document.querySelector(".bds-text-input");
+    document.querySelector("#chat-input").focus();
+
+    wrapper.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    wrapper.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.advanceTimersByTimeAsync(0);
+    await flushUi();
+
+    expect(document.activeElement).toBe(input);
+    expect(composerPointerDown).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("focuses custom answer input when clicking the custom option row", async () => {
+    const { cleanup } = renderSvelte(QuestionPanel);
+    await flushUi();
+
+    window.dispatchEvent(
+      new CustomEvent("bds-ask-questions", {
+        detail: {
+          questions: [
+            {
+              id: "q1",
+              question: "Pick one",
+              type: "single",
+              options: ["Alpha", "Beta"],
+              allowCustom: true,
+            },
+          ],
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(150);
+    await flushUi();
+
+    const row = document.querySelector(".custom-item");
+    const input = row.querySelector(".bds-custom-text-input");
+    document.querySelector("#chat-input").focus();
+
+    row.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, cancelable: true }));
+    row.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.advanceTimersByTimeAsync(0);
+    await flushUi();
+
+    expect(document.activeElement).toBe(input);
+
+    input.value = "Gamma";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await flushUi();
+    document.querySelector(".bds-custom-confirm").dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(document.querySelector("#chat-input").value).toContain("Gamma");
+    expect(document.querySelector('button[title="Send message"]').click).toHaveBeenCalled();
     cleanup();
   });
 });


### PR DESCRIPTION
## Summary

  This PR fixes an input focus issue in the BDS question panel shown for `<BDS:ask_question>` prompts.

  Previously, text inputs inside `bds-question-panel` could only be focused reliably by clicking the leading icon or the
  very beginning of the input field. Clicking other visible areas of the input row often failed to enter typing mode.

  The fix improves event isolation and input focusing behavior when the question panel is mounted inside DeepSeek's
  native composer area.

  ## Changes

  Update question panel event handling:

  - `src/content/ui/QuestionPanel.svelte`

  Add panel-level pointer/mouse event isolation so DeepSeek's native composer does not steal focus from BDS panel
  inputs.

  Add a focused input container action so clicking the visible input row focuses the inner input consistently.

  Apply the focus behavior to:

  - Free text question inputs.
  - Single-choice custom answer rows.
  - Multiple-choice custom answer rows.

  Preserve existing click behavior for buttons and options:

  - Normal option button clicks still select and submit answers correctly.
  - Custom answer confirm button clicks still work.
  - Keyboard navigation and Enter handling remain unchanged.

  Improve input sizing:

  - Custom text inputs now fill the available row width more reliably.
  - Free text inputs keep stable sizing inside their wrapper.

  Add regression coverage:

  - `tests/integration/ui/QuestionPanel.test.js`

  New coverage includes:

  - Normal option button clicks.
  - Free text wrapper clicks focusing the input without leaking pointer events to the native composer.
  - Custom answer row clicks focusing the custom input.
  - Custom answer confirmation still submitting correctly.

  ## Motivation

  The question panel is inserted into DeepSeek's native prompt/composer area. That means BDS panel inputs share an
  interaction region with DeepSeek's own textarea/contenteditable editor.

  DeepSeek's composer can handle pointer and mouse events to focus its own input. Without stronger event isolation,
  clicks inside `bds-question-panel` may bubble to the native composer, causing DeepSeek to steal focus back from the
  BDS input.

  This made the visible input row misleading: users could see a full-width input area, but only a small part of it
  reliably entered typing mode.

  This PR keeps the existing `QuestionPanel` structure and applies a small, local fix similar to the existing
  event-isolation approach used by the Deep Research revision panel.

  ## Risk

  Low.

  The change is limited to `QuestionPanel` input interaction handling and does not change the question data format,
  answer formatting, injection flow, or public tag contract.

  The main risk is accidentally interfering with Svelte delegated click handlers. To reduce that risk, panel-level
  isolation only handles pointer/mouse events, and input-container click handling explicitly avoids blocking button
  clicks.

  Regression tests cover normal option clicks and custom confirm button behavior to ensure existing selection and submit
  paths still work.

  ## Testing

  Ran targeted QuestionPanel integration tests:

  ```bash
  npx vitest run tests/integration/ui/QuestionPanel.test.js
  ```

  Result:

  6 tests passed

  Ran full unit test suite:

  ```bash
  npm run test:unit
  ```

  Result:

  58 test files passed
  642 tests passed
