### PR TITLE
Fix hcaptcha drifting token and Google malformed auth flow

### DIFF
--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -71,6 +71,25 @@ internal fun shouldCapturePopupInApp(url: Uri, assetHost: String = "bds-asset.lo
     return !shouldOpenExternally(url, assetHost)
 }
 
+/**
+ * Decide whether a top-level navigation should be handed to the external browser.
+ *
+ * Only deliberate user-gesture navigations leave the app. OAuth redirect chains bounce through
+ * Google consent / ccTLD hosts that are not on the in-app allow list via 302 and JS redirects,
+ * none of which carry a gesture. Routing those to an external browser drops the WebView session
+ * cookies, so Google returns "400 malformed request". Keeping non-gesture navigations in-app
+ * lets the whole sign-in flow complete inside the WebView session.
+ */
+internal fun shouldOpenRequestExternally(
+        request: WebResourceRequest,
+        assetHost: String = "bds-asset.local"
+): Boolean {
+    if (!request.isForMainFrame) return false
+    val url = request.url ?: return false
+    if (!shouldOpenExternally(url, assetHost)) return false
+    return request.hasGesture()
+}
+
 internal fun deriveWebViewUserAgent(defaultUserAgent: String): String {
     return defaultUserAgent
             .replace(Regex(""";\s*wv(?=\))"""), "")
@@ -520,10 +539,8 @@ class MainActivity : ComponentActivity() {
                 ): Boolean {
                     val url = request.url ?: return false
                     // Never externalize subframe/iframe navigations (e.g. hCaptcha captcha
-                    // iframes, embedded auth flows). Only top-level navigation decisions are
-                    // delegated to shouldOpenExternally.
-                    if (!request.isForMainFrame) return false
-                    if (!shouldOpenExternally(url, getString(R.string.bds_asset_authority))) {
+                    // iframes, embedded auth flows) or non-gesture redirect hops (OAuth chains).
+                    if (!shouldOpenRequestExternally(request, getString(R.string.bds_asset_authority))) {
                         return false
                     }
                     return openExternalUrl(url)
@@ -596,8 +613,7 @@ class MainActivity : ComponentActivity() {
                         request: WebResourceRequest
                 ): Boolean {
                     val url = request.url ?: return false
-                    if (!request.isForMainFrame) return false
-                    if (!shouldOpenExternally(url, getString(R.string.bds_asset_authority))) {
+                    if (!shouldOpenRequestExternally(request, getString(R.string.bds_asset_authority))) {
                         return false
                     }
                     openExternalUrl(url)

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -28,11 +28,10 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.webkit.UserAgentMetadata
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewAssetLoader
-import java.io.ByteArrayInputStream
-import java.util.concurrent.TimeUnit
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import androidx.webkit.WebViewFeature
 
 internal fun applyRootWindowInsets(view: View, windowInsets: WindowInsetsCompat): WindowInsetsCompat {
     val systemBars = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
@@ -53,6 +52,7 @@ internal fun shouldOpenExternally(url: Uri, assetHost: String = "bds-asset.local
     val host = url.host?.lowercase() ?: return false
     if (host == assetHost.lowercase()) return false
     if (host == "deepseek.com" || host.endsWith(".deepseek.com")) return false
+    if (host == "hcaptcha.com" || host.endsWith(".hcaptcha.com")) return false
     if (
             host == "accounts.google.com" ||
                     host.endsWith(".accounts.google.com") ||
@@ -62,6 +62,41 @@ internal fun shouldOpenExternally(url: Uri, assetHost: String = "bds-asset.local
     }
 
     return true
+}
+
+internal fun deriveWebViewUserAgent(defaultUserAgent: String): String {
+    return defaultUserAgent
+            .replace(Regex(""";\s*wv(?=\))"""), "")
+            .replace(Regex("""\bVersion/\d+(?:\.\d+)*\s*"""), "")
+            .replace(Regex("""\s+"""), " ")
+            .trim()
+}
+
+internal fun parseChromeMajorVersion(ua: String): String? {
+    return CHROME_VERSION_REGEX.find(ua)?.groupValues?.get(1)?.substringBefore('.')
+}
+
+internal fun buildUserAgentMetadata(derivedUa: String): UserAgentMetadata {
+    val chromeVersion = CHROME_VERSION_REGEX.find(derivedUa)?.groupValues?.get(1)
+    val builder = UserAgentMetadata.Builder().setPlatform("Android").setMobile(true)
+    if (chromeVersion != null) {
+        val majorVersion = chromeVersion.substringBefore('.')
+        val brandVersions =
+                listOf(
+                        UserAgentMetadata.BrandVersion.Builder()
+                                .setBrand("Chromium")
+                                .setMajorVersion(majorVersion)
+                                .setFullVersion(chromeVersion)
+                                .build(),
+                        UserAgentMetadata.BrandVersion.Builder()
+                                .setBrand("Google Chrome")
+                                .setMajorVersion(majorVersion)
+                                .setFullVersion(chromeVersion)
+                                .build(),
+                )
+        builder.setFullVersion(chromeVersion).setBrandVersionList(brandVersions)
+    }
+    return builder.build()
 }
 
 internal fun buildFileChooserIntent(acceptTypes: Array<String>?, allowMultiple: Boolean): Intent {
@@ -125,14 +160,11 @@ private fun mapAcceptTypes(acceptTypes: Array<String>?): List<String> {
     return mapped.toList()
 }
 
+private val CHROME_VERSION_REGEX = Regex("""\bChrome/(\d+(?:\.\d+)*)""")
+
 /**
  * Single-activity host. Loads chat.deepseek.com inside a full-screen WebView and injects the BDS
  * extension scripts on every page finish.
- *
- * Google OAuth is proxied through OkHttp via [shouldInterceptRequest] so the code_verifier /
- * code_challenge pair generated in the WebView's JavaScript context is preserved. Cookies flow
- * bidirectionally: the WebView's [CookieManager] cookies are forwarded on proxy requests, and
- * `Set-Cookie` response headers are fed back into the WebView's cookie store.
  */
 class MainActivity : ComponentActivity() {
 
@@ -211,15 +243,6 @@ class MainActivity : ComponentActivity() {
                 }.start()
             }
 
-    private val proxyClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-                .connectTimeout(20, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
-                .callTimeout(120, TimeUnit.SECONDS)
-                .followRedirects(false)
-                .build()
-    }
-
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -262,6 +285,8 @@ class MainActivity : ComponentActivity() {
         // DeepSeek's persisted theme drives colours; system dark mode is only the first-launch
         // fallback (before any reportTheme call has been persisted to prefs).
         val isPageDark = bridge.getLastKnownIsDark(default = isSystemDark)
+        val derivedUserAgent =
+                deriveWebViewUserAgent(WebSettings.getDefaultUserAgent(this@MainActivity))
 
         webView =
                 WebView(this).apply {
@@ -279,7 +304,7 @@ class MainActivity : ComponentActivity() {
                         mediaPlaybackRequiresUserGesture = false
                         mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
                         cacheMode = WebSettings.LOAD_DEFAULT
-                        userAgentString = String.format(SPOOFED_UA, BuildConfig.VERSION_NAME)
+                        userAgentString = derivedUserAgent
                     }
                     addJavascriptInterface(bridge, BRIDGE_NAME)
                     webViewClient = bdsWebViewClient()
@@ -290,6 +315,7 @@ class MainActivity : ComponentActivity() {
                 }
 
         configureWebViewCookiePolicy(webView)
+        configureWebViewFingerprint(webView, derivedUserAgent)
         applySystemLocaleCookie()
 
         // FrameLayout wrapper receives system-bar padding and expands its bottom inset for IME.
@@ -324,6 +350,9 @@ class MainActivity : ComponentActivity() {
         }
 
         setContentView(rootLayout)
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true)
+        }
         webView.loadUrl(getString(R.string.bds_target_url))
 
         onBackPressedDispatcher.addCallback(
@@ -344,6 +373,21 @@ class MainActivity : ComponentActivity() {
         cookieManager.setAcceptCookie(true)
         cookieManager.setAcceptThirdPartyCookies(webView, true)
         cookieManager.flush()
+    }
+
+    private fun configureWebViewFingerprint(webView: WebView, derivedUa: String) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.REQUESTED_WITH_HEADER_ALLOW_LIST)) {
+            WebSettingsCompat.setRequestedWithHeaderOriginAllowList(
+                    webView.settings,
+                    emptySet<String>(),
+            )
+        }
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
+            WebSettingsCompat.setUserAgentMetadata(
+                    webView.settings,
+                    buildUserAgentMetadata(derivedUa),
+            )
+        }
     }
 
     private fun applySystemLocaleCookie() {
@@ -408,10 +452,8 @@ class MainActivity : ComponentActivity() {
             object : WebViewClient() {
 
                 /**
-                 * Intercept Google OAuth requests and proxy them through OkHttp. This keeps the
-                 * entire OAuth flow inside the WebView's cookie jar so the code_verifier /
-                 * code_challenge generated in JavaScript is preserved. All other requests fall
-                 * through to the asset loader or native WebView loading.
+                 * Serve bundled BDS assets. Network requests fall through to native WebView
+                 * loading so Chromium owns a single session and transport path.
                  */
                 override fun shouldInterceptRequest(
                         view: WebView,
@@ -419,10 +461,6 @@ class MainActivity : ComponentActivity() {
                 ): WebResourceResponse? {
                     assetLoader.shouldInterceptRequest(request.url)?.let {
                         return it
-                    }
-
-                    if (isGoogleOAuthUrl(request.url)) {
-                        return proxyGoogleOAuthRequest(request)
                     }
 
                     return null
@@ -480,8 +518,7 @@ class MainActivity : ComponentActivity() {
 
                 /**
                  * Supply a stub WebView when JS calls window.open() so the caller never receives
-                 * null. Google OAuth navigations are intercepted by [shouldInterceptRequest] and do
-                 * not need a popup.
+                 * null. Visible popup targets still go through the same external-link routing.
                  */
                 override fun onCreateWindow(
                         view: WebView?,
@@ -506,7 +543,7 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-    // ── OAuth proxy ──────────────────────────────────────────────────────
+    // External URL handling
 
     private fun openExternalUrl(url: Uri): Boolean {
         return runCatching {
@@ -518,106 +555,6 @@ class MainActivity : ComponentActivity() {
                 }
                 .onFailure { Log.w(TAG, "Failed to open external URL: $url", it) }
                 .isSuccess
-    }
-
-    /** Domains that must be proxied so the OAuth code_verifier state survives. */
-    private fun isGoogleOAuthUrl(url: Uri): Boolean {
-        val host = url.host?.lowercase() ?: return false
-        return host == "accounts.google.com" ||
-                host.endsWith(".accounts.google.com") ||
-                host == "accounts.youtube.com"
-    }
-
-    /**
-     * Forward the WebView request through OkHttp and return a [WebResourceResponse] the WebView can
-     * consume.
-     *
-     * - Strips `X-Requested-With` so Google doesn't reject the embedded UA.
-     * - Forwards the WebView's cookies into the proxy request.
-     * - Feeds `Set-Cookie` response headers back into the WebView's cookie manager so subsequent
-     * requests carry the correct session.
-     * - On failure, returns `null` so the WebView falls back to native loading (the user may see a
-     * "disallowed_useragent" page, but will not be stuck with an indefinite spinner).
-     */
-    private fun proxyGoogleOAuthRequest(request: WebResourceRequest): WebResourceResponse? {
-        return try {
-            val url = request.url.toString()
-            val method = request.method
-            val requestHeaders = request.requestHeaders
-
-            val builder = Request.Builder().url(url)
-
-            // Mirror safe headers, strip X-Requested-With
-            for ((name, value) in requestHeaders) {
-                if (name.equals("X-Requested-With", ignoreCase = true)) continue
-                if (name.equals("Host", ignoreCase = true)) continue
-                if (name.equals("Connection", ignoreCase = true)) continue
-                if (name.equals("Accept-Encoding", ignoreCase = true)) continue
-                if (name.equals("Content-Length", ignoreCase = true)) continue
-                builder.header(name, value)
-            }
-
-            // Forward WebView cookies so the proxy request carries the
-            // same session state (including any prior OAuth cookies).
-            val cookies = cookieManager.getCookie(url)
-            if (!cookies.isNullOrEmpty()) {
-                builder.header("Cookie", cookies)
-            }
-
-            // WebResourceRequest does not expose the request body, so POST/PUT
-            // cannot be proxied. Fall through to native WebView loading — the
-            // spoofed UA alone is usually sufficient for form-submission POSTs
-            // to succeed. The critical GET-based OAuth authorization requests
-            // are fully proxied with X-Requested-With stripped.
-            if (!method.equals("GET", ignoreCase = true) &&
-                            !method.equals("HEAD", ignoreCase = true)
-            ) {
-                return null
-            }
-
-            val proxyResponse = proxyClient.newCall(builder.build()).execute()
-            proxyResponse.use { resp ->
-                // Feed Set-Cookie back into the WebView
-                val setCookieHeaders = resp.headers("Set-Cookie")
-                for (cookie in setCookieHeaders) {
-                    cookieManager.setCookie(url, cookie)
-                }
-                cookieManager.flush()
-
-                val responseBody = resp.body?.bytes() ?: ByteArray(0)
-                val responseHeaders = mutableMapOf<String, String>()
-
-                for ((name, value) in resp.headers) {
-                    if (name.equals("Set-Cookie", ignoreCase = true)) continue
-                    if (name.equals("Content-Encoding", ignoreCase = true)) continue
-                    if (name.equals("Transfer-Encoding", ignoreCase = true)) continue
-                    if (name.equals("Content-Length", ignoreCase = true)) continue
-                    responseHeaders[name] = value
-                }
-
-                val fullContentType = resp.header("Content-Type") ?: "text/html"
-                val mimeType = fullContentType.split(";").firstOrNull()?.trim() ?: "text/html"
-                val encoding =
-                        if (mimeType.startsWith("text/") ||
-                                        mimeType == "application/json" ||
-                                        mimeType == "application/javascript"
-                        )
-                                "UTF-8"
-                        else null
-
-                WebResourceResponse(
-                        mimeType,
-                        encoding,
-                        resp.code,
-                        resp.message,
-                        responseHeaders,
-                        ByteArrayInputStream(responseBody)
-                )
-            }
-        } catch (t: Throwable) {
-            Log.e(TAG, "OAuth proxy failed for ${request.url}", t)
-            null
-        }
     }
 
     // ── BDS script injection ─────────────────────────────────────────────
@@ -704,16 +641,5 @@ class MainActivity : ComponentActivity() {
         // blends seamlessly before (and if) the page reports its live theme via reportTheme().
         private val PAGE_BG_DARK = Color.rgb(0x15, 0x15, 0x17)
         private val PAGE_BG_LIGHT = Color.WHITE
-
-        /**
-         * Fully synthetic Chrome-mobile UA string. Servers that block embedded WebViews (notably
-         * Google OAuth) check for the legacy "; wv)" marker AND for the `Version/4.0` part that
-         * Android WebView adds even when the stock UA is customised. We replace the entire string.
-         */
-        private const val SPOOFED_UA =
-                "Mozilla/5.0 (Linux; Android 14; Pixel 9 Pro) " +
-                        "AppleWebKit/537.36 (KHTML, like Gecko) " +
-                        "Chrome/132.0.6834.122 Mobile Safari/537.36 " +
-                        "BetterDeepSeekAndroid/%s"
     }
 }

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -64,6 +64,10 @@ internal fun shouldOpenExternally(url: Uri, assetHost: String = "bds-asset.local
     return true
 }
 
+internal fun shouldCapturePopupInApp(url: Uri, assetHost: String = "bds-asset.local"): Boolean {
+    return !shouldOpenExternally(url, assetHost)
+}
+
 internal fun deriveWebViewUserAgent(defaultUserAgent: String): String {
     return defaultUserAgent
             .replace(Regex(""";\s*wv(?=\))"""), "")
@@ -169,9 +173,14 @@ private val CHROME_VERSION_REGEX = Regex("""\bChrome/(\d+(?:\.\d+)*)""")
 class MainActivity : ComponentActivity() {
 
     private lateinit var webView: WebView
+    private lateinit var rootLayout: FrameLayout
     private lateinit var assetLoader: WebViewAssetLoader
     private lateinit var bridge: WebViewBridge
     private lateinit var cookieManager: CookieManager
+    private lateinit var derivedUserAgent: String
+
+    private var popupContainer: FrameLayout? = null
+    private var popupWebView: WebView? = null
 
     private var pendingFileChooser: ValueCallback<Array<Uri>>? = null
     private val fileChooserLauncher: ActivityResultLauncher<Intent> =
@@ -285,7 +294,7 @@ class MainActivity : ComponentActivity() {
         // DeepSeek's persisted theme drives colours; system dark mode is only the first-launch
         // fallback (before any reportTheme call has been persisted to prefs).
         val isPageDark = bridge.getLastKnownIsDark(default = isSystemDark)
-        val derivedUserAgent =
+        derivedUserAgent =
                 deriveWebViewUserAgent(WebSettings.getDefaultUserAgent(this@MainActivity))
 
         webView =
@@ -295,17 +304,7 @@ class MainActivity : ComponentActivity() {
                                     ViewGroup.LayoutParams.MATCH_PARENT,
                                     ViewGroup.LayoutParams.MATCH_PARENT
                             )
-                    settings.apply {
-                        javaScriptEnabled = true
-                        domStorageEnabled = true
-                        databaseEnabled = true
-                        useWideViewPort = true
-                        loadWithOverviewMode = true
-                        mediaPlaybackRequiresUserGesture = false
-                        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-                        cacheMode = WebSettings.LOAD_DEFAULT
-                        userAgentString = derivedUserAgent
-                    }
+                    applyBdsWebSettings(this, derivedUserAgent)
                     addJavascriptInterface(bridge, BRIDGE_NAME)
                     webViewClient = bdsWebViewClient()
                     webChromeClient = bdsWebChromeClient()
@@ -314,14 +313,12 @@ class MainActivity : ComponentActivity() {
                     setBackgroundColor(if (isPageDark) PAGE_BG_DARK else PAGE_BG_LIGHT)
                 }
 
-        configureWebViewCookiePolicy(webView)
-        configureWebViewFingerprint(webView, derivedUserAgent)
         applySystemLocaleCookie()
 
         // FrameLayout wrapper receives system-bar padding and expands its bottom inset for IME.
         // WebView.setPadding() does not shift the viewport reliably, so the wrapper is the
         // inset target. Its background fills the padding band behind the system bars.
-        val rootLayout = FrameLayout(this).apply {
+        rootLayout = FrameLayout(this).apply {
             layoutParams = ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -359,7 +356,10 @@ class MainActivity : ComponentActivity() {
                 this,
                 object : OnBackPressedCallback(true) {
                     override fun handleOnBackPressed() {
-                        if (webView.canGoBack()) {
+                        val popup = popupWebView
+                        if (popup != null) {
+                            closePopup(popup)
+                        } else if (webView.canGoBack()) {
                             webView.goBack()
                         } else {
                             moveTaskToBack(true)
@@ -367,6 +367,25 @@ class MainActivity : ComponentActivity() {
                     }
                 }
         )
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun applyBdsWebSettings(webView: WebView, derivedUa: String) {
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            databaseEnabled = true
+            useWideViewPort = true
+            loadWithOverviewMode = true
+            mediaPlaybackRequiresUserGesture = false
+            mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+            cacheMode = WebSettings.LOAD_DEFAULT
+            userAgentString = derivedUa
+            setSupportMultipleWindows(true)
+            javaScriptCanOpenWindowsAutomatically = true
+        }
+        configureWebViewCookiePolicy(webView)
+        configureWebViewFingerprint(webView, derivedUa)
     }
 
     private fun configureWebViewCookiePolicy(webView: WebView) {
@@ -425,6 +444,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        popupWebView?.let { closePopup(it) }
         bridge.onThemeChanged = null
         bridge.evaluateJs = null
         bridge.onPickFiles = null
@@ -517,8 +537,8 @@ class MainActivity : ComponentActivity() {
                 }
 
                 /**
-                 * Supply a stub WebView when JS calls window.open() so the caller never receives
-                 * null. Visible popup targets still go through the same external-link routing.
+                 * Capture OAuth popups in-app so window.opener/postMessage flows stay attached to
+                 * the main WebView session.
                  */
                 override fun onCreateWindow(
                         view: WebView?,
@@ -529,19 +549,92 @@ class MainActivity : ComponentActivity() {
                     val targetUrl = view?.hitTestResult?.extra
                     if (!targetUrl.isNullOrBlank()) {
                         val uri = Uri.parse(targetUrl)
-                        if (shouldOpenExternally(uri, getString(R.string.bds_asset_authority))) {
+                        if (!shouldCapturePopupInApp(uri, getString(R.string.bds_asset_authority))) {
                             openExternalUrl(uri)
                             return false
                         }
                     }
 
-                    val transport = resultMsg?.obj as? WebView.WebViewTransport
-                    val stub = WebView(this@MainActivity)
-                    transport?.webView = stub
-                    resultMsg?.sendToTarget()
+                    val transport = resultMsg?.obj as? WebView.WebViewTransport ?: return false
+                    val popup =
+                            WebView(this@MainActivity).apply {
+                                applyBdsWebSettings(this, derivedUserAgent)
+                                webViewClient = popupWebViewClient(this)
+                                webChromeClient = popupWebChromeClient(this)
+                                setBackgroundColor(Color.WHITE)
+                            }
+                    attachPopup(popup)
+                    transport.webView = popup
+                    resultMsg.sendToTarget()
                     return true
                 }
             }
+
+    private fun popupWebViewClient(popup: WebView) =
+            object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                        view: WebView,
+                        request: WebResourceRequest
+                ): Boolean {
+                    val url = request.url ?: return false
+                    if (!request.isForMainFrame) return false
+                    if (!shouldOpenExternally(url, getString(R.string.bds_asset_authority))) {
+                        return false
+                    }
+                    openExternalUrl(url)
+                    closePopup(popup)
+                    return true
+                }
+            }
+
+    private fun popupWebChromeClient(popup: WebView) =
+            object : WebChromeClient() {
+                override fun onCloseWindow(window: WebView?) {
+                    closePopup(popup)
+                }
+
+                override fun onCreateWindow(
+                        view: WebView?,
+                        isDialog: Boolean,
+                        isUserGesture: Boolean,
+                        resultMsg: android.os.Message?
+                ): Boolean {
+                    return false
+                }
+            }
+
+    private fun attachPopup(popup: WebView) {
+        popupWebView?.let { closePopup(it) }
+        val container =
+                FrameLayout(this).apply {
+                    layoutParams =
+                            FrameLayout.LayoutParams(
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                            )
+                    addView(
+                            popup,
+                            FrameLayout.LayoutParams(
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                            ),
+                    )
+                }
+        popupContainer = container
+        popupWebView = popup
+        rootLayout.addView(container)
+    }
+
+    private fun closePopup(popup: WebView) {
+        if (popupWebView !== popup) return
+        popupWebView = null
+        popupContainer?.let { container ->
+            container.removeView(popup)
+            rootLayout.removeView(container)
+        }
+        popupContainer = null
+        popup.destroy()
+    }
 
     // External URL handling
 

--- a/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
+++ b/android/app/src/main/java/com/betterdeepseek/app/MainActivity.kt
@@ -53,15 +53,18 @@ internal fun shouldOpenExternally(url: Uri, assetHost: String = "bds-asset.local
     if (host == assetHost.lowercase()) return false
     if (host == "deepseek.com" || host.endsWith(".deepseek.com")) return false
     if (host == "hcaptcha.com" || host.endsWith(".hcaptcha.com")) return false
-    if (
-            host == "accounts.google.com" ||
-                    host.endsWith(".accounts.google.com") ||
-                    host == "accounts.youtube.com"
-    ) {
-        return false
-    }
+    if (isGoogleAuthHost(host)) return false
 
     return true
+}
+
+internal fun isGoogleAuthHost(host: String): Boolean {
+    val h = host.lowercase()
+    return h == "google.com" ||
+            h.endsWith(".google.com") ||
+            h == "accounts.youtube.com" ||
+            h == "googleusercontent.com" ||
+            h.endsWith(".googleusercontent.com")
 }
 
 internal fun shouldCapturePopupInApp(url: Uri, assetHost: String = "bds-asset.local"): Boolean {
@@ -80,13 +83,34 @@ internal fun parseChromeMajorVersion(ua: String): String? {
     return CHROME_VERSION_REGEX.find(ua)?.groupValues?.get(1)?.substringBefore('.')
 }
 
+internal fun parseAndroidPlatformVersion(ua: String): String? {
+    return Regex("""Android\s+(\d+(?:\.\d+)*)""").find(ua)?.groupValues?.get(1)
+}
+
+internal fun parseDeviceModel(ua: String): String? {
+    val inner =
+            Regex("""Android\s+[\d.]+;\s*([^;)]+)""")
+                    .find(ua)
+                    ?.groupValues
+                    ?.get(1)
+                    ?.trim()
+                    ?: return null
+    return inner.substringBefore(" Build/").trim().ifBlank { null }
+}
+
 internal fun buildUserAgentMetadata(derivedUa: String): UserAgentMetadata {
-    val chromeVersion = CHROME_VERSION_REGEX.find(derivedUa)?.groupValues?.get(1)
     val builder = UserAgentMetadata.Builder().setPlatform("Android").setMobile(true)
+    val chromeVersion = CHROME_VERSION_REGEX.find(derivedUa)?.groupValues?.get(1)
     if (chromeVersion != null) {
         val majorVersion = chromeVersion.substringBefore('.')
         val brandVersions =
                 listOf(
+                        // GREASE brand; real Chrome includes a placeholder brand.
+                        UserAgentMetadata.BrandVersion.Builder()
+                                .setBrand("Not/A)Brand")
+                                .setMajorVersion("8")
+                                .setFullVersion("8.0.0.0")
+                                .build(),
                         UserAgentMetadata.BrandVersion.Builder()
                                 .setBrand("Chromium")
                                 .setMajorVersion(majorVersion)
@@ -100,6 +124,10 @@ internal fun buildUserAgentMetadata(derivedUa: String): UserAgentMetadata {
                 )
         builder.setFullVersion(chromeVersion).setBrandVersionList(brandVersions)
     }
+    // Mobile Chrome sends empty architecture and default bitness; platformVersion and model match the UA.
+    builder.setArchitecture("").setBitness(UserAgentMetadata.BITNESS_DEFAULT)
+    parseAndroidPlatformVersion(derivedUa)?.let { builder.setPlatformVersion(it) }
+    parseDeviceModel(derivedUa)?.let { builder.setModel(it) }
     return builder.build()
 }
 
@@ -546,15 +574,6 @@ class MainActivity : ComponentActivity() {
                         isUserGesture: Boolean,
                         resultMsg: android.os.Message?
                 ): Boolean {
-                    val targetUrl = view?.hitTestResult?.extra
-                    if (!targetUrl.isNullOrBlank()) {
-                        val uri = Uri.parse(targetUrl)
-                        if (!shouldCapturePopupInApp(uri, getString(R.string.bds_asset_authority))) {
-                            openExternalUrl(uri)
-                            return false
-                        }
-                    }
-
                     val transport = resultMsg?.obj as? WebView.WebViewTransport ?: return false
                     val popup =
                             WebView(this@MainActivity).apply {

--- a/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
@@ -41,6 +41,17 @@ class AndroidLinkRoutingTest {
     }
 
     @Test
+    fun `hCaptcha hosts stay inside the WebView`() {
+        assertFalse(shouldOpenExternally(Uri.parse("https://hcaptcha.com/")))
+        assertFalse(
+                shouldOpenExternally(
+                        Uri.parse("https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html")
+                )
+        )
+        assertFalse(shouldOpenExternally(Uri.parse("https://api.hcaptcha.com/getcaptcha")))
+    }
+
+    @Test
     fun `non-http schemes are not routed as browser links`() {
         assertFalse(shouldOpenExternally(Uri.parse("mailto:hello@example.com")))
         assertFalse(shouldOpenExternally(Uri.parse("javascript:alert(1)")))

--- a/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
@@ -35,9 +35,24 @@ class AndroidLinkRoutingTest {
 
     @Test
     fun `Google OAuth hosts stay inside the WebView`() {
+        assertFalse(shouldOpenExternally(Uri.parse("https://google.com/")))
+        assertFalse(shouldOpenExternally(Uri.parse("https://www.google.com/gsi/select")))
+        assertFalse(shouldOpenExternally(Uri.parse("https://myaccount.google.com/")))
         assertFalse(shouldOpenExternally(Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")))
         assertFalse(shouldOpenExternally(Uri.parse("https://login.accounts.google.com/path")))
         assertFalse(shouldOpenExternally(Uri.parse("https://accounts.youtube.com/accounts/SetSID")))
+        assertFalse(shouldOpenExternally(Uri.parse("https://lh3.googleusercontent.com/a/x")))
+        assertTrue(shouldOpenExternally(Uri.parse("https://www.googleapis.com/oauth2/v3/certs")))
+        assertTrue(shouldOpenExternally(Uri.parse("https://oauthaccountmanager.googleapis.com/")))
+    }
+
+    @Test
+    fun `isGoogleAuthHost matches identity hosts only`() {
+        assertTrue(isGoogleAuthHost("accounts.google.com"))
+        assertTrue(isGoogleAuthHost("www.google.com"))
+        assertTrue(isGoogleAuthHost("lh3.googleusercontent.com"))
+        assertFalse(isGoogleAuthHost("www.googleapis.com"))
+        assertFalse(isGoogleAuthHost("github.com"))
     }
 
     @Test
@@ -54,6 +69,8 @@ class AndroidLinkRoutingTest {
     @Test
     fun `popup capture follows internal routing allowlist`() {
         assertTrue(shouldCapturePopupInApp(Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")))
+        assertTrue(shouldCapturePopupInApp(Uri.parse("https://www.google.com/gsi/select")))
+        assertTrue(shouldCapturePopupInApp(Uri.parse("https://lh3.googleusercontent.com/a/x")))
         assertTrue(shouldCapturePopupInApp(Uri.parse("https://chat.deepseek.com/sign_in")))
         assertTrue(
                 shouldCapturePopupInApp(

--- a/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/AndroidLinkRoutingTest.kt
@@ -52,6 +52,18 @@ class AndroidLinkRoutingTest {
     }
 
     @Test
+    fun `popup capture follows internal routing allowlist`() {
+        assertTrue(shouldCapturePopupInApp(Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")))
+        assertTrue(shouldCapturePopupInApp(Uri.parse("https://chat.deepseek.com/sign_in")))
+        assertTrue(
+                shouldCapturePopupInApp(
+                        Uri.parse("https://newassets.hcaptcha.com/captcha/v1/hcaptcha.html")
+                )
+        )
+        assertFalse(shouldCapturePopupInApp(Uri.parse("https://github.com/EdgeTypE/better-deepseek")))
+    }
+
+    @Test
     fun `non-http schemes are not routed as browser links`() {
         assertFalse(shouldOpenExternally(Uri.parse("mailto:hello@example.com")))
         assertFalse(shouldOpenExternally(Uri.parse("javascript:alert(1)")))

--- a/android/app/src/test/java/com/betterdeepseek/app/UserAgentMetadataTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/UserAgentMetadataTest.kt
@@ -1,0 +1,40 @@
+package com.betterdeepseek.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UserAgentMetadataTest {
+
+    @Test
+    fun `parses Chrome major version from UA`() {
+        assertEquals(
+                "137",
+                parseChromeMajorVersion(
+                        "Mozilla/5.0 (Linux; Android 14; Pixel 7) " +
+                                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                                "Chrome/137.0.7151.61 Mobile Safari/537.36"
+                ),
+        )
+        assertEquals(null, parseChromeMajorVersion("Mozilla/5.0 Mobile Safari/537.36"))
+    }
+
+    @Test
+    fun `builds Android Chrome user agent metadata`() {
+        val metadata =
+                buildUserAgentMetadata(
+                        "Mozilla/5.0 (Linux; Android 14; Pixel 7) " +
+                                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                                "Chrome/137.0.7151.61 Mobile Safari/537.36"
+                )
+        val brandVersions =
+                metadata.brandVersionList.associate { brandVersion ->
+                    brandVersion.brand to brandVersion.majorVersion
+                }
+
+        assertEquals("137", brandVersions["Chromium"])
+        assertEquals("137", brandVersions["Google Chrome"])
+        assertTrue(metadata.isMobile)
+        assertEquals("Android", metadata.platform)
+    }
+}

--- a/android/app/src/test/java/com/betterdeepseek/app/UserAgentMetadataTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/UserAgentMetadataTest.kt
@@ -1,5 +1,6 @@
 package com.betterdeepseek.app
 
+import androidx.webkit.UserAgentMetadata
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -20,6 +21,28 @@ class UserAgentMetadataTest {
     }
 
     @Test
+    fun `parses android platform version and device model`() {
+        val pixelUa =
+                "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/AD1A.240905.004) " +
+                        "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                        "Chrome/137.0.7151.61 Mobile Safari/537.36"
+        assertEquals("14", parseAndroidPlatformVersion(pixelUa))
+        assertEquals("Pixel 7", parseDeviceModel(pixelUa))
+
+        val samsungUa =
+                "Mozilla/5.0 (Linux; Android 13; SM-G991B) AppleWebKit/537.36 " +
+                        "(KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+        assertEquals("13", parseAndroidPlatformVersion(samsungUa))
+        assertEquals("SM-G991B", parseDeviceModel(samsungUa))
+
+        val noModelUa =
+                "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 " +
+                        "(KHTML, like Gecko) Chrome/137.0.7151.61 Mobile Safari/537.36"
+        assertEquals("14", parseAndroidPlatformVersion(noModelUa))
+        assertEquals(null, parseDeviceModel(noModelUa))
+    }
+
+    @Test
     fun `builds Android Chrome user agent metadata`() {
         val metadata =
                 buildUserAgentMetadata(
@@ -36,5 +59,36 @@ class UserAgentMetadataTest {
         assertEquals("137", brandVersions["Google Chrome"])
         assertTrue(metadata.isMobile)
         assertEquals("Android", metadata.platform)
+    }
+
+    @Test
+    fun `metadata includes GREASE brand and matching high-entropy fields`() {
+        val metadata =
+                buildUserAgentMetadata(
+                        "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/AD1A.240905.004) " +
+                                "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                                "Chrome/137.0.7151.61 Mobile Safari/537.36"
+                )
+        val brands = metadata.brandVersionList.map { it.brand }
+        val brandVersions =
+                metadata.brandVersionList.associate { brandVersion ->
+                    brandVersion.brand to brandVersion.majorVersion
+                }
+
+        assertTrue("must include Chromium", brands.contains("Chromium"))
+        assertTrue("must include Google Chrome", brands.contains("Google Chrome"))
+        assertTrue(
+                "must include a GREASE brand",
+                brands.any { it != "Chromium" && it != "Google Chrome" },
+        )
+        assertEquals("137", brandVersions["Chromium"])
+        assertEquals("137", brandVersions["Google Chrome"])
+        assertEquals("Android", metadata.platform)
+        assertEquals("14", metadata.platformVersion)
+        assertEquals("Pixel 7", metadata.model)
+        assertEquals("", metadata.architecture)
+        assertEquals(UserAgentMetadata.BITNESS_DEFAULT, metadata.bitness)
+        assertTrue(metadata.isMobile)
+        assertEquals("137.0.7151.61", metadata.fullVersion)
     }
 }

--- a/android/app/src/test/java/com/betterdeepseek/app/UserAgentTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/UserAgentTest.kt
@@ -1,0 +1,45 @@
+package com.betterdeepseek.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UserAgentTest {
+
+    @Test
+    fun `derives browser-like UA from WebView default UA`() {
+        val defaultUserAgent =
+                "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/AD1A.240905.004; wv) " +
+                        "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 " +
+                        "Chrome/137.0.7151.61 Mobile Safari/537.36"
+
+        val derived = deriveWebViewUserAgent(defaultUserAgent)
+
+        assertEquals(
+                "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/AD1A.240905.004) " +
+                        "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                        "Chrome/137.0.7151.61 Mobile Safari/537.36",
+                derived,
+        )
+        assertTrue(derived.contains("Chrome/137.0.7151.61"))
+        assertTrue(derived.contains("Pixel 7 Build/AD1A.240905.004"))
+        assertFalse(derived.contains("; wv"))
+        assertFalse(derived.contains("Version/4.0"))
+        assertFalse(derived.contains("BetterDeepSeek"))
+        assertFalse(derived.contains("  "))
+        assertFalse(derived.contains("; )"))
+        assertFalse(derived.contains(";)"))
+        assertEquals(derived, deriveWebViewUserAgent(derived))
+    }
+
+    @Test
+    fun `leaves non-WebView UA unchanged`() {
+        val chromeUserAgent =
+                "Mozilla/5.0 (Linux; Android 14; Pixel 7 Build/AD1A.240905.004) " +
+                        "AppleWebKit/537.36 (KHTML, like Gecko) " +
+                        "Chrome/137.0.7151.61 Mobile Safari/537.36"
+
+        assertEquals(chromeUserAgent, deriveWebViewUserAgent(chromeUserAgent))
+    }
+}

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
@@ -56,14 +56,29 @@ class WebViewNavigationTest {
     }
 
     @Test
-    fun `top-level external URL opens in browser`() {
+    fun `top-level external URL from a user gesture opens in browser`() {
         val request = mock<WebResourceRequest> {
             on { url } doReturn Uri.parse("https://github.com/EdgeTypE/better-deepseek")
             on { isForMainFrame } doReturn true
+            on { hasGesture() } doReturn true
         }
 
         val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
-        assertTrue("External top-level URL must open externally", result)
+        assertTrue("External top-level URL from a tap must open externally", result)
+    }
+
+    @Test
+    fun `external redirect without a gesture stays in WebView`() {
+        // OAuth redirect chains (302 / JS hops through non-allowlisted Google hosts) carry no
+        // gesture; externalizing them drops the session cookies and yields Google 400.
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://www.google.co.in/oauth/continue?state=abc")
+            on { isForMainFrame } doReturn true
+            on { hasGesture() } doReturn false
+        }
+
+        val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+        assertFalse("Non-gesture OAuth redirect must stay inside WebView", result)
     }
 
     @Test

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
@@ -5,6 +5,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.widget.FrameLayout
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -85,6 +86,16 @@ class WebViewNavigationTest {
 
         val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
         assertFalse("Google OAuth URL must stay inside WebView", result)
+    }
+
+    @Test
+    fun `Google OAuth requests are not intercepted`() {
+        val request = mock<WebResourceRequest> {
+            on { url } doReturn Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")
+        }
+
+        val result = webView.webViewClient.shouldInterceptRequest(webView, request)
+        assertNull("Google OAuth should load through the native WebView network stack", result)
     }
 
     @Test

--- a/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
+++ b/android/app/src/test/java/com/betterdeepseek/app/WebViewNavigationTest.kt
@@ -89,6 +89,22 @@ class WebViewNavigationTest {
     }
 
     @Test
+    fun `intermediate Google OAuth host stays in WebView`() {
+        for (url in listOf(
+                "https://www.google.com/gsi/select",
+                "https://accounts.google.com/signin/oauth/consent",
+        )) {
+            val request = mock<WebResourceRequest> {
+                on { this.url } doReturn Uri.parse(url)
+                on { isForMainFrame } doReturn true
+            }
+
+            val result = webView.webViewClient.shouldOverrideUrlLoading(webView, request)
+            assertFalse("Google OAuth hop must stay inside WebView: $url", result)
+        }
+    }
+
+    @Test
     fun `Google OAuth requests are not intercepted`() {
         val request = mock<WebResourceRequest> {
             on { url } doReturn Uri.parse("https://accounts.google.com/o/oauth2/v2/auth")


### PR DESCRIPTION
(DeepSeek's  apparently tightened security again. This implements proper fingerprinting so we don't look like a bot, and also fixes the old janky malformed Google Auth redirect in the Log in with Google flow.)

PR adds comprehensive unit tests for user agent handling and WebView navigation logic in the Android app. The new and expanded tests ensure that user agent parsing, construction, and derivation work as intended, and that link routing and navigation in the WebView correctly handle OAuth flows, external URLs, and popup capture scenarios. The tests also verify that only appropriate URLs are opened externally and that session integrity is maintained during OAuth redirects.

**User Agent Handling:**

* Added `UserAgentTest.kt` to verify that browser-like user agents are correctly derived from the WebView default UA, and that non-WebView UAs remain unchanged.
* Added `UserAgentMetadataTest.kt` to test parsing of Chrome version, Android platform version, device model, and construction of `UserAgentMetadata` including GREASE brand and high-entropy fields.

**WebView Navigation and Routing:**

* Improved and expanded `WebViewNavigationTest.kt` to:
  - Distinguish between top-level external URLs opened by user gesture and those from redirects, ensuring only user-initiated navigation opens externally.
  - Ensure OAuth redirect chains without user gestures stay within the WebView to preserve session cookies.
  - Add tests for intermediate Google OAuth hosts, confirming they remain in the WebView, and that Google OAuth requests are not intercepted by custom handlers.
  - Added missing import for `assertNull` for null assertions.

**Link Routing and Popup Capture:**

* Expanded `AndroidLinkRoutingTest.kt` with tests for:
  - Google OAuth and hCaptcha hosts, ensuring correct routing (internal vs. external) for various URLs.
  - The `isGoogleAuthHost` utility to confirm it matches only intended identity hosts.
  - The popup capture logic, verifying it follows the internal routing allowlist.