### PR TITLE
Enhance cookie handling during auth and add tests for WebView navigation

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
     testOptions {
         unitTests {
             isReturnDefaultValues = true
+            isIncludeAndroidResources = true
         }
     }
 }

--- a/android/app/src/androidTest/java/com/betterdeepseek/app/CookiePolicyTest.kt
+++ b/android/app/src/androidTest/java/com/betterdeepseek/app/CookiePolicyTest.kt
@@ -1,0 +1,56 @@
+package com.betterdeepseek.app
+
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.widget.FrameLayout
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented tests verifying cookie policy in MainActivity.
+ *
+ * Runs on a connected device or emulator (API 26+). Robolectric's RoboCookieManager
+ * always returns false from acceptThirdPartyCookies, so we must test on a real runtime.
+ *
+ * Run with: ./gradlew connectedDebugAndroidTest
+ */
+@RunWith(AndroidJUnit4::class)
+class CookiePolicyTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun thirdPartyCookies_areAccepted() {
+        activityRule.scenario.onActivity { activity ->
+            val webView = findWebView(activity)
+            assertTrue(
+                "Third-party cookies must be accepted for hCaptcha iframe auth",
+                CookieManager.getInstance().acceptThirdPartyCookies(webView),
+            )
+        }
+    }
+
+    @Test
+    fun firstPartyCookies_areAccepted() {
+        activityRule.scenario.onActivity { _ ->
+            assertTrue(
+                "First-party cookies must be accepted",
+                CookieManager.getInstance().acceptCookie(),
+            )
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private fun findWebView(activity: MainActivity): WebView {
+        val content = activity.window.decorView
+            .findViewById<android.view.ViewGroup>(android.R.id.content)
+        val rootLayout = content.getChildAt(0) as FrameLayout
+        return rootLayout.getChildAt(0) as WebView
+    }
+}

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -139,7 +139,6 @@ class MainActivity : ComponentActivity() {
 
         bridge = WebViewBridge(applicationContext)
         cookieManager = CookieManager.getInstance()
-        applySystemLocaleCookie()
 
         bridge.onPickFiles = { mode, requestId ->
             pendingPickFilesRequestId = requestId
@@ -189,6 +188,9 @@ class MainActivity : ComponentActivity() {
                     setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
+        configureWebViewCookiePolicy(webView)
+        applySystemLocaleCookie()
+
         // FrameLayout wrapper receives system-bar padding and expands its bottom inset for IME.
         // WebView.setPadding() does not shift the viewport reliably, so the wrapper is the
         // inset target. Its background fills the padding band behind the system bars.
@@ -221,11 +223,6 @@ class MainActivity : ComponentActivity() {
         }
 
         setContentView(rootLayout)
-
-        // Accept third-party cookies so hCaptcha iframe auth on the DeepSeek login page
-        // can store session state in the embedded captcha widget.
-        cookieManager.setAcceptThirdPartyCookies(webView, true)
-
         webView.loadUrl(getString(R.string.bds_target_url))
 
         onBackPressedDispatcher.addCallback(
@@ -242,6 +239,12 @@ class MainActivity : ComponentActivity() {
         )
     }
 
+    private fun configureWebViewCookiePolicy(webView: WebView) {
+        cookieManager.setAcceptCookie(true)
+        cookieManager.setAcceptThirdPartyCookies(webView, true)
+        cookieManager.flush()
+    }
+
     private fun applySystemLocaleCookie() {
         val localeTag =
                 bridge.getSystemLocale()
@@ -249,7 +252,6 @@ class MainActivity : ComponentActivity() {
                         .filter { it.isLetterOrDigit() || it == '-' }
         if (localeTag.isBlank()) return
 
-        cookieManager.setAcceptCookie(true)
         cookieManager.setCookie(
                 getString(R.string.bds_target_url),
                 "NEXT_LOCALE=$localeTag; Path=/; SameSite=Lax"

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -221,6 +221,11 @@ class MainActivity : ComponentActivity() {
         }
 
         setContentView(rootLayout)
+
+        // Accept third-party cookies so hCaptcha iframe auth on the DeepSeek login page
+        // can store session state in the embedded captcha widget.
+        cookieManager.setAcceptThirdPartyCookies(webView, true)
+
         webView.loadUrl(getString(R.string.bds_target_url))
 
         onBackPressedDispatcher.addCallback(
@@ -319,6 +324,10 @@ class MainActivity : ComponentActivity() {
                         request: WebResourceRequest
                 ): Boolean {
                     val url = request.url ?: return false
+                    // Never externalize subframe/iframe navigations (e.g. hCaptcha captcha
+                    // iframes, embedded auth flows). Only top-level navigation decisions are
+                    // delegated to shouldOpenExternally.
+                    if (!request.isForMainFrame) return false
                     if (!shouldOpenExternally(url, getString(R.string.bds_asset_authority))) {
                         return false
                     }

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
@@ -1,0 +1,109 @@
+package com.betterdeepseek.app
+
+import android.net.Uri
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.widget.FrameLayout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * JVM (Robolectric) tests for WebView navigation routing in MainActivity.
+ *
+ * These tests exercise the real [WebViewClient.shouldOverrideUrlLoading] implementation
+ * through the activity's anonymous [bdsWebViewClient]. Subframe / iframe navigations
+ * (notably hCaptcha) must never be routed to external intents, while top-level external
+ * links must continue to open in the browser.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class WebViewNavigationTest {
+
+    private lateinit var activity: MainActivity
+    private lateinit var webView: WebView
+
+    @Before
+    fun setUp() {
+        activity = Robolectric
+            .buildActivity(MainActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+        webView = findWebView(activity)
+    }
+
+    @Test
+    fun `non-main-frame hCaptcha URL stays in WebView`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse(
+                "https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html"
+            )
+            on { isForMainFrame } doReturn false
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertFalse("hCaptcha subframe must not open externally", result)
+    }
+
+    @Test
+    fun `top-level external URL opens in browser`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://github.com/EdgeTypE/better-deepseek")
+            on { isForMainFrame } doReturn true
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertTrue("External top-level URL must open externally", result)
+    }
+
+    @Test
+    fun `top-level DeepSeek URL stays in WebView`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://chat.deepseek.com/chat/s/abc")
+            on { isForMainFrame } doReturn true
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertFalse("DeepSeek URL must stay inside WebView", result)
+    }
+
+    @Test
+    fun `top-level Google OAuth URL stays in WebView`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")
+            on { isForMainFrame } doReturn true
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertFalse("Google OAuth URL must stay inside WebView", result)
+    }
+
+    @Test
+    fun `top-level BDS asset URL stays in WebView`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://bds-asset.local/bds/content.js")
+            on { isForMainFrame } doReturn true
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertFalse("BDS asset URL must stay inside WebView", result)
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    private fun findWebView(activity: MainActivity): WebView {
+        val content = activity.window.decorView
+            .findViewById<android.view.ViewGroup>(android.R.id.content)
+        val rootLayout = content.getChildAt(0) as FrameLayout
+        return rootLayout.getChildAt(0) as WebView
+    }
+}

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -176,6 +176,35 @@ function scanPage() {
 }
 
 /**
+ * Check whether the current page has a genuine chat composer surface.
+ *
+ * Returns true only when at least one chat-specific marker is found:
+ *   - multi-file upload input
+ *   - native DeepThink / prompt action row
+ *   - DeepSeek send button
+ *   - #chat-input textarea, .ds-textarea textarea, or contenteditable rich editor
+ *
+ * If the only "editor" found is a plain <input> (text/email/tel/password with
+ * placeholder — typical of login/auth pages) with none of the markers above,
+ * this is not a chat composer and Deep Research / attach controls must not mount.
+ */
+function isChatComposer() {
+  if (findActiveFileInput()) return true;
+  if (findNativePromptActionRow()) return true;
+  if (findDeepSeekSendButton()) return true;
+
+  const editor = findComposerEditor();
+  if (!editor) return false;
+
+  const tag = editor.tagName.toLowerCase();
+  // textarea or contenteditable = rich chat composer
+  if (tag === "textarea" || editor.isContentEditable) return true;
+
+  // plain <input> with no chat markers = auth/form page
+  return false;
+}
+
+/**
  * Scan for the chat text input area to inject custom attachment menu
  */
 export function scanInputArea() {
@@ -183,6 +212,11 @@ export function scanInputArea() {
   const wrapper = findComposerControlsWrapper(fileInput);
   const deepResearchWrapper = findDeepResearchControlsWrapper(fileInput, wrapper);
   if (!deepResearchWrapper) {
+    return;
+  }
+
+  // Surface check: reject login/auth forms that lack chat-specific markers.
+  if (!isChatComposer()) {
     return;
   }
 

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -281,4 +281,40 @@ describe("scanner input controls", () => {
     expect(deepResearchMount).toBeTruthy();
     expect(mountMock.mock.calls[0][0]).toBe(deepResearchToggleMock);
   });
+
+  it("rejects login/auth form — no deep research mount", async () => {
+    document.body.innerHTML = `
+      <div id="login-form">
+        <input type="text" placeholder="Email or phone number" />
+        <input type="password" placeholder="Password" />
+        <button type="submit">Log in</button>
+      </div>
+    `;
+    const { scanInputArea } = await import("../../src/content/scanner.js");
+
+    scanInputArea();
+
+    expect(document.querySelector(".bds-deep-research-mount")).toBeNull();
+    expect(mountMock).not.toHaveBeenCalled();
+  });
+
+  it("mounts deep research on root URL chat composer when chat markers present", async () => {
+    document.body.innerHTML = `
+      <div id="composer">
+        <textarea id="chat-input" placeholder="Message DeepSeek"></textarea>
+        <div id="prompt-actions">
+          <button id="deepthink" type="button">DeepThink</button>
+        </div>
+        <div id="send-cluster">
+          <button id="send" title="Send message" type="button"></button>
+        </div>
+      </div>
+    `;
+    const { scanInputArea } = await import("../../src/content/scanner.js");
+
+    scanInputArea();
+
+    expect(document.querySelector(".bds-deep-research-mount")).toBeTruthy();
+    expect(mountMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #88.

PR introduces several improvements to both the Android app and the web extension, focusing on stricter cookie and navigation policies, enhanced test coverage, and better detection of chat composers to avoid mounting features on login/auth forms.

**Android App:**

*Cookie and Navigation Policy Improvements:*
- Added a `configureWebViewCookiePolicy` method in `MainActivity` to explicitly accept both first-party and third-party cookies, ensuring proper authentication flows (e.g., hCaptcha) and moved cookie setup to a more appropriate place in the activity lifecycle. [[1]](diffhunk://#diff-ecfc06e2215b69db87cfe41a1e7f57057d71f5c77d8a1faf6ea1aeb3ec547064L142) [[2]](diffhunk://#diff-ecfc06e2215b69db87cfe41a1e7f57057d71f5c77d8a1faf6ea1aeb3ec547064R191-R193) [[3]](diffhunk://#diff-ecfc06e2215b69db87cfe41a1e7f57057d71f5c77d8a1faf6ea1aeb3ec547064R242-L247)
- Updated navigation handling in `WebViewClient.shouldOverrideUrlLoading` to never externalize subframe/iframe navigations (such as hCaptcha), ensuring only top-level navigations are considered for external handling.

*Testing Enhancements:*
- Added an instrumented test `CookiePolicyTest.kt` to verify that both first-party and third-party cookies are accepted in a real device/emulator environment.
- Introduced a Robolectric test `WebViewNavigationTest.kt` to cover navigation routing, ensuring correct handling of subframe and top-level URLs.
- Enabled Android resources in unit tests by setting `isIncludeAndroidResources = true` in `build.gradle.kts`.

**Web Extension:**

*Chat Composer Detection and Feature Mounting:*
- Added an `isChatComposer` function to detect genuine chat composer surfaces, preventing deep research controls from mounting on login/auth forms. [[1]](diffhunk://#diff-871bd13cd6e0548c40f2a9edabbfc15d23fa29b1bd7c26cfd1953f7340ca1e8dR178-R206) [[2]](diffhunk://#diff-871bd13cd6e0548c40f2a9edabbfc15d23fa29b1bd7c26cfd1953f7340ca1e8dR218-R222)
- Improved integration tests to verify that deep research controls do not mount on login/auth forms and do mount on valid chat composers.