### PR TITLE
fix(ui): prevent question panel reopening after user replies

### DIFF
--- a/src/content/message-processor.svelte.js
+++ b/src/content/message-processor.svelte.js
@@ -7,6 +7,7 @@ import { simpleHash } from "../lib/utils/hash.js";
 import {
   detectMessageRole,
   isLatestAssistantMessage,
+  isAbsoluteLastMessage,
   scheduleScan,
   collectMessageNodes
 } from "./scanner.js";
@@ -481,7 +482,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
       }
     }
 
-    if (!state.activeQuestions && !isSystemGenerating() && parsed.askQuestions.length > 0 && isLatestAssistantMessage(node)) {
+    if (!state.activeQuestions && !isSystemGenerating() && parsed.askQuestions.length > 0 && isLatestAssistantMessage(node) && isAbsoluteLastMessage(node)) {
       state.activeQuestions = parsed.askQuestions;
       window.dispatchEvent(new CustomEvent('bds-ask-questions', { 
         detail: { 

--- a/tests/integration/message-processor.test.js
+++ b/tests/integration/message-processor.test.js
@@ -415,6 +415,32 @@ describe("message processor integration", () => {
     expect(listener).toHaveBeenCalledOnce();
   });
 
+  it("does not reopen clarifying questions after a user reply", () => {
+    const originalNode = createMessageNode(
+      '<BDS:ask_question>[{"id":"q1","question":"Pick one","type":"test","options":["A"]}]</BDS:ask_question>',
+    );
+    const listener = vi.fn();
+    window.addEventListener("bds-ask-questions", listener);
+
+    processMessageNode(originalNode);
+    vi.advanceTimersByTime(3000);
+    processMessageNode(originalNode);
+
+    expect(listener).toHaveBeenCalledOnce();
+
+    state.activeQuestions = null;
+    originalNode.remove();
+    const recreatedNode = createMessageNode(originalNode.dataset.rawText);
+    recreatedNode.dataset.absoluteLast = "0";
+    processMessageNode(recreatedNode);
+    vi.advanceTimersByTime(3000);
+    processMessageNode(recreatedNode);
+
+    expect(state.activeQuestions).toBeNull();
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener("bds-ask-questions", listener);
+  });
+
   it("removes injected BetterDeepSeek blocks from user messages", () => {
     const node = createMessageNode(
       "<BetterDeepSeek>Hidden</BetterDeepSeek>\nVisible text",


### PR DESCRIPTION
## Summary

- Require an `ask_question` message to be the absolute last message in the conversation before opening the question panel
- Prevent historical assistant messages from reopening the panel after the user has replied
- Add an integration test covering message node recreation after a user response

## Problem

After the user submitted an answer, `activeQuestions` was cleared and the panel was closed.

However, when DeepSeek recreated the historical assistant message DOM node, the message was processed again. Because it was still the latest assistant message and still contained an `<BDS:ask_question>` block, the question panel could be opened again.

## Solution

The question activation condition now requires the message to satisfy both conditions:

- It is the latest assistant message
- It is the absolute last message in the conversation

Once the user has replied, the historical assistant message is no longer the absolute last message, so recreating or rescanning its DOM node cannot reopen the panel.

## Testing

Added an integration test that:

1. Opens the question panel from an assistant message
2. Simulates the user completing the question
3. Recreates the historical assistant message node
4. Marks it as no longer being the absolute last message
5. Verifies that the question event is not dispatched again

```bash
npx vitest run tests/integration/message-processor.test.js
```
Result: 25 tests passed.