### PR TITLE
Fix Quadratic Polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,13 @@ jobs:
             ${{ runner.os }}-selenium-
 
       - name: Setup Firefox
+        id: setup-firefox
         uses: browser-actions/setup-firefox@v1
         with:
           firefox-version: latest
 
       - name: Print Firefox version
-        run: firefox --version
+        run: ${{ steps.setup-firefox.outputs.firefox-path }} --version
 
       - name: Build Firefox extension
         run: npm run build:firefox
@@ -107,7 +108,7 @@ jobs:
         run: npm run test:e2e:firefox
         env:
           CI: "1"
-          FIREFOX_BIN: firefox
+          FIREFOX_BIN: ${{ steps.setup-firefox.outputs.firefox-path }}
 
       - name: Upload Firefox test artifacts
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,55 @@ jobs:
           path: test-results
           if-no-files-found: ignore
 
+  firefox-e2e:
+    name: Firefox E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Selenium browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/selenium
+          key: ${{ runner.os }}-selenium-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-selenium-
+
+      - name: Setup Firefox
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: latest
+
+      - name: Print Firefox version
+        run: firefox --version
+
+      - name: Build Firefox extension
+        run: npm run build:firefox
+
+      - name: Run Firefox E2E suite
+        run: npm run test:e2e:firefox
+        env:
+          CI: "1"
+          FIREFOX_BIN: firefox
+
+      - name: Upload Firefox test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-firefox
+          path: test-results-firefox
+          if-no-files-found: ignore
+
   android:
     name: Android
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ coverage/
 playwright-report/
 playwright-report-android/
 test-results/
+test-results-firefox/
 # Ignore local Claude Code files
 .claude
 AGENTS.md

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,7 +67,7 @@ Useful variants:
 1. Build both extensions with `npm run build`.
 2. Selenium Manager auto-provisions GeckoDriver. Set `FIREFOX_BIN` to override the Firefox binary.
 3. Firefox launches with BiDi enabled and the unsigned `dist-firefox/` extension installed temporarily via `installAddon(path, true)`.
-4. BiDi `network.addIntercept` + `network.continueResponse` serve the same deterministic fixture HTML and API payloads as the Chrome lane (shared `tests/e2e/fixtures/payloads.js`).
+4. BiDi `network.addIntercept` + `network.provideResponse` serve the same deterministic fixture HTML and API payloads as the Chrome lane (shared `tests/e2e/fixtures/payloads.js`).
 5. `npm run test:e2e:firefox` invokes Vitest with `vitest.firefox.config.js`, running tests from `tests/e2e-firefox/`.
 6. In CI, Firefox runs headless. Selenium caches at `~/.cache/selenium` — cache this directory for faster runs.
 7. Test results are written to `test-results-firefox/` on failure.
@@ -75,9 +75,13 @@ Useful variants:
 ### Firefox contracts
 
 1. **Boot**: Extension boots on the mock fixture and exposes `#bds-toggle`, `.bds-plus-btn`.
-2. **Storage quiescence**: A unique `replaceRemote` produces exactly one `bds:remote-config-updated` event over 750 ms; repeating the identical replacement produces zero additional events. This validates the [#108](https://github.com/EdgeTypE/better-deepseek/issues/108) fix in Firefox.
-3. **2000-message processing**: After seeding 2,000 settled messages and appending one new message, the new message gains `data-bds-msg-id`, proving the built extension processes it. This validates the [#105](https://github.com/EdgeTypE/better-deepseek/issues/105) fix in Firefox.
-4. **Host wrapper box model**: The `bds-host-wrapper` has a nonzero box, is not `display: contents`, and sibling tool/unknown hosts survive when another host is removed.
+2. **Storage quiescence (#108)**: A unique `replaceRemote` produces exactly one `bds:remote-config-updated` event and exactly one `chrome.storage.onChanged` event for the remoteConfig key. Repeating the identical replacement produces zero additional events or storage writes. A 500 ms idle window shows stable counts. Verified via extension-realm storage probe (`startStorageProbe`/`getStorageProbe`/`stopStorageProbe` debug API methods).
+3. **Performance (#105)**: 200-message baseline and 2000-message scale. All five samples at each scale must complete; each append under 2,000 ms. Median ratio ≤ 2.5×, absolute median increase ≤ 750 ms. Uses observable `waitForAllMessagesProcessed` and `appendAndMeasureProcessing` helpers (no fixed sleeps).
+4. **Host wrapper box model**: `create_file` message produces `.bds-download-card` inside `.bds-host-wrapper`. Wrapper `display` is not `contents`; both `width` and `height` are greater than zero.
+
+### Chrome contracts (matching)
+
+The Chrome Playwright lane runs the identical performance (#105), storage (#108), and host-wrapper contracts using the same shared mock fixture helpers (`waitForAllMessagesProcessed`, `appendAndMeasureProcessing`, debug API storage probe).
 
 ## Android simulator
 
@@ -96,7 +100,9 @@ Useful variants:
 
 ## CI
 
-- GitHub Actions runs two jobs: a web lane and an Android lane.
-- The web lane builds `dist-chrome/` and `dist-firefox/`, runs `npm run test:unit`, then runs `npm run test:e2e` (Chrome) and `npm run test:e2e:firefox`.
+- GitHub Actions runs three jobs: **Web / Extension** (Chrome + unit), **Firefox E2E**, and **Android**.
+- The web lane builds `dist-chrome/`, runs `npm run test:unit`, then runs `npm run test:e2e` (Chrome Playwright).
+- The Firefox lane builds `dist-firefox/` on `ubuntu-latest` with Node 20, installs Firefox Stable via `browser-actions/setup-firefox@v1`, caches `~/.cache/selenium`, runs `npm run test:e2e:firefox`, and uploads `test-results-firefox/` on failure.
 - The Android lane builds `dist-android/`, assembles the debug APK, runs `npm run test:e2e:android`, then runs `npm run android:test`.
-- Coverage, Playwright reports, Android artifacts, and Firefox `test-results-firefox/` are uploaded on every CI run.
+- Coverage, Playwright reports, Android artifacts, and Firefox test results are uploaded on every CI run.
+- `npm test` builds (`pretest`) before running the unit + Chrome + Firefox suites — works from a clean checkout with no pre-existing `dist-chrome/` or `dist-firefox/`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -55,19 +55,21 @@ Useful variants:
 - For Svelte 5 components, mount via `mount()` through [tests/helpers/svelte.js](/d:/Creative%20Corner/Projects/Software/better-deepseek/tests/helpers/svelte.js).
 - If a test touches browser-extension APIs, extend the shared chrome mock instead of creating one-off mocks.
 
-## Playwright workflow (Chrome)
+## Playwright workflow (Chrome-target Chromium)
 
 1. Build the extension first with `npm run build:chrome`.
-2. Playwright loads `dist-chrome/` as an unpacked Chromium extension.
+2. Playwright loads the exact `dist-chrome/` build as an unpacked extension in its bundled Chromium using `channel: "chromium"`.
 3. All HTTP(S) requests are intercepted via a catch-all route and resolved through the shared `tests/e2e/fixtures/fixture-resolver.js`. Unmatched external URLs receive a terminal 500 response and fail the test.
 4. The E2E suite then drives the real content script, sidebar injectors, and UI overlay behavior.
+
+This lane is intentionally named Chrome-target Chromium, not branded Chrome Stable. Current Chrome and Edge releases removed the command-line flags Playwright needs to side-load unpacked extensions, so [Playwright requires its bundled Chromium for extension automation](https://playwright.dev/docs/chrome-extensions). Release verification for a store-installed build in branded Chrome remains a manual check; the same production source is exercised automatically here and independently in Firefox.
 
 ## Selenium WebDriver workflow (Firefox)
 
 1. Build both extensions with `npm run build`.
 2. Selenium Manager auto-provisions GeckoDriver. Set `FIREFOX_BIN` to an **absolute path** to override. Relative paths or command names (e.g. `firefox`) are rejected with an actionable error before driver construction.
 3. Firefox launches with BiDi enabled and the unsigned `dist-firefox/` extension installed temporarily via `installAddon(path, true)`.
-4. BiDi `network.addIntercept` + `network.provideResponse` resolve every external request through the same shared `tests/e2e/fixtures/fixture-resolver.js` as Chrome. Unknown external URLs receive a terminal 500 response and mark the fixture failed.
+4. Catch-all HTTP(S) BiDi interception plus `network.provideResponse` resolves every external request through the same shared `tests/e2e/fixtures/fixture-resolver.js` as Chromium. Unknown external URLs receive a terminal 500 response and mark the fixture failed.
 5. Extension bootstrap is verified via WebDriver waits for `#bds-toggle` and `.bds-plus-btn` (no fixed sleeps).
 6. `npm run test:e2e:firefox` invokes Vitest with `vitest.firefox.config.js`, running tests from `tests/e2e-firefox/`.
 7. In CI, Firefox runs headless. Selenium caches at `~/.cache/selenium` — cache this directory for faster runs. The CI job uses `${{ steps.setup-firefox.outputs.firefox-path }}` for the absolute binary path.
@@ -76,13 +78,13 @@ Useful variants:
 ### Firefox contracts
 
 1. **Boot**: Extension boots and exposes `#bds-toggle`, `.bds-plus-btn`. Driver health checked before each test.
-2. **Storage quiescence (#108)**: Correlated `debugRequest` helper awaits every operation. Storage probe started in `try`, stopped in `finally`. One unique `replaceRemote` → `total === 1`, `remoteConfig === 1`. Reordered identical config → zero additional events. Idle window → stable counts.
+2. **Storage quiescence (#108)**: `waitForStartup` first awaits background config/status and content locale persistence. A fresh probe must then remain at `total === 0`, `remoteConfig === 0` for an observed quiet window. Correlated debug writes await storage completion. One unique `replaceRemote` produces exactly one total/remote event; a reordered repeat produces none; a second quiet window proves stability.
 3. **Performance (#105)**: 200/2000 message baselines with `waitForAllMessagesProcessed`. All 5 samples at each scale required via `appendAndMeasureProcessing`. Each < 2000ms, median ratio ≤ 2.5×, absolute increase ≤ 750ms.
 4. **Host wrapper**: `.bds-download-card` is a descendant of `.bds-host-wrapper` (`wrapper.contains(card)`). Wrapper has nonzero width and height, display is not `contents`.
 
-### Chrome contracts (matching)
+### Chrome-target Chromium contracts (matching)
 
-The Chrome Playwright lane runs the identical performance (#105), storage (#108 with correlation-ID-based debugRequest + try/finally), and host-wrapper (`wrapper.contains(card)`) contracts using the same shared mock fixture resolver and helpers.
+The Chromium Playwright lane runs the identical performance (#105), startup/storage-quiescence (#108), and exact host-ownership contracts using the same shared fixture resolver. Its fixture teardown fails the test if any external request was unmatched.
 
 ## Android simulator
 
@@ -102,7 +104,7 @@ The Chrome Playwright lane runs the identical performance (#105), storage (#108 
 ## CI
 
 - GitHub Actions runs three jobs: **Web / Extension** (Chrome + unit), **Firefox E2E**, and **Android**.
-- The web lane builds `dist-chrome/`, runs `npm run test:unit`, then runs `npm run test:e2e` (Chrome Playwright).
+- The web lane builds `dist-chrome/`, runs `npm run test:unit`, then runs `npm run test:e2e` (Chrome-target Playwright Chromium).
 - The Firefox lane builds `dist-firefox/` on `ubuntu-latest` with Node 20, installs Firefox Stable via `browser-actions/setup-firefox@v1`, caches `~/.cache/selenium`, runs `npm run test:e2e:firefox`, and uploads `test-results-firefox/` on failure.
 - The Android lane builds `dist-android/`, assembles the debug APK, runs `npm run test:e2e:android`, then runs `npm run android:test`.
 - Coverage, Playwright reports, Android artifacts, and Firefox test results are uploaded on every CI run.

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,29 +59,30 @@ Useful variants:
 
 1. Build the extension first with `npm run build:chrome`.
 2. Playwright loads `dist-chrome/` as an unpacked Chromium extension.
-3. Requests to `https://chat.deepseek.com/*` are fulfilled with the local mock fixture at [tests/e2e/fixtures/mock-deepseek.html](/d:/Creative%20Corner/Projects/Software/better-deepseek/tests/e2e/fixtures/mock-deepseek.html).
+3. All HTTP(S) requests are intercepted via a catch-all route and resolved through the shared `tests/e2e/fixtures/fixture-resolver.js`. Unmatched external URLs receive a terminal 500 response and fail the test.
 4. The E2E suite then drives the real content script, sidebar injectors, and UI overlay behavior.
 
 ## Selenium WebDriver workflow (Firefox)
 
 1. Build both extensions with `npm run build`.
-2. Selenium Manager auto-provisions GeckoDriver. Set `FIREFOX_BIN` to override the Firefox binary.
+2. Selenium Manager auto-provisions GeckoDriver. Set `FIREFOX_BIN` to an **absolute path** to override. Relative paths or command names (e.g. `firefox`) are rejected with an actionable error before driver construction.
 3. Firefox launches with BiDi enabled and the unsigned `dist-firefox/` extension installed temporarily via `installAddon(path, true)`.
-4. BiDi `network.addIntercept` + `network.provideResponse` serve the same deterministic fixture HTML and API payloads as the Chrome lane (shared `tests/e2e/fixtures/payloads.js`).
-5. `npm run test:e2e:firefox` invokes Vitest with `vitest.firefox.config.js`, running tests from `tests/e2e-firefox/`.
-6. In CI, Firefox runs headless. Selenium caches at `~/.cache/selenium` — cache this directory for faster runs.
-7. Test results are written to `test-results-firefox/` on failure.
+4. BiDi `network.addIntercept` + `network.provideResponse` resolve every external request through the same shared `tests/e2e/fixtures/fixture-resolver.js` as Chrome. Unknown external URLs receive a terminal 500 response and mark the fixture failed.
+5. Extension bootstrap is verified via WebDriver waits for `#bds-toggle` and `.bds-plus-btn` (no fixed sleeps).
+6. `npm run test:e2e:firefox` invokes Vitest with `vitest.firefox.config.js`, running tests from `tests/e2e-firefox/`.
+7. In CI, Firefox runs headless. Selenium caches at `~/.cache/selenium` — cache this directory for faster runs. The CI job uses `${{ steps.setup-firefox.outputs.firefox-path }}` for the absolute binary path.
+8. Test results are written to `test-results-firefox/` on failure.
 
 ### Firefox contracts
 
-1. **Boot**: Extension boots on the mock fixture and exposes `#bds-toggle`, `.bds-plus-btn`.
-2. **Storage quiescence (#108)**: A unique `replaceRemote` produces exactly one `bds:remote-config-updated` event and exactly one `chrome.storage.onChanged` event for the remoteConfig key. Repeating the identical replacement produces zero additional events or storage writes. A 500 ms idle window shows stable counts. Verified via extension-realm storage probe (`startStorageProbe`/`getStorageProbe`/`stopStorageProbe` debug API methods).
-3. **Performance (#105)**: 200-message baseline and 2000-message scale. All five samples at each scale must complete; each append under 2,000 ms. Median ratio ≤ 2.5×, absolute median increase ≤ 750 ms. Uses observable `waitForAllMessagesProcessed` and `appendAndMeasureProcessing` helpers (no fixed sleeps).
-4. **Host wrapper box model**: `create_file` message produces `.bds-download-card` inside `.bds-host-wrapper`. Wrapper `display` is not `contents`; both `width` and `height` are greater than zero.
+1. **Boot**: Extension boots and exposes `#bds-toggle`, `.bds-plus-btn`. Driver health checked before each test.
+2. **Storage quiescence (#108)**: Correlated `debugRequest` helper awaits every operation. Storage probe started in `try`, stopped in `finally`. One unique `replaceRemote` → `total === 1`, `remoteConfig === 1`. Reordered identical config → zero additional events. Idle window → stable counts.
+3. **Performance (#105)**: 200/2000 message baselines with `waitForAllMessagesProcessed`. All 5 samples at each scale required via `appendAndMeasureProcessing`. Each < 2000ms, median ratio ≤ 2.5×, absolute increase ≤ 750ms.
+4. **Host wrapper**: `.bds-download-card` is a descendant of `.bds-host-wrapper` (`wrapper.contains(card)`). Wrapper has nonzero width and height, display is not `contents`.
 
 ### Chrome contracts (matching)
 
-The Chrome Playwright lane runs the identical performance (#105), storage (#108), and host-wrapper contracts using the same shared mock fixture helpers (`waitForAllMessagesProcessed`, `appendAndMeasureProcessing`, debug API storage probe).
+The Chrome Playwright lane runs the identical performance (#105), storage (#108 with correlation-ID-based debugRequest + try/finally), and host-wrapper (`wrapper.contains(card)`) contracts using the same shared mock fixture resolver and helpers.
 
 ## Android simulator
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,6 +5,7 @@
 - `Vitest` drives unit and integration coverage.
 - `jsdom` is used for DOM-bound module and Svelte component tests.
 - `Playwright` runs end-to-end tests against the built Chrome extension.
+- `Selenium WebDriver` with BiDi runs end-to-end tests against the built Firefox extension.
 - `Playwright` also runs Android WebView simulator parity tests against the built `dist-android/` bundle.
 - `Gradle` runs Kotlin unit tests and APK assembly checks for the Android shell.
 - Chrome extension APIs are mocked centrally in [tests/mocks/chrome.js](/d:/Creative%20Corner/Projects/Software/better-deepseek/tests/mocks/chrome.js).
@@ -13,9 +14,11 @@
 
 ```bash
 npm run build:chrome
+npm run build:firefox
 npm run build:android
 npm run test:unit
 npm run test:e2e
+npm run test:e2e:firefox
 npm run test:e2e:android
 npm run android:test
 npm run android:assemble:debug
@@ -30,7 +33,7 @@ Useful variants:
 - `npm run test:watch` runs Vitest in watch mode.
 - `npm run test:ui` opens the Vitest UI.
 - `npm run test:android` builds `dist-android/` and runs the Android simulator Playwright suite.
-- `npm run test:ci:web` mirrors the web GitHub Actions job.
+- `npm run test:ci:web` mirrors the web GitHub Actions job (Chrome + Firefox).
 - `npm run test:ci:android` mirrors the Android GitHub Actions job.
 - `npm run test:ci` runs both CI-equivalent jobs locally.
 
@@ -38,9 +41,11 @@ Useful variants:
 
 - Unit tests live next to the source file when the module is mostly pure.
 - Integration tests live under `tests/integration/`.
-- E2E tests live under `tests/e2e/`.
+- Chrome E2E tests live under `tests/e2e/`.
+- Firefox E2E tests live under `tests/e2e-firefox/`.
 - Android simulator E2E tests live under `tests/e2e-android/`.
 - Shared DOM helpers live under `tests/helpers/`.
+- Shared response payloads live in `tests/e2e/fixtures/payloads.js`.
 
 ## Vitest conventions
 
@@ -50,16 +55,31 @@ Useful variants:
 - For Svelte 5 components, mount via `mount()` through [tests/helpers/svelte.js](/d:/Creative%20Corner/Projects/Software/better-deepseek/tests/helpers/svelte.js).
 - If a test touches browser-extension APIs, extend the shared chrome mock instead of creating one-off mocks.
 
-## Playwright workflow
-
-### Chrome extension
+## Playwright workflow (Chrome)
 
 1. Build the extension first with `npm run build:chrome`.
 2. Playwright loads `dist-chrome/` as an unpacked Chromium extension.
 3. Requests to `https://chat.deepseek.com/*` are fulfilled with the local mock fixture at [tests/e2e/fixtures/mock-deepseek.html](/d:/Creative%20Corner/Projects/Software/better-deepseek/tests/e2e/fixtures/mock-deepseek.html).
 4. The E2E suite then drives the real content script, sidebar injectors, and UI overlay behavior.
 
-### Android simulator
+## Selenium WebDriver workflow (Firefox)
+
+1. Build both extensions with `npm run build`.
+2. Selenium Manager auto-provisions GeckoDriver. Set `FIREFOX_BIN` to override the Firefox binary.
+3. Firefox launches with BiDi enabled and the unsigned `dist-firefox/` extension installed temporarily via `installAddon(path, true)`.
+4. BiDi `network.addIntercept` + `network.continueResponse` serve the same deterministic fixture HTML and API payloads as the Chrome lane (shared `tests/e2e/fixtures/payloads.js`).
+5. `npm run test:e2e:firefox` invokes Vitest with `vitest.firefox.config.js`, running tests from `tests/e2e-firefox/`.
+6. In CI, Firefox runs headless. Selenium caches at `~/.cache/selenium` — cache this directory for faster runs.
+7. Test results are written to `test-results-firefox/` on failure.
+
+### Firefox contracts
+
+1. **Boot**: Extension boots on the mock fixture and exposes `#bds-toggle`, `.bds-plus-btn`.
+2. **Storage quiescence**: A unique `replaceRemote` produces exactly one `bds:remote-config-updated` event over 750 ms; repeating the identical replacement produces zero additional events. This validates the [#108](https://github.com/EdgeTypE/better-deepseek/issues/108) fix in Firefox.
+3. **2000-message processing**: After seeding 2,000 settled messages and appending one new message, the new message gains `data-bds-msg-id`, proving the built extension processes it. This validates the [#105](https://github.com/EdgeTypE/better-deepseek/issues/105) fix in Firefox.
+4. **Host wrapper box model**: The `bds-host-wrapper` has a nonzero box, is not `display: contents`, and sibling tool/unknown hosts survive when another host is removed.
+
+## Android simulator
 
 1. Build the Android bundle first with `npm run build:android`.
 2. Playwright loads the same mock DeepSeek fixture in a mobile Chromium context.
@@ -72,10 +92,11 @@ Useful variants:
 - For content-script modules with side effects, prefer integration tests under `tests/integration/` and mock the smallest stable boundary.
 - For new UI components, render them through the shared Svelte helper and assert only on public DOM behavior.
 - For new extension flows, add them to the mock DeepSeek fixture only if the real selector contract requires it.
+- For shared response payloads (pricing, GitHub ZIP, etc.), add them to `tests/e2e/fixtures/payloads.js` so both Chrome and Firefox lanes consume the same data.
 
 ## CI
 
 - GitHub Actions runs two jobs: a web lane and an Android lane.
-- The web lane builds `dist-chrome/`, runs `npm run test:unit`, then runs `npm run test:e2e`.
+- The web lane builds `dist-chrome/` and `dist-firefox/`, runs `npm run test:unit`, then runs `npm run test:e2e` (Chrome) and `npm run test:e2e:firefox`.
 - The Android lane builds `dist-android/`, assembles the debug APK, runs `npm run test:e2e:android`, then runs `npm run android:test`.
-- Coverage, Playwright reports, APKs, and Android unit-test artifacts are uploaded on every CI run.
+- Coverage, Playwright reports, Android artifacts, and Firefox `test-results-firefox/` are uploaded on every CI run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "jsdom": "^26.1.0",
+        "selenium-webdriver": "^4.46.0",
         "svelte": "^5.28.2",
         "vite": "^6.3.1",
         "vitest": "^3.2.4"
@@ -107,6 +108,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
@@ -2830,6 +2838,32 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/selenium-webdriver": {
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.46.0.tgz",
+      "integrity": "sha512-UlTkgnx9y+bf3QxFsrgUyMqC2oy1Yf+qcOs7xIC/XfsUPv/ow7Sicx6SJ7AeOn2/Z+xF1M8SLqyn983wipI82w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/SeleniumHQ"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/selenium"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.5.0",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.7",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3228,6 +3262,16 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/totalist": {
       "version": "3.0.1",
@@ -3701,9 +3745,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:android": "node build.js --target=android && node scripts/copy-to-android-assets.js",
     "build:source": "node build.js --source",
     "sanitize": "node scripts/sanitize-dist.js",
+    "pretest": "npm run build",
     "test": "npm run test:unit && npm run test:e2e && npm run test:e2e:firefox",
     "test:unit": "vitest run --coverage",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:android": "node build.js --target=android && node scripts/copy-to-android-assets.js",
     "build:source": "node build.js --source",
     "sanitize": "node scripts/sanitize-dist.js",
-    "test": "npm run test:unit && npm run test:e2e",
+    "test": "npm run test:unit && npm run test:e2e && npm run test:e2e:firefox",
     "test:unit": "vitest run --coverage",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test",
+    "test:e2e:firefox": "vitest run --config=vitest.firefox.config.js",
     "test:e2e:android": "playwright test --config=playwright.android.config.js",
     "android:test": "node scripts/run-android-gradle.js test",
     "android:assemble:debug": "node scripts/run-android-gradle.js assembleDebug",
     "test:android": "npm run build:android && npm run test:e2e:android",
-    "test:ci:web": "npm run build:chrome && npm run test:unit && npm run test:e2e",
+    "test:ci:web": "npm run build && npm run test:unit && npm run test:e2e && npm run test:e2e:firefox",
     "test:ci:android": "npm run build:android && npm run android:assemble:debug && npm run test:e2e:android && npm run android:test",
     "test:ci": "npm run test:ci:web && npm run test:ci:android"
   },
@@ -31,6 +32,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "jsdom": "^26.1.0",
+    "selenium-webdriver": "^4.46.0",
     "svelte": "^5.28.2",
     "vite": "^6.3.1",
     "vitest": "^3.2.4"

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -439,105 +439,20 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 });
 
-// Remote status announcement system
-const REMOTE_STATUS_URL = "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json";
+import {
+  persistRemoteConfig,
+  persistRemoteStatus,
+  persistLocales,
+} from "../lib/remote-persistence.js";
 
-async function fetchRemoteStatus() {
-  try {
-    const response = await fetch(`${REMOTE_STATUS_URL}?t=${Date.now()}`, {
-      cache: "no-store"
-    });
-    if (!response.ok) return;
-    
-    let data = await response.json();
-    if (data) {
-      // Ensure data is always an array for the new multi-announcement system
-      const announcements = Array.isArray(data) ? data : [data];
-      await chrome.storage.local.set({ bds_remote_announcement: announcements });
-    }
-  } catch (err) {
-    console.error("Failed to fetch remote status:", err);
-  }
-}
-
-// Remote config system — fetch the latest config from GitHub
-const REMOTE_CONFIG_URL = "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json";
-
-/**
- * Deep structural equality check. Returns true when `a` and `b` have the same
- * JSON-serializable shape (key order independent for objects).
- */
-function isDeepEqual(a, b) {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== "object" || a === null || b === null) return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-  if (Array.isArray(a)) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (!isDeepEqual(a[i], b[i])) return false;
-    }
-    return true;
-  }
-
-  const aKeys = Object.keys(a).sort();
-  const bKeys = Object.keys(b).sort();
-  if (aKeys.length !== bKeys.length) return false;
-  for (let i = 0; i < aKeys.length; i++) {
-    if (aKeys[i] !== bKeys[i]) return false;
-    if (!isDeepEqual(a[aKeys[i]], b[bKeys[i]])) return false;
-  }
-  return true;
-}
-
-async function fetchRemoteConfig() {
-  try {
-    const response = await fetch(`${REMOTE_CONFIG_URL}?t=${Date.now()}`, {
-      cache: "no-store"
-    });
-    if (!response.ok) return;
-
-    const config = await response.json();
-    if (!config || typeof config !== "object") return;
-
-    // Compare structurally with stored config to avoid unnecessary writes.
-    // Only write bds_remote_config when the fetched value actually changed.
-    const stored = await chrome.storage.local.get("bds_remote_config");
-    const currentConfig = stored?.bds_remote_config;
-
-    // Normalize: strip metadata from config before comparison, and exclude
-    // meta from the config key itself (meta lives in bds_remote_config_meta).
-    const configForComparison = { ...config };
-    delete configForComparison.meta;
-
-    const storedForComparison = currentConfig && typeof currentConfig === "object"
-      ? (() => { const c = { ...currentConfig }; delete c.meta; return c; })()
-      : null;
-
-    if (!isDeepEqual(configForComparison, storedForComparison)) {
-      await chrome.storage.local.set({ bds_remote_config: config });
-    }
-
-    // Metadata always updates (tracks last-fetch time and version for cache-busting).
-    // Written separately so a metadata-only change does not disturb config consumers.
-    const meta = {
-      lastFetched: Date.now(),
-      version: config.meta?.version || 0,
-    };
-    const storedMeta = await chrome.storage.local.get("bds_remote_config_meta");
-    const currentMeta = storedMeta?.bds_remote_config_meta;
-    if (!isDeepEqual(meta, currentMeta)) {
-      await chrome.storage.local.set({ bds_remote_config_meta: meta });
-    }
-  } catch (err) {
-    console.error("Failed to fetch remote config:", err);
-  }
-}
+const storageAdapter = {
+  get: (key) => chrome.storage.local.get(key),
+  set: (values) => chrome.storage.local.set(values),
+};
 
 // Run once on startup
-fetchRemoteStatus();
-fetchRemoteConfig();
+persistRemoteStatus({ fetch, storage: storageAdapter });
+persistRemoteConfig({ fetch, storage: storageAdapter });
 
 const localeMods = import.meta.glob("../locales/*.json", { eager: true });
 const localeCodes = Object.keys(localeMods)
@@ -545,33 +460,7 @@ const localeCodes = Object.keys(localeMods)
   .filter(Boolean);
 
 async function handleLanguageUpdate() {
-  try {
-    const BASE_URL = "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales";
-    const results = await Promise.allSettled(
-      localeCodes.map(code =>
-        fetch(`${BASE_URL}/${code}.json?t=${Date.now()}`, { cache: "no-store" })
-          .then(r => r.ok ? r.json() : null)
-          .then(data => data?.messages ? { [code]: data } : null)
-      )
-    );
-    const updates = {};
-    for (const result of results) {
-      if (result.status === "fulfilled" && result.value) {
-        Object.assign(updates, result.value);
-      }
-    }
-    if (Object.keys(updates).length === 0) {
-      return { success: false, error: "No valid locale files fetched" };
-    }
-    await chrome.storage.local.set({
-      bds_locale_updates: updates,
-      bds_locale_update_last_checked: new Date().toLocaleDateString()
-    });
-    return { success: true };
-  } catch (err) {
-    console.error("Failed to execute dynamic language update:", err);
-    return { success: false, error: err.message };
-  }
+  return persistLocales({ fetch, storage: storageAdapter }, localeCodes);
 }
 
 async function handleLanguageReset() {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -463,23 +463,71 @@ async function fetchRemoteStatus() {
 // Remote config system — fetch the latest config from GitHub
 const REMOTE_CONFIG_URL = "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json";
 
+/**
+ * Deep structural equality check. Returns true when `a` and `b` have the same
+ * JSON-serializable shape (key order independent for objects).
+ */
+function isDeepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!isDeepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false;
+    if (!isDeepEqual(a[aKeys[i]], b[bKeys[i]])) return false;
+  }
+  return true;
+}
+
 async function fetchRemoteConfig() {
   try {
     const response = await fetch(`${REMOTE_CONFIG_URL}?t=${Date.now()}`, {
       cache: "no-store"
     });
     if (!response.ok) return;
-    
+
     const config = await response.json();
-    if (config && typeof config === "object") {
-      // Store full config; the content script will deep-merge with built-in defaults
+    if (!config || typeof config !== "object") return;
+
+    // Compare structurally with stored config to avoid unnecessary writes.
+    // Only write bds_remote_config when the fetched value actually changed.
+    const stored = await chrome.storage.local.get("bds_remote_config");
+    const currentConfig = stored?.bds_remote_config;
+
+    // Normalize: strip metadata from config before comparison, and exclude
+    // meta from the config key itself (meta lives in bds_remote_config_meta).
+    const configForComparison = { ...config };
+    delete configForComparison.meta;
+
+    const storedForComparison = currentConfig && typeof currentConfig === "object"
+      ? (() => { const c = { ...currentConfig }; delete c.meta; return c; })()
+      : null;
+
+    if (!isDeepEqual(configForComparison, storedForComparison)) {
       await chrome.storage.local.set({ bds_remote_config: config });
-      
-      // Store fetch metadata for cache-busting
-      const meta = {
-        lastFetched: Date.now(),
-        version: config.meta?.version || 0,
-      };
+    }
+
+    // Metadata always updates (tracks last-fetch time and version for cache-busting).
+    // Written separately so a metadata-only change does not disturb config consumers.
+    const meta = {
+      lastFetched: Date.now(),
+      version: config.meta?.version || 0,
+    };
+    const storedMeta = await chrome.storage.local.get("bds_remote_config_meta");
+    const currentMeta = storedMeta?.bds_remote_config_meta;
+    if (!isDeepEqual(meta, currentMeta)) {
       await chrome.storage.local.set({ bds_remote_config_meta: meta });
     }
   } catch (err) {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -93,6 +93,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === "BDS_WAIT_FOR_STARTUP") {
+    startupRemoteDataPromise
+      .then((result) => sendResponse(result))
+      .catch((error) => sendResponse({ success: false, error: error.message }));
+    return true;
+  }
+
   if (message.type === "BDS_RESET_LANGUAGES") {
     handleLanguageReset()
       .then((res) => sendResponse(res))
@@ -449,13 +456,24 @@ const storageAdapter = {
   get: (key) => chrome.storage.local.get(key),
   set: (values) => chrome.storage.local.set(values),
 };
+const fetchAdapter = (...args) => globalThis.fetch(...args);
 
 // Run once on startup — log failures but don't reject
-persistRemoteStatus({ fetch, storage: storageAdapter }).then((r) => {
-  if (!r.success) console.warn("[BDS] Startup status fetch failed:", r.error);
-});
-persistRemoteConfig({ fetch, storage: storageAdapter }).then((r) => {
-  if (!r.success) console.warn("[BDS] Startup config fetch failed:", r.error);
+const startupRemoteDataPromise = Promise.all([
+  persistRemoteStatus({ fetch: fetchAdapter, storage: storageAdapter }),
+  persistRemoteConfig({ fetch: fetchAdapter, storage: storageAdapter }),
+]).then(([remoteStatus, remoteConfig]) => {
+  if (!remoteStatus.success) {
+    console.warn("[BDS] Startup status fetch failed:", remoteStatus.error);
+  }
+  if (!remoteConfig.success) {
+    console.warn("[BDS] Startup config fetch failed:", remoteConfig.error);
+  }
+  return {
+    success: remoteStatus.success && remoteConfig.success,
+    remoteStatus,
+    remoteConfig,
+  };
 });
 
 const localeMods = import.meta.glob("../locales/*.json", { eager: true });
@@ -464,7 +482,7 @@ const localeCodes = Object.keys(localeMods)
   .filter(Boolean);
 
 async function handleLanguageUpdate() {
-  return persistLocales({ fetch, storage: storageAdapter }, localeCodes);
+  return persistLocales({ fetch: fetchAdapter, storage: storageAdapter }, localeCodes);
 }
 
 async function handleLanguageReset() {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -450,9 +450,13 @@ const storageAdapter = {
   set: (values) => chrome.storage.local.set(values),
 };
 
-// Run once on startup
-persistRemoteStatus({ fetch, storage: storageAdapter });
-persistRemoteConfig({ fetch, storage: storageAdapter });
+// Run once on startup — log failures but don't reject
+persistRemoteStatus({ fetch, storage: storageAdapter }).then((r) => {
+  if (!r.success) console.warn("[BDS] Startup status fetch failed:", r.error);
+});
+persistRemoteConfig({ fetch, storage: storageAdapter }).then((r) => {
+  if (!r.success) console.warn("[BDS] Startup config fetch failed:", r.error);
+});
 
 const localeMods = import.meta.glob("../locales/*.json", { eager: true });
 const localeCodes = Object.keys(localeMods)

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -21,10 +21,16 @@ function getCurrentConversationIdForBudget() {
   return match ? match[1] : null;
 }
 
+let _bridgeEventsInstalled = false;
+
 /**
  * Set up listeners for bridge events from the injected script.
+ * Idempotent — subsequent calls are no-ops.
  */
 export function setupBridgeEvents() {
+  if (_bridgeEventsInstalled) return;
+  _bridgeEventsInstalled = true;
+
   window.addEventListener(BRIDGE_EVENTS.requestConfig, () => {
     pushConfigToPage();
   });

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -182,7 +182,16 @@ function handleHistoryMessages(data) {
   // Reject the entire payload if any entry is not a non-null object with
   // a non-empty message_id. A later valid response remains accepted.
   for (const msg of incomingMessages) {
-    if (!msg || typeof msg !== "object" || !msg.message_id) return;
+    if (
+      !msg ||
+      typeof msg !== "object" ||
+      Array.isArray(msg) ||
+      Object.getPrototypeOf(msg) !== Object.prototype ||
+      typeof msg.message_id !== "string" ||
+      !msg.message_id.trim()
+    ) {
+      return;
+    }
   }
 
   // Enforce current-session-only invariant before storing

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -10,6 +10,7 @@ import { getActiveProject, getActiveFiles, getFilesForProject } from "./project-
 import { getDirectoryFiles } from "../lib/local-directory-source.js";
 import { discoverTags } from "./tags/tag-manager.js";
 import { recordOutgoingContext, recordServerUsage } from "./context-budget.js";
+import { retainOnlyHistorySession } from "./load-all-history.js";
 
 /**
  * Extract the current conversation ID from the URL for budget tracking.
@@ -166,13 +167,15 @@ function handleHistoryMessages(data) {
   const sessionId = bizData.chat_session?.id;
   if (!sessionId) return;
 
-  // Ignore history responses whose session ID no longer matches current URL
+  // Require exact match with current URL session — ignore stale responses
   const match = String(location.href || "").match(/\/chat\/s\/([^/?#]+)/);
   const currentSessionId = match ? match[1] : null;
-  if (currentSessionId && sessionId !== currentSessionId) return;
+  if (!currentSessionId || sessionId !== currentSessionId) return;
 
   const incomingMessages = bizData.chat_messages;
-  if (!Array.isArray(incomingMessages) || incomingMessages.length === 0) return;
+
+  // Enforce current-session-only invariant before storing
+  retainOnlyHistorySession(currentSessionId);
 
   const cacheControl = bizData.cache_control || "APPEND";
 
@@ -183,15 +186,17 @@ function handleHistoryMessages(data) {
   const existing = state.chatMessagesBySession.get(sessionId);
   const existingIds = new Set(existing.map(m => m.message_id));
 
-  for (const msg of incomingMessages) {
-    if (!existingIds.has(msg.message_id)) {
-      existing.push(msg);
-      existingIds.add(msg.message_id);
+  if (Array.isArray(incomingMessages)) {
+    for (const msg of incomingMessages) {
+      if (!existingIds.has(msg.message_id)) {
+        existing.push(msg);
+        existingIds.add(msg.message_id);
+      }
     }
   }
 
-  // Only notify explicit full-history requests to avoid partial data from
-  // DeepSeek's lazy-load paginated calls also resolving the promise.
+  // Notify explicit full-history requests (including empty responses —
+  // treat as completed so waiters resolve promptly without timeout).
   if (data.__bdsExplicit) {
     window.dispatchEvent(new CustomEvent("bds:history-msgs-loaded", {
       detail: JSON.stringify({ sessionId, count: existing.length })
@@ -200,6 +205,7 @@ function handleHistoryMessages(data) {
 
   // Trigger page rescan to inject precise timestamps from API — only when
   // timestamp rendering is enabled, since that is the primary consumer.
+  // Explicit export/select waiters still resolve via the event above.
   if (state.settings.showTimestamps) {
     scheduleScan();
   }

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -178,6 +178,13 @@ function handleHistoryMessages(data) {
   const incomingMessages = bizData.chat_messages;
   if (!Array.isArray(incomingMessages)) return;
 
+  // Validate every entry before mutating cache state.
+  // Reject the entire payload if any entry is not a non-null object with
+  // a non-empty message_id. A later valid response remains accepted.
+  for (const msg of incomingMessages) {
+    if (!msg || typeof msg !== "object" || !msg.message_id) return;
+  }
+
   // Enforce current-session-only invariant before storing
   retainOnlyHistorySession(currentSessionId);
 

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -22,12 +22,14 @@ function getCurrentConversationIdForBudget() {
 }
 
 let _bridgeCleanup = null;
+let _bridgeGen = 0;
 
 /**
  * Set up listeners for bridge events from the injected script.
  * Idempotent — subsequent calls return the same cleanup handle.
  * Returns a cleanup function that removes all registered listeners
  * and permits a later fresh setup via another `setupBridgeEvents()` call.
+ * A stale cleanup from a prior generation does not clear the current one.
  *
  * @returns {() => void}
  */
@@ -123,7 +125,13 @@ export function setupBridgeEvents() {
   };
   window.addEventListener("bds:network-error", handlers["bds:network-error"]);
 
+  _bridgeGen += 1;
+  const gen = _bridgeGen;
+
   _bridgeCleanup = () => {
+    // Only clear if this is still the current generation.
+    // A stale cleanup from a prior install must not null the current one.
+    if (_bridgeGen !== gen) return;
     for (const [event, handler] of Object.entries(handlers)) {
       window.removeEventListener(event, handler);
     }

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -166,6 +166,11 @@ function handleHistoryMessages(data) {
   const sessionId = bizData.chat_session?.id;
   if (!sessionId) return;
 
+  // Ignore history responses whose session ID no longer matches current URL
+  const match = String(location.href || "").match(/\/chat\/s\/([^/?#]+)/);
+  const currentSessionId = match ? match[1] : null;
+  if (currentSessionId && sessionId !== currentSessionId) return;
+
   const incomingMessages = bizData.chat_messages;
   if (!Array.isArray(incomingMessages) || incomingMessages.length === 0) return;
 
@@ -193,8 +198,11 @@ function handleHistoryMessages(data) {
     }));
   }
 
-  // Trigger page rescan to inject precise timestamps from API
-  scheduleScan();
+  // Trigger page rescan to inject precise timestamps from API — only when
+  // timestamp rendering is enabled, since that is the primary consumer.
+  if (state.settings.showTimestamps) {
+    scheduleScan();
+  }
 }
 
 /**

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -21,50 +21,56 @@ function getCurrentConversationIdForBudget() {
   return match ? match[1] : null;
 }
 
-let _bridgeEventsInstalled = false;
+let _bridgeCleanup = null;
 
 /**
  * Set up listeners for bridge events from the injected script.
- * Idempotent — subsequent calls are no-ops.
+ * Idempotent — subsequent calls return the same cleanup handle.
+ * Returns a cleanup function that removes all registered listeners
+ * and permits a later fresh setup via another `setupBridgeEvents()` call.
+ *
+ * @returns {() => void}
  */
 export function setupBridgeEvents() {
-  if (_bridgeEventsInstalled) return;
-  _bridgeEventsInstalled = true;
+  if (_bridgeCleanup) return _bridgeCleanup;
 
-  window.addEventListener(BRIDGE_EVENTS.requestConfig, () => {
+  const handlers = {};
+
+  handlers[BRIDGE_EVENTS.requestConfig] = () => {
     pushConfigToPage();
-  });
+  };
+  window.addEventListener(BRIDGE_EVENTS.requestConfig, handlers[BRIDGE_EVENTS.requestConfig]);
 
-  window.addEventListener(BRIDGE_EVENTS.networkState, (event) => {
+  handlers[BRIDGE_EVENTS.networkState] = (event) => {
     let detail = event && event.detail ? event.detail : {};
-    // Handle stringified detail (Firefox Xray Vision fix)
     if (typeof detail === "string") {
-      try {
-        detail = JSON.parse(detail);
-      } catch (e) {
+      try { detail = JSON.parse(detail); } catch (e) {
         console.error("[BDS] Failed to parse networkState detail:", e);
       }
     }
     handleNetworkState(detail);
-  });
+  };
+  window.addEventListener(BRIDGE_EVENTS.networkState, handlers[BRIDGE_EVENTS.networkState]);
 
-  window.addEventListener("bds:session-data", (event) => {
+  handlers["bds:session-data"] = (event) => {
     let data = event.detail;
     if (typeof data === "string") {
       try { data = JSON.parse(data); } catch (e) { return; }
     }
     handleSessionData(data);
-  });
+  };
+  window.addEventListener("bds:session-data", handlers["bds:session-data"]);
 
-  window.addEventListener("bds:history-msgs", (event) => {
+  handlers["bds:history-msgs"] = (event) => {
     let data = event.detail;
     if (typeof data === "string") {
       try { data = JSON.parse(data); } catch (e) { return; }
     }
     handleHistoryMessages(data);
-  });
+  };
+  window.addEventListener("bds:history-msgs", handlers["bds:history-msgs"]);
 
-  window.addEventListener("bds:token-usage", (event) => {
+  handlers["bds:token-usage"] = (event) => {
     let data = event.detail;
     if (typeof data === "string") {
       try { data = JSON.parse(data); } catch (e) { return; }
@@ -72,8 +78,6 @@ export function setupBridgeEvents() {
     if (data && data.modelName) {
       state.pricing.modelName = data.modelName;
     }
-    // Feed server-reported usage into the context budget tracker for the
-    // active Deep Research conversation (if any guard is enabled).
     if (data && state.settings.deepResearchContextGuardEnabled) {
       const conversationId = getCurrentConversationIdForBudget();
       if (conversationId) {
@@ -85,9 +89,10 @@ export function setupBridgeEvents() {
         });
       }
     }
-  });
+  };
+  window.addEventListener("bds:token-usage", handlers["bds:token-usage"]);
 
-  window.addEventListener("bds:mutation-applied", (event) => {
+  handlers["bds:mutation-applied"] = (event) => {
     let data = event.detail;
     if (typeof data === "string") {
       try { data = JSON.parse(data); } catch (e) { return; }
@@ -105,18 +110,27 @@ export function setupBridgeEvents() {
         });
       }
     }
-  });
+  };
+  window.addEventListener("bds:mutation-applied", handlers["bds:mutation-applied"]);
 
-  window.addEventListener("bds:network-error", (event) => {
+  handlers["bds:network-error"] = (event) => {
     let detail = event.detail;
     if (typeof detail === "string") {
       try { detail = JSON.parse(detail); } catch (e) { return; }
     }
     console.warn("[BDS] Network error detected:", detail);
-
-    // Trigger immediate status check
     import("./status-monitor.js").then(m => m.fetchServerStatus());
-  });
+  };
+  window.addEventListener("bds:network-error", handlers["bds:network-error"]);
+
+  _bridgeCleanup = () => {
+    for (const [event, handler] of Object.entries(handlers)) {
+      window.removeEventListener(event, handler);
+    }
+    _bridgeCleanup = null;
+  };
+
+  return _bridgeCleanup;
 }
 
 /**

--- a/src/content/bridge.js
+++ b/src/content/bridge.js
@@ -172,7 +172,11 @@ function handleHistoryMessages(data) {
   const currentSessionId = match ? match[1] : null;
   if (!currentSessionId || sessionId !== currentSessionId) return;
 
+  // Reject malformed payloads — only arrays (including empty) are valid.
+  // Non-array chat_messages cannot complete a request; a later valid
+  // response must still be accepted.
   const incomingMessages = bizData.chat_messages;
+  if (!Array.isArray(incomingMessages)) return;
 
   // Enforce current-session-only invariant before storing
   retainOnlyHistorySession(currentSessionId);
@@ -186,17 +190,15 @@ function handleHistoryMessages(data) {
   const existing = state.chatMessagesBySession.get(sessionId);
   const existingIds = new Set(existing.map(m => m.message_id));
 
-  if (Array.isArray(incomingMessages)) {
-    for (const msg of incomingMessages) {
-      if (!existingIds.has(msg.message_id)) {
-        existing.push(msg);
-        existingIds.add(msg.message_id);
-      }
+  for (const msg of incomingMessages) {
+    if (!existingIds.has(msg.message_id)) {
+      existing.push(msg);
+      existingIds.add(msg.message_id);
     }
   }
 
-  // Notify explicit full-history requests (including empty responses —
-  // treat as completed so waiters resolve promptly without timeout).
+  // Notify explicit full-history requests — including empty arrays so
+  // waiters resolve promptly without hitting the 10 s timeout.
   if (data.__bdsExplicit) {
     window.dispatchEvent(new CustomEvent("bds:history-msgs-loaded", {
       detail: JSON.stringify({ sessionId, count: existing.length })

--- a/src/content/dom/host.js
+++ b/src/content/dom/host.js
@@ -9,33 +9,61 @@
  */
 
 const hostWrappers = new WeakMap();
+const wrapperOwner = new WeakMap();
+
+function adoptWrapper(wrapper, node) {
+  const previousOwner = wrapperOwner.get(wrapper);
+  if (previousOwner && previousOwner !== node) {
+    hostWrappers.delete(previousOwner);
+  }
+  wrapperOwner.set(wrapper, node);
+  hostWrappers.set(node, wrapper);
+}
 
 /**
  * Get or create the bds-host-wrapper for a message node.
+ * A cached wrapper that is still in the document and adjacent to the message
+ * is reused as-is. If the message has moved, the wrapper is reinserted
+ * immediately after the message in its new parent.
  */
 export function getOrCreateWrapper(node) {
   let wrapper = hostWrappers.get(node);
-  if (!wrapper || !document.contains(wrapper)) {
-    // Search existing siblings for an existing wrapper
-    let sibling = node.nextElementSibling;
-    let attempts = 0;
-    while (sibling && attempts < 10) {
-      if (sibling.classList?.contains("ds-message")) break;
-      if (sibling.classList?.contains("bds-host-wrapper")) {
-        wrapper = sibling;
-        break;
-      }
-      sibling = sibling.nextElementSibling;
-      attempts++;
-    }
 
-    if (!wrapper) {
-      wrapper = document.createElement("div");
-      wrapper.className = "bds-host-wrapper";
+  // Validate: wrapper must still be in the document, and its owner must
+  // still point to this message (prevents adoption by a different message).
+  if (wrapper && document.contains(wrapper) && wrapperOwner.get(wrapper) === node) {
+    // Ensure adjacency — if reparented, move wrapper with the message
+    if (wrapper.previousElementSibling !== node) {
       node.insertAdjacentElement("afterend", wrapper);
     }
-    hostWrappers.set(node, wrapper);
+    return wrapper;
   }
+
+  // Search existing siblings for a pre-existing but unowned wrapper
+  let sibling = node.nextElementSibling;
+  let attempts = 0;
+  while (sibling && attempts < 10) {
+    if (sibling.classList?.contains("ds-message")) break;
+    if (sibling.classList?.contains("bds-host-wrapper") && !wrapperOwner.has(sibling)) {
+      wrapper = sibling;
+      break;
+    }
+    sibling = sibling.nextElementSibling;
+    attempts++;
+  }
+
+  if (!wrapper) {
+    wrapper = document.createElement("div");
+    wrapper.className = "bds-host-wrapper";
+    node.insertAdjacentElement("afterend", wrapper);
+  } else {
+    // Reinsert adjacency if needed
+    if (wrapper.previousElementSibling !== node) {
+      node.insertAdjacentElement("afterend", wrapper);
+    }
+  }
+
+  adoptWrapper(wrapper, node);
   return wrapper;
 }
 

--- a/src/content/dom/host.js
+++ b/src/content/dom/host.js
@@ -1,28 +1,50 @@
 /**
- * Get or create a host container next to a message node.
+ * Centralized message host ownership.
+ *
+ * Every message node gets at most one bds-host-wrapper element (tracked via
+ * WeakMap). Feature hosts (.bds-overlay-host, .bds-file-host, etc.) live
+ * inside the wrapper. This module is the single source of truth for host
+ * lifecycle — other modules call these helpers rather than creating their
+ * own wrapper/container elements.
+ */
+
+const hostWrappers = new WeakMap();
+
+/**
+ * Get or create the bds-host-wrapper for a message node.
+ */
+export function getOrCreateWrapper(node) {
+  let wrapper = hostWrappers.get(node);
+  if (!wrapper || !document.contains(wrapper)) {
+    // Search existing siblings for an existing wrapper
+    let sibling = node.nextElementSibling;
+    let attempts = 0;
+    while (sibling && attempts < 10) {
+      if (sibling.classList?.contains("ds-message")) break;
+      if (sibling.classList?.contains("bds-host-wrapper")) {
+        wrapper = sibling;
+        break;
+      }
+      sibling = sibling.nextElementSibling;
+      attempts++;
+    }
+
+    if (!wrapper) {
+      wrapper = document.createElement("div");
+      wrapper.className = "bds-host-wrapper";
+      wrapper.style.display = "contents";
+      node.insertAdjacentElement("afterend", wrapper);
+    }
+    hostWrappers.set(node, wrapper);
+  }
+  return wrapper;
+}
+
+/**
+ * Get or create a specific feature host inside the message wrapper.
  */
 export function getOrCreateHost(node, hostClass) {
-  let wrapper = null;
-  let sibling = node.nextElementSibling;
-  
-  // DeepSeek might insert elements, search siblings up to next ds-message
-  // or limit searching to 5 siblings just to be safe.
-  let attempts = 0;
-  while (sibling && attempts < 10) {
-    if (sibling.classList && sibling.classList.contains("ds-message")) break;
-    if (sibling.classList && sibling.classList.contains("bds-host-wrapper")) {
-      wrapper = sibling;
-      break;
-    }
-    sibling = sibling.nextElementSibling;
-    attempts++;
-  }
-
-  if (!wrapper) {
-    wrapper = document.createElement("div");
-    wrapper.className = "bds-host-wrapper";
-    node.insertAdjacentElement("afterend", wrapper);
-  }
+  const wrapper = getOrCreateWrapper(node);
 
   let host = wrapper.querySelector(`.${hostClass}`);
   if (!host) {
@@ -32,4 +54,31 @@ export function getOrCreateHost(node, hostClass) {
   }
 
   return host;
+}
+
+/**
+ * Remove a specific feature host from a message wrapper.
+ * Deletes the wrapper if it becomes empty.
+ */
+export function removeMessageHost(node, hostClass) {
+  const wrapper = hostWrappers.get(node);
+  if (!wrapper || !document.contains(wrapper)) return;
+  const host = wrapper.querySelector?.(`.${hostClass}`);
+  if (host) host.remove();
+  if (!wrapper.querySelector(".bds-overlay-host, .bds-file-host, .bds-download-card")) {
+    wrapper.remove();
+    hostWrappers.delete(node);
+  }
+}
+
+/**
+ * Remove the wrapper and all its hosts for a message node.
+ * Used during detached-message disposal.
+ */
+export function removeAllMessageHosts(node) {
+  const wrapper = hostWrappers.get(node);
+  if (wrapper) {
+    wrapper.remove();
+    hostWrappers.delete(node);
+  }
 }

--- a/src/content/dom/host.js
+++ b/src/content/dom/host.js
@@ -29,14 +29,26 @@ function adoptWrapper(wrapper, node) {
 export function getOrCreateWrapper(node) {
   let wrapper = hostWrappers.get(node);
 
-  // Validate: wrapper must still be in the document, and its owner must
-  // still point to this message (prevents adoption by a different message).
-  if (wrapper && document.contains(wrapper) && wrapperOwner.get(wrapper) === node) {
-    // Ensure adjacency — if reparented, move wrapper with the message
-    if (wrapper.previousElementSibling !== node) {
-      node.insertAdjacentElement("afterend", wrapper);
+  // Cached wrapper exists — handle based on connection state
+  if (wrapper && wrapperOwner.get(wrapper) === node) {
+    if (document.contains(node)) {
+      // Message is connected — ensure wrapper is adjacent in DOM
+      if (!document.contains(wrapper) || wrapper.previousElementSibling !== node) {
+        node.insertAdjacentElement("afterend", wrapper);
+      }
+      return wrapper;
+    }
+    // Message detached — remove wrapper from live DOM but preserve it off-DOM
+    if (document.contains(wrapper)) {
+      wrapper.remove();
     }
     return wrapper;
+  }
+
+  // Cached wrapper owned by another message or missing — drop stale reference
+  if (wrapper) {
+    hostWrappers.delete(node);
+    wrapper = null;
   }
 
   // Search existing siblings for a pre-existing but unowned wrapper
@@ -55,14 +67,9 @@ export function getOrCreateWrapper(node) {
   if (!wrapper) {
     wrapper = document.createElement("div");
     wrapper.className = "bds-host-wrapper";
-    node.insertAdjacentElement("afterend", wrapper);
-  } else {
-    // Reinsert adjacency if needed
-    if (wrapper.previousElementSibling !== node) {
-      node.insertAdjacentElement("afterend", wrapper);
-    }
   }
 
+  node.insertAdjacentElement("afterend", wrapper);
   adoptWrapper(wrapper, node);
   return wrapper;
 }
@@ -90,12 +97,13 @@ export function getOrCreateHost(node, hostClass) {
  */
 export function removeMessageHost(node, hostClass) {
   const wrapper = hostWrappers.get(node);
-  if (!wrapper || !document.contains(wrapper)) return;
+  if (!wrapper) return;
   const host = wrapper.querySelector(`.${hostClass}`);
   if (host) host.remove();
   if (wrapper.childElementCount === 0) {
     wrapper.remove();
     hostWrappers.delete(node);
+    wrapperOwner.delete(wrapper);
   }
 }
 
@@ -108,5 +116,6 @@ export function removeAllMessageHosts(node) {
   if (wrapper) {
     wrapper.remove();
     hostWrappers.delete(node);
+    wrapperOwner.delete(wrapper);
   }
 }

--- a/src/content/dom/host.js
+++ b/src/content/dom/host.js
@@ -21,6 +21,28 @@ function adoptWrapper(wrapper, node) {
 }
 
 /**
+ * Reconcile an existing wrapper with its message without creating a new one.
+ */
+export function reconcileMessageHost(node) {
+  const wrapper = hostWrappers.get(node);
+  if (!wrapper || wrapperOwner.get(wrapper) !== node) return null;
+
+  if (!document.contains(node)) {
+    if (document.contains(wrapper)) wrapper.remove();
+    return wrapper;
+  }
+
+  if (
+    !document.contains(wrapper) ||
+    wrapper.parentElement !== node.parentElement ||
+    wrapper.previousElementSibling !== node
+  ) {
+    node.insertAdjacentElement("afterend", wrapper);
+  }
+  return wrapper;
+}
+
+/**
  * Get or create the bds-host-wrapper for a message node.
  * A cached wrapper that is still in the document and adjacent to the message
  * is reused as-is. If the message has moved, the wrapper is reinserted

--- a/src/content/dom/host.js
+++ b/src/content/dom/host.js
@@ -32,7 +32,6 @@ export function getOrCreateWrapper(node) {
     if (!wrapper) {
       wrapper = document.createElement("div");
       wrapper.className = "bds-host-wrapper";
-      wrapper.style.display = "contents";
       node.insertAdjacentElement("afterend", wrapper);
     }
     hostWrappers.set(node, wrapper);
@@ -58,14 +57,15 @@ export function getOrCreateHost(node, hostClass) {
 
 /**
  * Remove a specific feature host from a message wrapper.
- * Deletes the wrapper if it becomes empty.
+ * Deletes the wrapper only when childElementCount reaches zero.
+ * Unknown/sibling hosts (tool hosts, etc.) are preserved.
  */
 export function removeMessageHost(node, hostClass) {
   const wrapper = hostWrappers.get(node);
   if (!wrapper || !document.contains(wrapper)) return;
-  const host = wrapper.querySelector?.(`.${hostClass}`);
+  const host = wrapper.querySelector(`.${hostClass}`);
   if (host) host.remove();
-  if (!wrapper.querySelector(".bds-overlay-host, .bds-file-host, .bds-download-card")) {
+  if (wrapper.childElementCount === 0) {
     wrapper.remove();
     hostWrappers.delete(node);
   }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -97,6 +97,53 @@ async function init() {
     pushConfigToPage();
   });
 
+  // ── Storage probe state (#108 contract verification) ──
+  let storageProbeListener = null;
+  let storageProbeState = null;
+
+  function sanitizeStorageValue(value) {
+    if (value === undefined) return undefined;
+    try { return JSON.parse(JSON.stringify(value)); } catch { return undefined; }
+  }
+
+  function startStorageProbe() {
+    if (storageProbeListener) return; // already started — idempotent
+    storageProbeState = { total: 0, remoteConfig: 0, events: [] };
+    storageProbeListener = (changes, area) => {
+      if (area !== "local") return;
+      storageProbeState.total += 1;
+      const sanitized = {};
+      for (const [key, change] of Object.entries(changes)) {
+        sanitized[key] = {
+          oldValue: sanitizeStorageValue(change.oldValue),
+          newValue: sanitizeStorageValue(change.newValue),
+        };
+      }
+      if (changes[STORAGE_KEYS.remoteConfig]) {
+        storageProbeState.remoteConfig += 1;
+      }
+      storageProbeState.events.push(sanitized);
+    };
+    chrome.storage.onChanged.addListener(storageProbeListener);
+  }
+
+  function getStorageProbe() {
+    if (!storageProbeState) return null;
+    return {
+      total: storageProbeState.total,
+      remoteConfig: storageProbeState.remoteConfig,
+      events: storageProbeState.events.slice(),
+    };
+  }
+
+  function stopStorageProbe() {
+    if (storageProbeListener) {
+      chrome.storage.onChanged.removeListener(storageProbeListener);
+      storageProbeListener = null;
+    }
+    storageProbeState = null;
+  }
+
   // Debug API — listen for requests from MAIN-world injected script
   window.addEventListener("bds:debug-api-request", (e) => {
     let detail = e.detail;
@@ -114,6 +161,17 @@ async function init() {
         case "detectModel": result = detectModelType() || "instant"; break;
         case "toggleDebugPanel":
           window.dispatchEvent(new CustomEvent("bds:toggle-debug-panel"));
+          result = true;
+          break;
+        case "startStorageProbe":
+          startStorageProbe();
+          result = true;
+          break;
+        case "getStorageProbe":
+          result = getStorageProbe();
+          break;
+        case "stopStorageProbe":
+          stopStorageProbe();
           result = true;
           break;
       }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -33,7 +33,7 @@ import { initDeepResearchRuntime } from "./deep-research.js";
 import { i18n } from "../lib/i18n.svelte.js";
 import { remoteConfig, REMOTE_CONFIG_EVENT, detectModelType } from "../lib/remote-config.svelte.js";
 import { STORAGE_KEYS, CSS_PRESETS } from "../lib/constants.js";
-import { loadAllHistory } from "./load-all-history.js";
+import { loadAllHistory, retainOnlyHistorySession } from "./load-all-history.js";
 
 const CONTENT_BOOTSTRAP_KEY = "__bdsContentBootstrapped";
 
@@ -138,6 +138,10 @@ async function init() {
   }
 
   window.addEventListener("bds:urlChanged", () => {
+    // Evict every session's cached messages except the current one
+    const newId = (location.href.match(/\/chat\/s\/([^/?#]+)/) || [])[1] || null;
+    retainOnlyHistorySession(newId);
+
     if ((state.settings.loadAllHistoryOnSession || state.settings.showTimestamps) && location.href.includes("/chat/s/")) {
       loadAllHistory();
     }

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -58,9 +58,12 @@ async function init() {
   i18n.init(state.settings.syncLocale ? null : state.settings.locale);
 
   // Silently check for language updates on startup
-  if (typeof chrome !== "undefined" && chrome.runtime?.sendMessage) {
-    chrome.runtime.sendMessage({ type: "BDS_UPDATE_LANGUAGES" });
-  }
+  const languageUpdatePromise =
+    typeof chrome !== "undefined" && chrome.runtime?.sendMessage
+      ? chrome.runtime
+          .sendMessage({ type: "BDS_UPDATE_LANGUAGES" })
+          .catch((error) => ({ success: false, error: error.message }))
+      : Promise.resolve({ success: true });
 
   injectHookScript();
   setupBridgeEvents();
@@ -145,7 +148,7 @@ async function init() {
   }
 
   // Debug API — listen for requests from MAIN-world injected script
-  window.addEventListener("bds:debug-api-request", (e) => {
+  window.addEventListener("bds:debug-api-request", async (e) => {
     let detail = e.detail;
     if (typeof detail === "string") { try { detail = JSON.parse(detail); } catch { return; } }
     const { id, method, args } = detail || {};
@@ -155,9 +158,9 @@ async function init() {
         case "getRaw":   result = remoteConfig.raw; break;
         case "getFlag":  result = remoteConfig.getFlag(args?.[0]); break;
         case "getConfig": result = remoteConfig.getConfig(args?.[0]); break;
-        case "applyRemote":   remoteConfig.applyRemote(args?.[0]); result = remoteConfig.raw; break;
-        case "replaceRemote": remoteConfig.replaceRemote(args?.[0]); result = remoteConfig.raw; break;
-        case "resetToBuiltin": remoteConfig.resetToBuiltin(); result = remoteConfig.raw; break;
+        case "applyRemote":   await remoteConfig.applyRemote(args?.[0]); result = remoteConfig.raw; break;
+        case "replaceRemote": await remoteConfig.replaceRemote(args?.[0]); result = remoteConfig.raw; break;
+        case "resetToBuiltin": await remoteConfig.resetToBuiltin(); result = remoteConfig.raw; break;
         case "detectModel": result = detectModelType() || "instant"; break;
         case "toggleDebugPanel":
           window.dispatchEvent(new CustomEvent("bds:toggle-debug-panel"));
@@ -174,6 +177,18 @@ async function init() {
           stopStorageProbe();
           result = true;
           break;
+        case "waitForStartup": {
+          const [background, locales] = await Promise.all([
+            chrome.runtime.sendMessage({ type: "BDS_WAIT_FOR_STARTUP" }),
+            languageUpdatePromise,
+          ]);
+          result = {
+            success: Boolean(background?.success && locales?.success),
+            background,
+            locales,
+          };
+          break;
+        }
       }
     } catch (err) { result = { __error: err.message }; }
     window.dispatchEvent(new CustomEvent("bds:debug-api-response", {

--- a/src/content/load-all-history.js
+++ b/src/content/load-all-history.js
@@ -9,15 +9,28 @@
  */
 
 import state from "./state.js";
+import { scheduleScan } from "./scanner.js";
 
 const HISTORY_MSGS_TIMEOUT = 10000;
 
-/** @type {Map<string, Promise<?Array>>} per-session pending loads */
+/**
+ * Per-session pending records: { promise, cancel }.
+ * Cancel removes the event listener, clears the timeout, and resolves
+ * the wait once with `false` so the load path can clean up.
+ *
+ * @type {Map<string, {promise: Promise<?Array>, cancel: () => void}>}
+ */
 const pendingBySession = new Map();
 const _fullHistoryLoaded = new Set();
 
 export function isLoadInProgress() {
-  return pendingBySession.size > 0;
+  // A session is "in progress" if it has an unresolved pending record
+  for (const [, rec] of pendingBySession) {
+    // We can't inspect promise state synchronously, but if the map is
+    // non-empty, at least one load hasn't been finally-cleaned yet.
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -31,11 +44,21 @@ function getSessionId() {
 
 /**
  * Evict every session's cached messages except the given one.
+ * Cancels pending loads for evicted sessions.
  * Pass `null` to clear everything.
  *
  * @param {string|null} sessionId
  */
 export function retainOnlyHistorySession(sessionId) {
+  // Cancel and remove stale pending records
+  for (const [key, rec] of pendingBySession) {
+    if (key !== sessionId) {
+      rec.cancel();
+      pendingBySession.delete(key);
+    }
+  }
+
+  // Evict cached messages for other sessions
   for (const key of state.chatMessagesBySession.keys()) {
     if (key !== sessionId) {
       state.chatMessagesBySession.delete(key);
@@ -46,13 +69,7 @@ export function retainOnlyHistorySession(sessionId) {
       _fullHistoryLoaded.delete(key);
     }
   }
-  // Reject stale pending promises so they don't block the new session
-  for (const [key, promise] of pendingBySession) {
-    if (key !== sessionId) {
-      // Don't reject — just remove so it can't resolve into the cache
-      pendingBySession.delete(key);
-    }
-  }
+
   if (sessionId === null) {
     state.chatMessagesBySession.clear();
     _fullHistoryLoaded.clear();
@@ -62,27 +79,46 @@ export function retainOnlyHistorySession(sessionId) {
 
 /**
  * Wait for the `bds:history-msgs-loaded` event.
+ * Returns a promise and a cancel function.
+ *
  * @param {string} sessionId
- * @returns {Promise<boolean>} true if data was loaded
+ * @returns {{promise: Promise<boolean>, cancel: () => void}}
  */
 function waitForHistoryData(sessionId) {
-  return new Promise((resolve) => {
-    const handler = (event) => {
+  let timeoutId;
+  let handler;
+
+  const promise = new Promise((resolve) => {
+    let settled = false;
+
+    const finalize = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      window.removeEventListener("bds:history-msgs-loaded", handler);
+      resolve(value);
+    };
+
+    handler = (event) => {
       let detail = event.detail;
       if (typeof detail === "string") {
         try { detail = JSON.parse(detail); } catch { return; }
       }
       // Ignore responses for sessions other than the one we're waiting on
       if (detail?.sessionId !== sessionId) return;
-      window.removeEventListener("bds:history-msgs-loaded", handler);
-      resolve(true);
+      finalize(true);
     };
+
     window.addEventListener("bds:history-msgs-loaded", handler);
-    setTimeout(() => {
-      window.removeEventListener("bds:history-msgs-loaded", handler);
-      resolve(false);
-    }, HISTORY_MSGS_TIMEOUT);
+    timeoutId = setTimeout(() => finalize(false), HISTORY_MSGS_TIMEOUT);
   });
+
+  const cancel = () => {
+    clearTimeout(timeoutId);
+    window.removeEventListener("bds:history-msgs-loaded", handler);
+  };
+
+  return { promise, cancel };
 }
 
 /**
@@ -102,7 +138,7 @@ export async function loadAllHistory() {
   // Check per-session pending — never block on a different session's load
   const existing = pendingBySession.get(sessionId);
   if (existing) {
-    return existing;
+    return existing.promise;
   }
 
   // Only trust cache if a full explicit load was previously completed
@@ -111,12 +147,21 @@ export async function loadAllHistory() {
     return messages && messages.length > 0 ? messages : null;
   }
 
-  const promise = (async () => {
+  const { promise, cancel } = waitForHistoryData(sessionId);
+  const record = { promise: null, cancel };
+
+  const loadPromise = (async () => {
     window.dispatchEvent(new CustomEvent("bds:request-history-msgs", {
       detail: JSON.stringify({ sessionId })
     }));
 
-    const loaded = await waitForHistoryData(sessionId);
+    const loaded = await promise;
+
+    // Verify this record is still the current one for this session
+    if (pendingBySession.get(sessionId) !== record) {
+      // A newer request replaced us — discard
+      return null;
+    }
 
     if (loaded && state.chatMessagesBySession.has(sessionId)) {
       const messages = state.chatMessagesBySession.get(sessionId);
@@ -124,14 +169,24 @@ export async function loadAllHistory() {
       if (messages.length > 0) return messages;
     }
 
+    // loaded but no messages cached (e.g. empty explicit response)
+    // Treat as completed: cache the empty result so we don't re-request
+    if (loaded && !state.chatMessagesBySession.has(sessionId)) {
+      _fullHistoryLoaded.add(sessionId);
+    }
+
     return null;
   })();
 
-  pendingBySession.set(sessionId, promise);
+  record.promise = loadPromise;
+  pendingBySession.set(sessionId, record);
 
   try {
-    return await promise;
+    return await loadPromise;
   } finally {
-    pendingBySession.delete(sessionId);
+    // Only delete if this exact record is still in the map
+    if (pendingBySession.get(sessionId) === record) {
+      pendingBySession.delete(sessionId);
+    }
   }
 }

--- a/src/content/load-all-history.js
+++ b/src/content/load-all-history.js
@@ -9,14 +9,12 @@
  */
 
 import state from "./state.js";
-import { scheduleScan } from "./scanner.js";
 
 const HISTORY_MSGS_TIMEOUT = 10000;
 
 /**
  * Per-session pending records: { promise, cancel }.
- * Cancel removes the event listener, clears the timeout, and resolves
- * the wait once with `false` so the load path can clean up.
+ * Cancel finalizes the promise with `false`, removes listeners, and clears timers.
  *
  * @type {Map<string, {promise: Promise<?Array>, cancel: () => void}>}
  */
@@ -24,13 +22,7 @@ const pendingBySession = new Map();
 const _fullHistoryLoaded = new Set();
 
 export function isLoadInProgress() {
-  // A session is "in progress" if it has an unresolved pending record
-  for (const [, rec] of pendingBySession) {
-    // We can't inspect promise state synchronously, but if the map is
-    // non-empty, at least one load hasn't been finally-cleaned yet.
-    return true;
-  }
-  return false;
+  return pendingBySession.size > 0;
 }
 
 /**
@@ -79,7 +71,7 @@ export function retainOnlyHistorySession(sessionId) {
 
 /**
  * Wait for the `bds:history-msgs-loaded` event.
- * Returns a promise and a cancel function.
+ * Routes success, timeout, and cancellation through one idempotent finalize.
  *
  * @param {string} sessionId
  * @returns {{promise: Promise<boolean>, cancel: () => void}}
@@ -87,36 +79,35 @@ export function retainOnlyHistorySession(sessionId) {
 function waitForHistoryData(sessionId) {
   let timeoutId;
   let handler;
+  let settled = false;
 
-  const promise = new Promise((resolve) => {
-    let settled = false;
-
-    const finalize = (value) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeoutId);
-      window.removeEventListener("bds:history-msgs-loaded", handler);
-      resolve(value);
-    };
-
-    handler = (event) => {
-      let detail = event.detail;
-      if (typeof detail === "string") {
-        try { detail = JSON.parse(detail); } catch { return; }
-      }
-      // Ignore responses for sessions other than the one we're waiting on
-      if (detail?.sessionId !== sessionId) return;
-      finalize(true);
-    };
-
-    window.addEventListener("bds:history-msgs-loaded", handler);
-    timeoutId = setTimeout(() => finalize(false), HISTORY_MSGS_TIMEOUT);
-  });
-
-  const cancel = () => {
+  const finalize = (value) => {
+    if (settled) return;
+    settled = true;
     clearTimeout(timeoutId);
     window.removeEventListener("bds:history-msgs-loaded", handler);
+    resolve(value);
   };
+
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+
+  handler = (event) => {
+    let detail = event.detail;
+    if (typeof detail === "string") {
+      try { detail = JSON.parse(detail); } catch { return; }
+    }
+    // Ignore responses for sessions other than the one we're waiting on
+    if (detail?.sessionId !== sessionId) return;
+    finalize(true);
+  };
+
+  window.addEventListener("bds:history-msgs-loaded", handler);
+  timeoutId = setTimeout(() => finalize(false), HISTORY_MSGS_TIMEOUT);
+
+  const cancel = () => finalize(false);
 
   return { promise, cancel };
 }

--- a/src/content/load-all-history.js
+++ b/src/content/load-all-history.js
@@ -12,11 +12,12 @@ import state from "./state.js";
 
 const HISTORY_MSGS_TIMEOUT = 10000;
 
-let pendingPromise = null;
+/** @type {Map<string, Promise<?Array>>} per-session pending loads */
+const pendingBySession = new Map();
 const _fullHistoryLoaded = new Set();
 
 export function isLoadInProgress() {
-  return pendingPromise !== null;
+  return pendingBySession.size > 0;
 }
 
 /**
@@ -26,6 +27,37 @@ export function isLoadInProgress() {
 function getSessionId() {
   const match = String(location.href || "").match(/\/chat\/s\/([^/?#]+)/);
   return match ? match[1] : null;
+}
+
+/**
+ * Evict every session's cached messages except the given one.
+ * Pass `null` to clear everything.
+ *
+ * @param {string|null} sessionId
+ */
+export function retainOnlyHistorySession(sessionId) {
+  for (const key of state.chatMessagesBySession.keys()) {
+    if (key !== sessionId) {
+      state.chatMessagesBySession.delete(key);
+    }
+  }
+  for (const key of _fullHistoryLoaded) {
+    if (key !== sessionId) {
+      _fullHistoryLoaded.delete(key);
+    }
+  }
+  // Reject stale pending promises so they don't block the new session
+  for (const [key, promise] of pendingBySession) {
+    if (key !== sessionId) {
+      // Don't reject — just remove so it can't resolve into the cache
+      pendingBySession.delete(key);
+    }
+  }
+  if (sessionId === null) {
+    state.chatMessagesBySession.clear();
+    _fullHistoryLoaded.clear();
+    pendingBySession.clear();
+  }
 }
 
 /**
@@ -40,10 +72,10 @@ function waitForHistoryData(sessionId) {
       if (typeof detail === "string") {
         try { detail = JSON.parse(detail); } catch { return; }
       }
-      if (detail?.sessionId === sessionId) {
-        window.removeEventListener("bds:history-msgs-loaded", handler);
-        resolve(true);
-      }
+      // Ignore responses for sessions other than the one we're waiting on
+      if (detail?.sessionId !== sessionId) return;
+      window.removeEventListener("bds:history-msgs-loaded", handler);
+      resolve(true);
     };
     window.addEventListener("bds:history-msgs-loaded", handler);
     setTimeout(() => {
@@ -62,13 +94,15 @@ function waitForHistoryData(sessionId) {
  * Callers can pass these to `collectMessagesFromApi()` in exporter.js.
  */
 export async function loadAllHistory() {
-  if (pendingPromise) {
-    return pendingPromise;
-  }
-
   const sessionId = getSessionId();
   if (!sessionId) {
     return null;
+  }
+
+  // Check per-session pending — never block on a different session's load
+  const existing = pendingBySession.get(sessionId);
+  if (existing) {
+    return existing;
   }
 
   // Only trust cache if a full explicit load was previously completed
@@ -77,7 +111,7 @@ export async function loadAllHistory() {
     return messages && messages.length > 0 ? messages : null;
   }
 
-  pendingPromise = (async () => {
+  const promise = (async () => {
     window.dispatchEvent(new CustomEvent("bds:request-history-msgs", {
       detail: JSON.stringify({ sessionId })
     }));
@@ -93,9 +127,11 @@ export async function loadAllHistory() {
     return null;
   })();
 
+  pendingBySession.set(sessionId, promise);
+
   try {
-    return await pendingPromise;
+    return await promise;
   } finally {
-    pendingPromise = null;
+    pendingBySession.delete(sessionId);
   }
 }

--- a/src/content/message-processor.svelte.js
+++ b/src/content/message-processor.svelte.js
@@ -23,7 +23,7 @@ import { upsertCharacters } from "./parser/character-parser.js";
 import { upsertSkills } from "./parser/skill-parser.js";
 import { collectLongWorkFiles, finalizeLongWork, emitZipForFiles } from "./files/long-work.js";
 import { emitStandaloneFiles } from "./files/standalone.js";
-import { getOrCreateHost } from "./dom/host.js";
+import { getOrCreateHost, removeAllMessageHosts, removeMessageHost } from "./dom/host.js";
 import { handleAutoWebFetch, handleAutoGitHubFetch, handleAutoTwitterFetch, handleAutoYouTubeFetch, handleAutoSearch, handleAutoSearchForRun } from "./auto.js";
 import { handleManagedAutoContinuation, isManagedRunActive, trySynthesizeReport } from "./deep-research.js";
 
@@ -43,7 +43,7 @@ const processedSearchResultCards = new WeakSet();
 
 /**
  * Dispose a single message node: clear its timers, unmount its Svelte
- * component, remove its registry entry, and clean up orphaned overlay hosts.
+ * component, remove its registry entry, and clean up all hosts.
  */
 export function disposeMessageNode(node) {
   const stateData = nodeStates.get(node);
@@ -59,21 +59,16 @@ export function disposeMessageNode(node) {
       try { unmount(entry.component); } catch (e) { /* already unmounted */ }
     }
     messageOverlays.delete(node);
-
-    // Remove orphaned overlay host/wrapper
-    if (entry.host) {
-      const wrapper = entry.host.closest?.(".bds-host-wrapper");
-      if (wrapper && !wrapper.querySelector(".bds-overlay-host, .bds-file-host, .bds-download-card")) {
-        wrapper.remove();
-      } else if (entry.host.parentNode) {
-        entry.host.remove();
-      }
-    }
   }
 
+  // Clear all weak-set memberships
   readMessages.delete(node);
   userMsgCleaned.delete(node);
   processedSearchResultCards.delete(node);
+  nodeStates.delete(node);
+
+  // Remove all associated hosts and wrapper
+  removeAllMessageHosts(node);
 }
 
 /**
@@ -129,6 +124,10 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null, context =
     nodeIndex = collected.indexOf(node);
     nodes = collected;
   }
+
+  // Resolve cached context for isMessageFinished / isLatestAssistant
+  const cachedIsLatestAssistant = context ? context.latestAssistantNode === node : null;
+  const cachedSystemGenerating = context ? context.systemGenerating : null;
 
   // Inject Run buttons into any Python/JS/Lua/Ruby code blocks in this message
   injectPythonRunButtons(node);
@@ -272,7 +271,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null, context =
   const isStalled = timeSinceUpdate > 2500;
 
   // Fix false positives: a message cannot be completely settled if it's currently mutating
-  let isSettled = isMessageFinished(node);
+  let isSettled = isMessageFinished(node, cachedIsLatestAssistant, cachedSystemGenerating);
   if (!isStalled) {
     isSettled = false;
   }
@@ -606,12 +605,8 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null, context =
       
       stateData.overlayActive = false;
       
-      // NEVER remove the bds-host-wrapper, as it may contain bds-file-host (the ZIP card).
-      // Only clear the overlay sub-container.
-      const overlayHost = node.nextElementSibling?.querySelector(".bds-overlay-host");
-      if (overlayHost) {
-        overlayHost.replaceChildren();
-      }
+      // Remove only the overlay host; preserve file/tool hosts (ZIP cards, etc.)
+      removeMessageHost(node, "bds-overlay-host");
     }
   }
 }
@@ -812,18 +807,22 @@ export function isSystemGenerating() {
 /**
  * Checks if a specific message has finished and settled.
  * Settled messages have action buttons (Copy, Regenerate, etc.).
+ *
+ * @param {Element} node
+ * @param {boolean|null} cachedIsLatest - pre-computed latest-assistant result, or null to query
+ * @param {boolean|null} cachedGenerating - pre-computed systemGenerating result, or null to query
  */
-function isMessageFinished(node) {
+function isMessageFinished(node, cachedIsLatest = null, cachedGenerating = null) {
   const hasCursor = !!node.querySelector('.ds-cursor');
   const isCurrentlyStreamingClass = node.classList.contains('_streaming');
-  
+
   // If we see a cursor or the active streaming class, it's NOT finished, regardless of buttons.
   if (hasCursor || isCurrentlyStreamingClass) {
     return false;
   }
 
-  const generating = isSystemGenerating();
-  
+  const generating = cachedGenerating ?? isSystemGenerating();
+
   // If the system is no longer generating globally, it's definitely done.
   if (!generating) {
     return true;
@@ -833,9 +832,9 @@ function isMessageFinished(node) {
   // (e.g. it's an earlier message in the session).
   // We look for action buttons as a sign of completion.
   const hasFooterButtons = !!node.querySelector('div[role="button"] svg, .ds-icon-copy, .ds-icon-regenerate, .ds-icon-share');
-  
+
   // Backup check: if it's the latest message and the system is generating, it's usually NOT finished.
-  const isLatest = isLatestAssistantMessage(node);
+  const isLatest = cachedIsLatest ?? isLatestAssistantMessage(node);
   if (isLatest && generating) {
     return false;
   }

--- a/src/content/message-processor.svelte.js
+++ b/src/content/message-processor.svelte.js
@@ -9,6 +9,7 @@ import {
   isLatestAssistantMessage,
   isAbsoluteLastMessage,
   scheduleScan,
+  scheduleMessageScan,
   collectMessageNodes
 } from "./scanner.js";
 import { extractMessageRawText } from "./dom/message-text.js";
@@ -40,6 +41,53 @@ const userMsgCleaned = new WeakSet();
 const readMessages = new WeakSet();
 const processedSearchResultCards = new WeakSet();
 
+/**
+ * Dispose a single message node: clear its timers, unmount its Svelte
+ * component, remove its registry entry, and clean up orphaned overlay hosts.
+ */
+export function disposeMessageNode(node) {
+  const stateData = nodeStates.get(node);
+  if (stateData) {
+    if (stateData.autoTimer) { clearTimeout(stateData.autoTimer); stateData.autoTimer = null; }
+    if (stateData.stallTimer) { clearTimeout(stateData.stallTimer); stateData.stallTimer = null; }
+    if (stateData.deepResearchTimer) { clearTimeout(stateData.deepResearchTimer); stateData.deepResearchTimer = null; }
+  }
+
+  const entry = messageOverlays.get(node);
+  if (entry) {
+    if (entry.component) {
+      try { unmount(entry.component); } catch (e) { /* already unmounted */ }
+    }
+    messageOverlays.delete(node);
+
+    // Remove orphaned overlay host/wrapper
+    if (entry.host) {
+      const wrapper = entry.host.closest?.(".bds-host-wrapper");
+      if (wrapper && !wrapper.querySelector(".bds-overlay-host, .bds-file-host, .bds-download-card")) {
+        wrapper.remove();
+      } else if (entry.host.parentNode) {
+        entry.host.remove();
+      }
+    }
+  }
+
+  readMessages.delete(node);
+  userMsgCleaned.delete(node);
+  processedSearchResultCards.delete(node);
+}
+
+/**
+ * Dispose overlays whose message nodes are no longer in the document.
+ * Safe to call during URL transitions — only removes truly detached nodes.
+ */
+export function disposeDetachedMessageOverlays() {
+  for (const [node] of messageOverlays) {
+    if (!document.contains(node)) {
+      disposeMessageNode(node);
+    }
+  }
+}
+
 function normalizeSearchKeyPart(value) {
   return String(value || "").replace(/\s+/g, " ").trim();
 }
@@ -65,8 +113,13 @@ function getNodeState(node) {
 
 /**
  * Process a single message node — the main per-node logic.
+ *
+ * @param {Element} node
+ * @param {number} [nodeIndex=-1]
+ * @param {Element[]|null} [nodes=null]
+ * @param {{latestAssistantNode?: Element|null, absoluteLastNode?: Element|null}} [context]
  */
-export function processMessageNode(node, nodeIndex = -1, nodes = null) {
+export function processMessageNode(node, nodeIndex = -1, nodes = null, context = null) {
   if (!node || node.closest("#bds-root")) {
     return;
   }
@@ -122,7 +175,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
           removeStaleMessageOverlays(host);
           const props = $state({ text: "", blocks: newBlocks, loading: false });
           const component = mount(MessageOverlay, { target: host, props });
-          messageOverlays.set(node, { component, props });
+          messageOverlays.set(node, { component, props, host });
         }
         syncVisibilityState(node, false, stateData, true);
       }
@@ -165,7 +218,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
             removeStaleMessageOverlays(host);
             const props = $state({ text: "", blocks: newBlocks, loading: false });
             const component = mount(MessageOverlay, { target: host, props });
-            messageOverlays.set(node, { component, props });
+            messageOverlays.set(node, { component, props, host });
           }
           syncVisibilityState(node, false, stateData, true);
         }
@@ -205,7 +258,9 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
     return;
   }
 
-  const isLatestAssistant = role === "assistant" && isLatestAssistantMessage(node);
+  const isLatestAssistant = role === "assistant" && (
+    context ? context.latestAssistantNode === node : isLatestAssistantMessage(node)
+  );
 
   const now = Date.now();
   if (stateData.lastRawText !== rawText) {
@@ -328,7 +383,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
     } else if (!stateData.autoTimer) {
       stateData.autoTimer = setTimeout(() => {
         stateData.autoTimer = null;
-        scheduleScan();
+        scheduleMessageScan(node);
       }, 3000);
     }
   }
@@ -337,7 +392,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
   if (!isStalled && parsed.isStreamingTool) {
     if (stateData.stallTimer) clearTimeout(stateData.stallTimer);
     stateData.stallTimer = setTimeout(() => {
-      scheduleScan();
+      scheduleMessageScan(node);
     }, 2600);
   }
 
@@ -354,7 +409,7 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
     } else if (!stateData.deepResearchTimer) {
       stateData.deepResearchTimer = setTimeout(() => {
         stateData.deepResearchTimer = null;
-        scheduleScan();
+        scheduleMessageScan(node);
       }, 3000);
     }
   }
@@ -482,7 +537,8 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null) {
       }
     }
 
-    if (!state.activeQuestions && !isSystemGenerating() && parsed.askQuestions.length > 0 && isLatestAssistantMessage(node) && isAbsoluteLastMessage(node)) {
+    const isAbsLast = context ? context.absoluteLastNode === node : isAbsoluteLastMessage(node);
+    if (!state.activeQuestions && !isSystemGenerating() && parsed.askQuestions.length > 0 && isLatestAssistant && isAbsLast) {
       state.activeQuestions = parsed.askQuestions;
       window.dispatchEvent(new CustomEvent('bds-ask-questions', { 
         detail: { 

--- a/src/content/message-processor.svelte.js
+++ b/src/content/message-processor.svelte.js
@@ -23,7 +23,12 @@ import { upsertCharacters } from "./parser/character-parser.js";
 import { upsertSkills } from "./parser/skill-parser.js";
 import { collectLongWorkFiles, finalizeLongWork, emitZipForFiles } from "./files/long-work.js";
 import { emitStandaloneFiles } from "./files/standalone.js";
-import { getOrCreateHost, removeAllMessageHosts, removeMessageHost } from "./dom/host.js";
+import {
+  getOrCreateHost,
+  reconcileMessageHost,
+  removeAllMessageHosts,
+  removeMessageHost,
+} from "./dom/host.js";
 import { handleAutoWebFetch, handleAutoGitHubFetch, handleAutoTwitterFetch, handleAutoYouTubeFetch, handleAutoSearch, handleAutoSearchForRun } from "./auto.js";
 import { handleManagedAutoContinuation, isManagedRunActive, trySynthesizeReport } from "./deep-research.js";
 
@@ -40,6 +45,39 @@ const nodeStates = new WeakMap();
 const userMsgCleaned = new WeakSet();
 const readMessages = new WeakSet();
 const processedSearchResultCards = new WeakSet();
+const pricingContributions = new Map();
+
+function removePricingContribution(node) {
+  const previous = pricingContributions.get(node);
+  if (!previous) return;
+  pricingContributions.delete(node);
+  if (previous.role === "user") {
+    state.pricing.sessionInputTokens -= previous.tokens;
+  } else {
+    state.pricing.sessionOutputTokens -= previous.tokens;
+  }
+  state.pricing.sessionTotals.totalCost -= previous.cost;
+}
+
+function setPricingContribution(node, stateData, role, tokens, cost) {
+  removePricingContribution(node);
+  pricingContributions.set(node, { role, tokens, cost });
+  if (role === "user") state.pricing.sessionInputTokens += tokens;
+  else state.pricing.sessionOutputTokens += tokens;
+  state.pricing.sessionTotals.totalCost += cost;
+  stateData.role = role;
+  stateData.tokens = tokens;
+  stateData.cost = cost;
+  refreshSessionTotalDisplayInline();
+}
+
+export function resetMessagePricing() {
+  pricingContributions.clear();
+  state.pricing.sessionInputTokens = 0;
+  state.pricing.sessionOutputTokens = 0;
+  state.pricing.sessionTotals = { inputCost: 0, outputCost: 0, totalCost: 0 };
+  document.querySelector(".bds-session-total")?.remove();
+}
 
 /**
  * Dispose a single message node: clear its timers, unmount its Svelte
@@ -66,6 +104,8 @@ export function disposeMessageNode(node) {
   userMsgCleaned.delete(node);
   processedSearchResultCards.delete(node);
   nodeStates.delete(node);
+  removePricingContribution(node);
+  refreshSessionTotalDisplayInline();
 
   // Remove all associated hosts and wrapper
   removeAllMessageHosts(node);
@@ -118,6 +158,8 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null, context =
   if (!node || node.closest("#bds-root")) {
     return;
   }
+
+  reconcileMessageHost(node);
 
   if (nodeIndex === -1 || !nodes) {
     const collected = collectMessageNodes();
@@ -245,12 +287,8 @@ export function processMessageNode(node, nodeIndex = -1, nodes = null, context =
       const cacheHitTokens = 0; // We will handle cache hit logic differently or just ignore for user display
       const { inputCost } = calcCostInline(newInputTokens, 0, modelName);
       
-      stateData.tokens = newInputTokens;
-      stateData.cost = inputCost;
-      stateData.role = "user";
-      
       injectPriceUser(node, newInputTokens, inputCost);
-      refreshSessionTotalDisplayInline();
+      setPricingContribution(node, stateData, "user", newInputTokens, inputCost);
       stateData.priceInjected = true;
     }
     handleUserMessageCollapse(node);
@@ -874,12 +912,8 @@ function syncVisibilityState(node, isLatestAssistant, stateData, isSettled) {
     const outputTokens = estimateTokensInline(totalText);
     const { outputCost } = calcCostInline(0, outputTokens, modelName);
     
-    stateData.tokens = outputTokens;
-    stateData.cost = outputCost;
-    stateData.role = "assistant";
-    
     injectPriceAssistant(node, outputTokens, outputCost);
-    refreshSessionTotalDisplayInline();
+    setPricingContribution(node, stateData, "assistant", outputTokens, outputCost);
   }
 }
 
@@ -1237,28 +1271,10 @@ function formatCostDisplay(cost) {
 
 function refreshSessionTotalDisplayInline() {
   if (!state.settings.tokenPriceDisplay) return;
-  
-  const nodes = collectMessageNodes();
-  let totalInputTokens = 0;
-  let totalOutputTokens = 0;
-  let totalCost = 0;
 
-  for (const node of nodes) {
-    const sd = nodeStates.get(node);
-    if (sd && sd.tokens) {
-      if (sd.role === "user") {
-        totalInputTokens += sd.tokens;
-      } else {
-        totalOutputTokens += sd.tokens;
-      }
-      totalCost += sd.cost || 0;
-    }
-  }
-
-  // Update global state for other components that might read it
-  state.pricing.sessionInputTokens = totalInputTokens;
-  state.pricing.sessionOutputTokens = totalOutputTokens;
-  state.pricing.sessionTotals.totalCost = totalCost;
+  const totalInputTokens = state.pricing.sessionInputTokens;
+  const totalOutputTokens = state.pricing.sessionOutputTokens;
+  const totalCost = state.pricing.sessionTotals.totalCost;
 
   let el = document.querySelector(".bds-session-total");
   if (!el) {

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -224,7 +224,15 @@ export function observeChatDom() {
  * Coalesced under the same debounce timer. Never requests a full scan.
  */
 export function scheduleMessageScan(node) {
-  if (!node || !(node instanceof Element) || node.closest?.("#bds-root")) {
+  // Require a connected div.ds-message element. Non-message elements, text
+  // nodes, detached nodes, and nodes inside #bds-root must not arm a scan.
+  if (
+    !node ||
+    !(node instanceof Element) ||
+    !node.classList?.contains("ds-message") ||
+    !document.contains(node) ||
+    node.closest?.("#bds-root")
+  ) {
     return;
   }
   dirtyNodes.add(node);

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -216,9 +216,10 @@ export function observeChatDom() {
  * Coalesced under the same debounce timer. Never requests a full scan.
  */
 export function scheduleMessageScan(node) {
-  if (node && !node.closest?.("#bds-root")) {
-    dirtyNodes.add(node);
+  if (!node || !(node instanceof Element) || node.closest?.("#bds-root")) {
+    return;
   }
+  dirtyNodes.add(node);
   armScanTimer();
 }
 

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -5,7 +5,7 @@
 import state, { withObserverPaused } from "./state.js";
 import { LONG_WORK_STALE_MS } from "../lib/constants.js";
 import { devLog } from "../lib/dev-log.js";
-import { processMessageNode, disposeMessageNode, disposeDetachedMessageOverlays } from "./message-processor.svelte.js";
+import { processMessageNode, disposeMessageNode, disposeDetachedMessageOverlays, isSystemGenerating } from "./message-processor.svelte.js";
 import { mount, unmount } from "svelte";
 import AttachMenu from "./ui/AttachMenu.svelte";
 import ExpandToggle from "./ui/ExpandToggle.svelte";
@@ -22,9 +22,21 @@ import CommandsHelp from "./commands/CommandsHelp.svelte";
 
 // ── Incremental scan state ──
 const dirtyNodes = new Set();
+const removedNodes = new Set();
 let pendingFullScan = false;
 let previousLatestAssistant = null;
 let previousAbsoluteLast = null;
+
+// ── Internal: arm the shared debounce timer ──
+function armScanTimer() {
+  if (state.scanTimer) {
+    clearTimeout(state.scanTimer);
+  }
+  state.scanTimer = window.setTimeout(() => {
+    state.scanTimer = 0;
+    scanPage();
+  }, 140);
+}
 
 /**
  * Collect all message nodes from the chat DOM.
@@ -47,11 +59,12 @@ export function collectMessageNodes() {
 
 /**
  * Find the latest assistant message node.
+ * Accepts an optional pre-collected nodes array to avoid redundant DOM walks.
  */
-export function findLatestAssistantMessageNode() {
-  const nodes = collectMessageNodes();
-  for (let index = nodes.length - 1; index >= 0; index -= 1) {
-    const candidate = nodes[index];
+export function findLatestAssistantMessageNode(nodes) {
+  const list = nodes || collectMessageNodes();
+  for (let index = list.length - 1; index >= 0; index -= 1) {
+    const candidate = list[index];
     if (!candidate || candidate.closest("#bds-root")) {
       continue;
     }
@@ -94,17 +107,19 @@ export function detectMessageRole(node) {
 
 /**
  * Check if a node is the absolute last message in the entire chat.
+ * Accepts an optional pre-collected nodes array.
  */
-export function isAbsoluteLastMessage(node) {
-  const nodes = collectMessageNodes();
-  return nodes[nodes.length - 1] === node;
+export function isAbsoluteLastMessage(node, nodes) {
+  const list = nodes || collectMessageNodes();
+  return list[list.length - 1] === node;
 }
 
 /**
  * Check if a node is the latest assistant message.
+ * Accepts an optional pre-collected nodes array.
  */
-export function isLatestAssistantMessage(node) {
-  return findLatestAssistantMessageNode() === node;
+export function isLatestAssistantMessage(node, nodes) {
+  return findLatestAssistantMessageNode(nodes) === node;
 }
 
 /**
@@ -120,6 +135,7 @@ function closestMessageNode(target) {
 /**
  * Set up a MutationObserver on the document body.
  * Collects dirty message nodes for incremental processing.
+ * Arms the scan timer but never requests a full scan on its own.
  */
 export function observeChatDom() {
   if (state.observer || !document.body) {
@@ -127,35 +143,35 @@ export function observeChatDom() {
   }
 
   state.observer = new MutationObserver((records) => {
-    let hasNonMessageMutation = false;
-
     for (const r of records) {
-      // Check removed nodes for messages needing disposal
+      // Ignore records wholly owned by #bds-root
+      if (r.target.closest?.("#bds-root")) continue;
+
+      // Collect removed message subtrees
       for (const removed of r.removedNodes) {
         if (removed.nodeType !== Node.ELEMENT_NODE) continue;
-        // Collect removed message subtrees
+        if (removed.closest?.("#bds-root")) continue;
+
         const removedMessages = removed.classList?.contains("ds-message")
           ? [removed]
           : Array.from(removed.querySelectorAll?.("div.ds-message") || []);
         for (const rm of removedMessages) {
           if (!rm.closest?.("#bds-root")) {
-            dirtyNodes.add(rm);
+            removedNodes.add(rm);
           }
         }
       }
 
-      // Check added nodes for new/modified messages
+      // Collect added/modified messages
       for (const added of r.addedNodes) {
         if (added.nodeType !== Node.ELEMENT_NODE) continue;
+        if (added.closest?.("#bds-root")) continue;
 
         if (added.classList?.contains("ds-message")) {
-          if (!added.closest?.("#bds-root")) {
-            dirtyNodes.add(added);
-          }
+          dirtyNodes.add(added);
           continue;
         }
 
-        // Check descendant messages
         const descendantMessages = added.querySelectorAll?.("div.ds-message");
         if (descendantMessages?.length) {
           for (const dm of descendantMessages) {
@@ -166,20 +182,19 @@ export function observeChatDom() {
         }
       }
 
-      // For mutations without explicit message nodes (e.g. text changes),
-      // find the closest message ancestor
+      // For mutations without explicit message nodes, find closest message ancestor
       const target = r.target;
-      if (target && target !== document.body) {
+      if (target && target !== document.body && !target.closest?.("#bds-root")) {
         const msg = closestMessageNode(target);
         if (msg) {
           dirtyNodes.add(msg);
-        } else if (!target.closest?.("#bds-root")) {
-          hasNonMessageMutation = true;
         }
+        // Non-message mutations don't trigger message processing —
+        // page-wide enhancers run unconditionally in scanPage().
       }
     }
 
-    scheduleScan();
+    armScanTimer();
   });
 
   state.observer.observe(document.body, {
@@ -190,39 +205,26 @@ export function observeChatDom() {
 
 /**
  * Schedule targeted reprocessing of a single message node.
- * Coalesced under the same debounce timer as full scans.
+ * Coalesced under the same debounce timer. Never requests a full scan.
  */
 export function scheduleMessageScan(node) {
   if (node && !node.closest?.("#bds-root")) {
     dirtyNodes.add(node);
   }
-  scheduleScan();
+  armScanTimer();
 }
 
 /**
- * Debounced page scan scheduler. Trailing-edge: coalesces bursts into one
- * scan ~140ms after the LAST mutation.
- *
- * When called with pendingFullScan=true (default), targeted work is
- * discarded in favor of a full scan.
+ * Schedule a full page scan. Explicit full-scan API for initialization,
+ * settings/pricing changes, URL/focus recovery, timestamp refreshes.
  */
-export function scheduleScan(fullScan = true) {
-  if (fullScan) {
-    pendingFullScan = true;
-  }
-
-  if (state.scanTimer) {
-    clearTimeout(state.scanTimer);
-  }
-
-  state.scanTimer = window.setTimeout(() => {
-    state.scanTimer = 0;
-    scanPage();
-  }, 140);
+export function scheduleScan() {
+  pendingFullScan = true;
+  armScanTimer();
 }
 
 /**
- * Full page scan — process all or only dirty message nodes.
+ * Central scan dispatcher. Called when the debounce timer fires.
  */
 function scanPage() {
   withObserverPaused(() => {
@@ -241,22 +243,34 @@ function scanPage() {
     const doFullScan = pendingFullScan;
     pendingFullScan = false;
 
+    // Always process disconnected removedNodes first — full scan must not discard disposal
+    const toDispose = new Set(removedNodes);
+    removedNodes.clear();
+    for (const rn of toDispose) {
+      if (!document.contains(rn)) {
+        disposeMessageNode(rn);
+      }
+    }
+
     if (doFullScan) {
-      // Full scan: process all messages with shared context.
-      // First, dispose removed message overlays.
+      // Full scan: process all messages with shared context
       disposeDetachedMessageOverlays();
       dirtyNodes.clear();
+
       const nodes = collectMessageNodes();
-      const latestAssistant = findLatestAssistantMessageNode();
+      const latestAssistant = findLatestAssistantMessageNode(nodes);
       const absoluteLast = nodes[nodes.length - 1] || null;
+      const systemGenerating = isSystemGenerating();
+      const context = {
+        latestAssistantNode: latestAssistant,
+        absoluteLastNode: absoluteLast,
+        systemGenerating,
+      };
 
       for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
         try {
-          processMessageNode(node, i, nodes, {
-            latestAssistantNode: latestAssistant,
-            absoluteLastNode: absoluteLast,
-          });
+          processMessageNode(node, i, nodes, context);
         } catch (err) {
           console.error("[BDS] Error processing message node:", err, node);
         }
@@ -264,22 +278,28 @@ function scanPage() {
 
       previousLatestAssistant = latestAssistant;
       previousAbsoluteLast = absoluteLast;
-    } else if (dirtyNodes.size > 0) {
+    } else if (dirtyNodes.size > 0 || toDispose.size > 0) {
       // Incremental: process only dirty and state-transition nodes
       const nodes = collectMessageNodes();
       const nodeSet = new Set(nodes);
-      const latestAssistant = findLatestAssistantMessageNode();
+      const latestAssistant = findLatestAssistantMessageNode(nodes);
       const absoluteLast = nodes[nodes.length - 1] || null;
+      const systemGenerating = isSystemGenerating();
 
-      // Dispose dirty nodes that are no longer in the document (moved/removed)
+      // Dispose remaining dirty nodes disconnected at flush time (skip reparented)
       for (const dn of dirtyNodes) {
         if (!document.contains(dn)) {
           disposeMessageNode(dn);
         }
       }
 
-      // Build process set: dirty nodes + previous/current transition nodes
-      const toProcess = new Set(dirtyNodes);
+      // Build process set: still-connected dirty nodes + transition nodes
+      const toProcess = new Set();
+      for (const dn of dirtyNodes) {
+        if (document.contains(dn)) {
+          toProcess.add(dn);
+        }
+      }
       if (previousLatestAssistant && nodeSet.has(previousLatestAssistant)) {
         toProcess.add(previousLatestAssistant);
       }
@@ -291,14 +311,23 @@ function scanPage() {
 
       dirtyNodes.clear();
 
+      const context = {
+        latestAssistantNode: latestAssistant,
+        absoluteLastNode: absoluteLast,
+        systemGenerating,
+      };
+
+      // Build node-to-index map for efficient iteration
+      const indexMap = new Map();
       for (let i = 0; i < nodes.length; i++) {
-        const node = nodes[i];
-        if (!toProcess.has(node)) continue;
+        indexMap.set(nodes[i], i);
+      }
+
+      for (const node of toProcess) {
+        const idx = indexMap.get(node);
+        if (idx === undefined) continue;
         try {
-          processMessageNode(node, i, nodes, {
-            latestAssistantNode: latestAssistant,
-            absoluteLastNode: absoluteLast,
-          });
+          processMessageNode(node, idx, nodes, context);
         } catch (err) {
           console.error("[BDS] Error processing message node:", err, node);
         }
@@ -323,6 +352,7 @@ function scanPage() {
  */
 export function resetIncrementalState() {
   dirtyNodes.clear();
+  removedNodes.clear();
   pendingFullScan = false;
   previousLatestAssistant = null;
   previousAbsoluteLast = null;
@@ -855,6 +885,9 @@ export function startUrlWatcher() {
     const oldUrl = state.lastUrl;
     state.lastUrl = location.href;
     resetIncrementalState();
+    // Clear processed-standalone-files signature set so identical files can
+    // render in a later conversation without growing across sessions.
+    state.processedStandaloneFiles.clear();
     window.dispatchEvent(new CustomEvent("bds:urlChanged"));
 
     const isNewSessionTransition = (oldUrl === "https://chat.deepseek.com/" || oldUrl === "https://chat.deepseek.com") && state.lastUrl.includes("/chat/s/");

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -146,15 +146,17 @@ export function observeChatDom() {
     let hasExternalMutation = false;
 
     for (const r of records) {
-      // Ignore records wholly owned by #bds-root
+      // Ignore records where the target itself is within #bds-root
       if (r.target.closest?.("#bds-root")) continue;
 
-      hasExternalMutation = true;
+      let recordHasExternal = false;
 
       // Collect removed message subtrees
       for (const removed of r.removedNodes) {
         if (removed.nodeType !== Node.ELEMENT_NODE) continue;
         if (removed.closest?.("#bds-root")) continue;
+
+        recordHasExternal = true;
 
         const removedMessages = removed.classList?.contains("ds-message")
           ? [removed]
@@ -170,6 +172,8 @@ export function observeChatDom() {
       for (const added of r.addedNodes) {
         if (added.nodeType !== Node.ELEMENT_NODE) continue;
         if (added.closest?.("#bds-root")) continue;
+
+        recordHasExternal = true;
 
         if (added.classList?.contains("ds-message")) {
           dirtyNodes.add(added);
@@ -191,9 +195,13 @@ export function observeChatDom() {
       if (target && target !== document.body && !target.closest?.("#bds-root")) {
         const msg = closestMessageNode(target);
         if (msg) {
+          recordHasExternal = true;
           dirtyNodes.add(msg);
         }
-        // Non-message mutations still schedule page-wide enhancers
+      }
+
+      if (recordHasExternal) {
+        hasExternalMutation = true;
       }
     }
 

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -143,9 +143,13 @@ export function observeChatDom() {
   }
 
   state.observer = new MutationObserver((records) => {
+    let hasExternalMutation = false;
+
     for (const r of records) {
       // Ignore records wholly owned by #bds-root
       if (r.target.closest?.("#bds-root")) continue;
+
+      hasExternalMutation = true;
 
       // Collect removed message subtrees
       for (const removed of r.removedNodes) {
@@ -189,12 +193,16 @@ export function observeChatDom() {
         if (msg) {
           dirtyNodes.add(msg);
         }
-        // Non-message mutations don't trigger message processing —
-        // page-wide enhancers run unconditionally in scanPage().
+        // Non-message mutations still schedule page-wide enhancers
       }
     }
 
-    armScanTimer();
+    // Only arm the timer when at least one external mutation exists.
+    // A batch wholly inside #bds-root produces no external record and
+    // must not schedule a scan.
+    if (hasExternalMutation) {
+      armScanTimer();
+    }
   });
 
   state.observer.observe(document.body, {
@@ -348,14 +356,16 @@ function scanPage() {
 }
 
 /**
- * Reset incremental state when conversation DOM is replaced (URL change).
+ * Reset conversation-processing state when conversation DOM is replaced
+ * (URL change). Preserves the disconnected-removal queue so overlays from
+ * removed messages are disposed at the next flush even across navigation.
  */
 export function resetIncrementalState() {
   dirtyNodes.clear();
-  removedNodes.clear();
   pendingFullScan = false;
   previousLatestAssistant = null;
   previousAbsoluteLast = null;
+  // Do NOT clear removedNodes — disposal must survive navigation.
 }
 
 /**

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -5,7 +5,13 @@
 import state, { withObserverPaused } from "./state.js";
 import { LONG_WORK_STALE_MS } from "../lib/constants.js";
 import { devLog } from "../lib/dev-log.js";
-import { processMessageNode, disposeMessageNode, disposeDetachedMessageOverlays, isSystemGenerating } from "./message-processor.svelte.js";
+import {
+  processMessageNode,
+  disposeMessageNode,
+  disposeDetachedMessageOverlays,
+  isSystemGenerating,
+  resetMessagePricing,
+} from "./message-processor.svelte.js";
 import { mount, unmount } from "svelte";
 import AttachMenu from "./ui/AttachMenu.svelte";
 import ExpandToggle from "./ui/ExpandToggle.svelte";
@@ -34,6 +40,82 @@ let previousAbsoluteLast = null;
  * @type {Element[]}
  */
 let knownNodes = [];
+let knownNodesInitialized = false;
+let knownNodeIndexes = new WeakMap();
+let knownLatestAssistant = null;
+
+function rebuildKnownNodes(nodes) {
+  knownNodes = nodes;
+  knownNodesInitialized = true;
+  knownNodeIndexes = new WeakMap();
+  for (let index = 0; index < knownNodes.length; index += 1) {
+    knownNodeIndexes.set(knownNodes[index], index);
+  }
+  knownLatestAssistant = findLatestAssistantMessageNode(knownNodes);
+}
+
+function updateKnownIndexes(startIndex) {
+  for (let index = startIndex; index < knownNodes.length; index += 1) {
+    knownNodeIndexes.set(knownNodes[index], index);
+  }
+}
+
+function recomputeKnownLatestAssistant() {
+  knownLatestAssistant = findLatestAssistantMessageNode(knownNodes);
+}
+
+function removeKnownNode(node) {
+  let index = knownNodeIndexes.get(node);
+  if (index === undefined) return false;
+  if (knownNodes[index] !== node) {
+    index = knownNodes.indexOf(node);
+  }
+  if (index === -1) return false;
+
+  knownNodes.splice(index, 1);
+  knownNodeIndexes.delete(node);
+  updateKnownIndexes(index);
+  if (knownLatestAssistant === node) recomputeKnownLatestAssistant();
+  return true;
+}
+
+function findKnownInsertIndex(node) {
+  let low = 0;
+  let high = knownNodes.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    const position = knownNodes[middle].compareDocumentPosition(node);
+    if (position & Node.DOCUMENT_POSITION_FOLLOWING) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+function registerKnownNode(node) {
+  if (!knownNodesInitialized || !document.contains(node)) return;
+
+  const wasKnown = removeKnownNode(node);
+  let index;
+  const last = knownNodes[knownNodes.length - 1];
+  if (!last || (last.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING)) {
+    index = knownNodes.length;
+    knownNodes.push(node);
+    knownNodeIndexes.set(node, index);
+  } else {
+    index = findKnownInsertIndex(node);
+    knownNodes.splice(index, 0, node);
+    updateKnownIndexes(index);
+  }
+
+  if (wasKnown) {
+    recomputeKnownLatestAssistant();
+  } else if (
+    detectMessageRole(node) === "assistant" &&
+    (!knownLatestAssistant || index > (knownNodeIndexes.get(knownLatestAssistant) ?? -1))
+  ) {
+    knownLatestAssistant = node;
+  }
+}
 
 // ── Internal: arm the shared debounce timer ──
 function armScanTimer() {
@@ -185,8 +267,7 @@ export function observeChatDom() {
 
         if (added.classList?.contains("ds-message")) {
           dirtyNodes.add(added);
-          if (knownNodes.length === 0) knownNodes = collectMessageNodes();
-          else if (!knownNodes.includes(added)) knownNodes.push(added);
+          registerKnownNode(added);
           continue;
         }
 
@@ -195,8 +276,7 @@ export function observeChatDom() {
           for (const dm of descendantMessages) {
             if (!dm.closest?.("#bds-root")) {
               dirtyNodes.add(dm);
-              if (knownNodes.length === 0) knownNodes = collectMessageNodes();
-              else if (!knownNodes.includes(dm)) knownNodes.push(dm);
+              registerKnownNode(dm);
             }
           }
         }
@@ -248,12 +328,8 @@ export function scheduleMessageScan(node) {
     return;
   }
   dirtyNodes.add(node);
-  // Seed the ordered registry from DOM if this is the first operation
-  if (knownNodes.length === 0) {
-    knownNodes = collectMessageNodes();
-  } else if (!knownNodes.includes(node)) {
-    knownNodes.push(node);
-  }
+  if (!knownNodesInitialized) rebuildKnownNodes(collectMessageNodes());
+  registerKnownNode(node);
   armScanTimer();
 }
 
@@ -291,7 +367,10 @@ function scanPage() {
     removedNodes.clear();
     for (const rn of toDispose) {
       if (!document.contains(rn)) {
+        removeKnownNode(rn);
         disposeMessageNode(rn);
+      } else {
+        registerKnownNode(rn);
       }
     }
 
@@ -301,8 +380,8 @@ function scanPage() {
       dirtyNodes.clear();
 
       const nodes = collectMessageNodes();
-      knownNodes = nodes; // seed incremental registry
-      const latestAssistant = findLatestAssistantMessageNode(nodes);
+      rebuildKnownNodes(nodes);
+      const latestAssistant = knownLatestAssistant;
       const absoluteLast = nodes[nodes.length - 1] || null;
       const systemGenerating = isSystemGenerating();
       const context = {
@@ -325,28 +404,17 @@ function scanPage() {
     } else if (dirtyNodes.size > 0 || toDispose.size > 0) {
       // Incremental: use cached knownNodes — no O(N) DOM walk after initial seed.
       // Seed with one full collection if the registry is empty (first run after nav).
-      if (knownNodes.length === 0) {
-        knownNodes = collectMessageNodes();
-      }
-      // Prune disconnected entries from knownNodes (removed by observer)
-      knownNodes = knownNodes.filter(n => document.contains(n));
-
-      // Also splice out nodes that were disposed
-      for (const rn of toDispose) {
-        const idx = knownNodes.indexOf(rn);
-        if (idx !== -1) knownNodes.splice(idx, 1);
-      }
+      if (!knownNodesInitialized) rebuildKnownNodes(collectMessageNodes());
 
       // Dispose remaining dirty nodes disconnected at flush time
       for (const dn of dirtyNodes) {
         if (!document.contains(dn)) {
           disposeMessageNode(dn);
-          const idx = knownNodes.indexOf(dn);
-          if (idx !== -1) knownNodes.splice(idx, 1);
+          removeKnownNode(dn);
         }
       }
 
-      const latestAssistant = findLatestAssistantMessageNode(knownNodes);
+      const latestAssistant = knownLatestAssistant;
       const absoluteLast = knownNodes[knownNodes.length - 1] || null;
       const systemGenerating = isSystemGenerating();
 
@@ -376,8 +444,8 @@ function scanPage() {
 
       // Use knownNodes for index lookups (no rebuild)
       for (const node of toProcess) {
-        const idx = knownNodes.indexOf(node);
-        if (idx === -1) continue;
+        const idx = knownNodeIndexes.get(node);
+        if (idx === undefined) continue;
         try {
           processMessageNode(node, idx, knownNodes, context);
         } catch (err) {
@@ -410,6 +478,9 @@ export function resetIncrementalState() {
   previousLatestAssistant = null;
   previousAbsoluteLast = null;
   knownNodes = [];
+  knownNodesInitialized = false;
+  knownNodeIndexes = new WeakMap();
+  knownLatestAssistant = null;
   // Do NOT clear removedNodes — disposal must survive navigation.
 }
 
@@ -953,9 +1024,7 @@ export function startUrlWatcher() {
     
     // Only reset session pricing if it's NOT the first message transition
     if (!isNewSessionTransition) {
-      state.pricing.sessionTotals = { inputCost: 0, outputCost: 0, totalCost: 0 };
-      state.pricing.sessionInputTokens = 0;
-      state.pricing.sessionOutputTokens = 0;
+      resetMessagePricing();
       state.pricing.pendingInjections.clear();
     } else {
       // Migrate "default" pending injection to the new real ID

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -5,7 +5,7 @@
 import state, { withObserverPaused } from "./state.js";
 import { LONG_WORK_STALE_MS } from "../lib/constants.js";
 import { devLog } from "../lib/dev-log.js";
-import { processMessageNode } from "./message-processor.svelte.js";
+import { processMessageNode, disposeMessageNode, disposeDetachedMessageOverlays } from "./message-processor.svelte.js";
 import { mount, unmount } from "svelte";
 import AttachMenu from "./ui/AttachMenu.svelte";
 import ExpandToggle from "./ui/ExpandToggle.svelte";
@@ -19,6 +19,12 @@ import { tryExecuteRawInput } from "./commands/executor.js";
 import { checkPendingHandoff } from "./commands/context-handoff.js";
 import Autocomplete from "./commands/Autocomplete.svelte";
 import CommandsHelp from "./commands/CommandsHelp.svelte";
+
+// ── Incremental scan state ──
+const dirtyNodes = new Set();
+let pendingFullScan = false;
+let previousLatestAssistant = null;
+let previousAbsoluteLast = null;
 
 /**
  * Collect all message nodes from the chat DOM.
@@ -102,7 +108,18 @@ export function isLatestAssistantMessage(node) {
 }
 
 /**
+ * Find the closest message ancestor for a given DOM node.
+ * Returns null if the node is not inside a message.
+ */
+function closestMessageNode(target) {
+  if (!target || target === document.body || target === document.documentElement) return null;
+  const msg = target.closest?.("div.ds-message");
+  return msg && !msg.closest("#bds-root") ? msg : null;
+}
+
+/**
  * Set up a MutationObserver on the document body.
+ * Collects dirty message nodes for incremental processing.
  */
 export function observeChatDom() {
   if (state.observer || !document.body) {
@@ -110,12 +127,59 @@ export function observeChatDom() {
   }
 
   state.observer = new MutationObserver((records) => {
+    let hasNonMessageMutation = false;
+
     for (const r of records) {
-      if (r.addedNodes.length || r.removedNodes.length) {
-        scheduleScan();
-        return;
+      // Check removed nodes for messages needing disposal
+      for (const removed of r.removedNodes) {
+        if (removed.nodeType !== Node.ELEMENT_NODE) continue;
+        // Collect removed message subtrees
+        const removedMessages = removed.classList?.contains("ds-message")
+          ? [removed]
+          : Array.from(removed.querySelectorAll?.("div.ds-message") || []);
+        for (const rm of removedMessages) {
+          if (!rm.closest?.("#bds-root")) {
+            dirtyNodes.add(rm);
+          }
+        }
+      }
+
+      // Check added nodes for new/modified messages
+      for (const added of r.addedNodes) {
+        if (added.nodeType !== Node.ELEMENT_NODE) continue;
+
+        if (added.classList?.contains("ds-message")) {
+          if (!added.closest?.("#bds-root")) {
+            dirtyNodes.add(added);
+          }
+          continue;
+        }
+
+        // Check descendant messages
+        const descendantMessages = added.querySelectorAll?.("div.ds-message");
+        if (descendantMessages?.length) {
+          for (const dm of descendantMessages) {
+            if (!dm.closest?.("#bds-root")) {
+              dirtyNodes.add(dm);
+            }
+          }
+        }
+      }
+
+      // For mutations without explicit message nodes (e.g. text changes),
+      // find the closest message ancestor
+      const target = r.target;
+      if (target && target !== document.body) {
+        const msg = closestMessageNode(target);
+        if (msg) {
+          dirtyNodes.add(msg);
+        } else if (!target.closest?.("#bds-root")) {
+          hasNonMessageMutation = true;
+        }
       }
     }
+
+    scheduleScan();
   });
 
   state.observer.observe(document.body, {
@@ -125,10 +189,28 @@ export function observeChatDom() {
 }
 
 /**
+ * Schedule targeted reprocessing of a single message node.
+ * Coalesced under the same debounce timer as full scans.
+ */
+export function scheduleMessageScan(node) {
+  if (node && !node.closest?.("#bds-root")) {
+    dirtyNodes.add(node);
+  }
+  scheduleScan();
+}
+
+/**
  * Debounced page scan scheduler. Trailing-edge: coalesces bursts into one
  * scan ~140ms after the LAST mutation.
+ *
+ * When called with pendingFullScan=true (default), targeted work is
+ * discarded in favor of a full scan.
  */
-export function scheduleScan() {
+export function scheduleScan(fullScan = true) {
+  if (fullScan) {
+    pendingFullScan = true;
+  }
+
   if (state.scanTimer) {
     clearTimeout(state.scanTimer);
   }
@@ -140,7 +222,7 @@ export function scheduleScan() {
 }
 
 /**
- * Full page scan — process all message nodes.
+ * Full page scan — process all or only dirty message nodes.
  */
 function scanPage() {
   withObserverPaused(() => {
@@ -156,16 +238,77 @@ function scanPage() {
       }
     }
 
-    const nodes = collectMessageNodes();
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      try {
-        processMessageNode(node, i, nodes);
-      } catch (err) {
-        console.error("[BDS] Error processing message node:", err, node);
+    const doFullScan = pendingFullScan;
+    pendingFullScan = false;
+
+    if (doFullScan) {
+      // Full scan: process all messages with shared context.
+      // First, dispose removed message overlays.
+      disposeDetachedMessageOverlays();
+      dirtyNodes.clear();
+      const nodes = collectMessageNodes();
+      const latestAssistant = findLatestAssistantMessageNode();
+      const absoluteLast = nodes[nodes.length - 1] || null;
+
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        try {
+          processMessageNode(node, i, nodes, {
+            latestAssistantNode: latestAssistant,
+            absoluteLastNode: absoluteLast,
+          });
+        } catch (err) {
+          console.error("[BDS] Error processing message node:", err, node);
+        }
       }
+
+      previousLatestAssistant = latestAssistant;
+      previousAbsoluteLast = absoluteLast;
+    } else if (dirtyNodes.size > 0) {
+      // Incremental: process only dirty and state-transition nodes
+      const nodes = collectMessageNodes();
+      const nodeSet = new Set(nodes);
+      const latestAssistant = findLatestAssistantMessageNode();
+      const absoluteLast = nodes[nodes.length - 1] || null;
+
+      // Dispose dirty nodes that are no longer in the document (moved/removed)
+      for (const dn of dirtyNodes) {
+        if (!document.contains(dn)) {
+          disposeMessageNode(dn);
+        }
+      }
+
+      // Build process set: dirty nodes + previous/current transition nodes
+      const toProcess = new Set(dirtyNodes);
+      if (previousLatestAssistant && nodeSet.has(previousLatestAssistant)) {
+        toProcess.add(previousLatestAssistant);
+      }
+      if (previousAbsoluteLast && nodeSet.has(previousAbsoluteLast)) {
+        toProcess.add(previousAbsoluteLast);
+      }
+      if (latestAssistant) toProcess.add(latestAssistant);
+      if (absoluteLast) toProcess.add(absoluteLast);
+
+      dirtyNodes.clear();
+
+      for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (!toProcess.has(node)) continue;
+        try {
+          processMessageNode(node, i, nodes, {
+            latestAssistantNode: latestAssistant,
+            absoluteLastNode: absoluteLast,
+          });
+        } catch (err) {
+          console.error("[BDS] Error processing message node:", err, node);
+        }
+      }
+
+      previousLatestAssistant = latestAssistant;
+      previousAbsoluteLast = absoluteLast;
     }
 
+    // Page-wide enhancers always run (composer, sidebar, logo, etc.)
     linkifyLogo();
     linkifyNewChatButton();
     injectSearchInput();
@@ -173,6 +316,16 @@ function scanPage() {
     hideTagsInSidebar();
     hideTagsInHeader();
   });
+}
+
+/**
+ * Reset incremental state when conversation DOM is replaced (URL change).
+ */
+export function resetIncrementalState() {
+  dirtyNodes.clear();
+  pendingFullScan = false;
+  previousLatestAssistant = null;
+  previousAbsoluteLast = null;
 }
 
 /**
@@ -701,6 +854,7 @@ export function startUrlWatcher() {
     }
     const oldUrl = state.lastUrl;
     state.lastUrl = location.href;
+    resetIncrementalState();
     window.dispatchEvent(new CustomEvent("bds:urlChanged"));
 
     const isNewSessionTransition = (oldUrl === "https://chat.deepseek.com/" || oldUrl === "https://chat.deepseek.com") && state.lastUrl.includes("/chat/s/");

--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -27,6 +27,14 @@ let pendingFullScan = false;
 let previousLatestAssistant = null;
 let previousAbsoluteLast = null;
 
+/**
+ * Ordered registry of known connected message nodes, seeded by full scans
+ * and updated incrementally by observer additions/removals/reparents.
+ * Avoids O(N) `collectMessageNodes()` DOM walks on every incremental flush.
+ * @type {Element[]}
+ */
+let knownNodes = [];
+
 // ── Internal: arm the shared debounce timer ──
 function armScanTimer() {
   if (state.scanTimer) {
@@ -177,6 +185,8 @@ export function observeChatDom() {
 
         if (added.classList?.contains("ds-message")) {
           dirtyNodes.add(added);
+          if (knownNodes.length === 0) knownNodes = collectMessageNodes();
+          else if (!knownNodes.includes(added)) knownNodes.push(added);
           continue;
         }
 
@@ -185,6 +195,8 @@ export function observeChatDom() {
           for (const dm of descendantMessages) {
             if (!dm.closest?.("#bds-root")) {
               dirtyNodes.add(dm);
+              if (knownNodes.length === 0) knownNodes = collectMessageNodes();
+              else if (!knownNodes.includes(dm)) knownNodes.push(dm);
             }
           }
         }
@@ -236,6 +248,12 @@ export function scheduleMessageScan(node) {
     return;
   }
   dirtyNodes.add(node);
+  // Seed the ordered registry from DOM if this is the first operation
+  if (knownNodes.length === 0) {
+    knownNodes = collectMessageNodes();
+  } else if (!knownNodes.includes(node)) {
+    knownNodes.push(node);
+  }
   armScanTimer();
 }
 
@@ -278,11 +296,12 @@ function scanPage() {
     }
 
     if (doFullScan) {
-      // Full scan: process all messages with shared context
+      // Full scan: rebuild knownNodes from DOM, process all
       disposeDetachedMessageOverlays();
       dirtyNodes.clear();
 
       const nodes = collectMessageNodes();
+      knownNodes = nodes; // seed incremental registry
       const latestAssistant = findLatestAssistantMessageNode(nodes);
       const absoluteLast = nodes[nodes.length - 1] || null;
       const systemGenerating = isSystemGenerating();
@@ -304,31 +323,44 @@ function scanPage() {
       previousLatestAssistant = latestAssistant;
       previousAbsoluteLast = absoluteLast;
     } else if (dirtyNodes.size > 0 || toDispose.size > 0) {
-      // Incremental: process only dirty and state-transition nodes
-      const nodes = collectMessageNodes();
-      const nodeSet = new Set(nodes);
-      const latestAssistant = findLatestAssistantMessageNode(nodes);
-      const absoluteLast = nodes[nodes.length - 1] || null;
-      const systemGenerating = isSystemGenerating();
+      // Incremental: use cached knownNodes — no O(N) DOM walk after initial seed.
+      // Seed with one full collection if the registry is empty (first run after nav).
+      if (knownNodes.length === 0) {
+        knownNodes = collectMessageNodes();
+      }
+      // Prune disconnected entries from knownNodes (removed by observer)
+      knownNodes = knownNodes.filter(n => document.contains(n));
 
-      // Dispose remaining dirty nodes disconnected at flush time (skip reparented)
+      // Also splice out nodes that were disposed
+      for (const rn of toDispose) {
+        const idx = knownNodes.indexOf(rn);
+        if (idx !== -1) knownNodes.splice(idx, 1);
+      }
+
+      // Dispose remaining dirty nodes disconnected at flush time
       for (const dn of dirtyNodes) {
         if (!document.contains(dn)) {
           disposeMessageNode(dn);
+          const idx = knownNodes.indexOf(dn);
+          if (idx !== -1) knownNodes.splice(idx, 1);
         }
       }
 
-      // Build process set: still-connected dirty nodes + transition nodes
+      const latestAssistant = findLatestAssistantMessageNode(knownNodes);
+      const absoluteLast = knownNodes[knownNodes.length - 1] || null;
+      const systemGenerating = isSystemGenerating();
+
+      // Build process set from dirty + transition nodes
       const toProcess = new Set();
       for (const dn of dirtyNodes) {
         if (document.contains(dn)) {
           toProcess.add(dn);
         }
       }
-      if (previousLatestAssistant && nodeSet.has(previousLatestAssistant)) {
+      if (previousLatestAssistant && document.contains(previousLatestAssistant)) {
         toProcess.add(previousLatestAssistant);
       }
-      if (previousAbsoluteLast && nodeSet.has(previousAbsoluteLast)) {
+      if (previousAbsoluteLast && document.contains(previousAbsoluteLast)) {
         toProcess.add(previousAbsoluteLast);
       }
       if (latestAssistant) toProcess.add(latestAssistant);
@@ -342,17 +374,12 @@ function scanPage() {
         systemGenerating,
       };
 
-      // Build node-to-index map for efficient iteration
-      const indexMap = new Map();
-      for (let i = 0; i < nodes.length; i++) {
-        indexMap.set(nodes[i], i);
-      }
-
+      // Use knownNodes for index lookups (no rebuild)
       for (const node of toProcess) {
-        const idx = indexMap.get(node);
-        if (idx === undefined) continue;
+        const idx = knownNodes.indexOf(node);
+        if (idx === -1) continue;
         try {
-          processMessageNode(node, idx, nodes, context);
+          processMessageNode(node, idx, knownNodes, context);
         } catch (err) {
           console.error("[BDS] Error processing message node:", err, node);
         }
@@ -382,6 +409,7 @@ export function resetIncrementalState() {
   pendingFullScan = false;
   previousLatestAssistant = null;
   previousAbsoluteLast = null;
+  knownNodes = [];
   // Do NOT clear removedNodes — disposal must survive navigation.
 }
 

--- a/src/content/storage.js
+++ b/src/content/storage.js
@@ -442,8 +442,31 @@ export function normalizeCssSnippets(raw) {
 
 // ── Storage change listener ──
 
+let _storageListenerRef = null;
+
+/**
+ * Bind the storage.onChanged listener. Idempotent — subsequent calls
+ * return the same cleanup handle. The returned cleanup function removes
+ * the listener and permits a later fresh bind.
+ *
+ * @returns {() => void}
+ */
 export function bindStorageChangeListener() {
-  chrome.storage.onChanged.addListener((changes, areaName) => {
+  // Re-register if previously cleared (e.g. mock reset)
+  if (_storageListenerRef) {
+    // Verify the listener is still registered; mock resets clear the Set
+    if (!chrome.storage.onChanged.hasListener(_storageListenerRef)) {
+      _storageListenerRef = null; // fall through to re-register
+    } else {
+      return () => {
+        chrome.storage.onChanged.removeListener(_storageListenerRef);
+        _storageListenerRef = null;
+      };
+    }
+  }
+
+  if (!_storageListenerRef) {
+    _storageListenerRef = (changes, areaName) => {
     if (areaName !== "local") {
       return;
     }
@@ -573,5 +596,13 @@ export function bindStorageChangeListener() {
     if (pageConfigChanged) {
       pushConfigToPage();
     }
-  });
+  };
+
+  chrome.storage.onChanged.addListener(_storageListenerRef);
+  }
+
+  return () => {
+    chrome.storage.onChanged.removeListener(_storageListenerRef);
+    _storageListenerRef = null;
+  };
 }

--- a/src/content/storage.js
+++ b/src/content/storage.js
@@ -443,6 +443,7 @@ export function normalizeCssSnippets(raw) {
 // ── Storage change listener ──
 
 let _storageListenerRef = null;
+let _storageCleanupRef = null;
 
 /**
  * Bind the storage.onChanged listener. Idempotent — subsequent calls
@@ -456,12 +457,10 @@ export function bindStorageChangeListener() {
   if (_storageListenerRef) {
     // Verify the listener is still registered; mock resets clear the Set
     if (!chrome.storage.onChanged.hasListener(_storageListenerRef)) {
-      _storageListenerRef = null; // fall through to re-register
+      _storageListenerRef = null;
+      _storageCleanupRef = null;
     } else {
-      return () => {
-        chrome.storage.onChanged.removeListener(_storageListenerRef);
-        _storageListenerRef = null;
-      };
+      return _storageCleanupRef;
     }
   }
 
@@ -599,10 +598,15 @@ export function bindStorageChangeListener() {
   };
 
   chrome.storage.onChanged.addListener(_storageListenerRef);
+  const listener = _storageListenerRef;
+  _storageCleanupRef = () => {
+    chrome.storage.onChanged.removeListener(listener);
+    if (_storageListenerRef === listener) {
+      _storageListenerRef = null;
+      _storageCleanupRef = null;
+    }
+  };
   }
 
-  return () => {
-    chrome.storage.onChanged.removeListener(_storageListenerRef);
-    _storageListenerRef = null;
-  };
+  return _storageCleanupRef;
 }

--- a/src/content/storage.js
+++ b/src/content/storage.js
@@ -448,6 +448,8 @@ export function bindStorageChangeListener() {
       return;
     }
 
+    let pageConfigChanged = false;
+
     if (changes[STORAGE_KEYS.settings]) {
       state.settings = {
         ...DEFAULT_SETTINGS,
@@ -467,6 +469,7 @@ export function bindStorageChangeListener() {
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent("bds:settingsChanged"));
       }
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.skills]) {
@@ -474,6 +477,7 @@ export function bindStorageChangeListener() {
       if (state.ui) {
         state.ui.refreshSkills();
       }
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.memories]) {
@@ -483,6 +487,7 @@ export function bindStorageChangeListener() {
       if (state.ui) {
         state.ui.refreshMemories();
       }
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.characters]) {
@@ -492,16 +497,19 @@ export function bindStorageChangeListener() {
       if (state.ui) {
         state.ui.refreshCharacters();
       }
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.projects]) {
       state.projects = normalizeProjects(changes[STORAGE_KEYS.projects].newValue);
       if (state.ui) state.ui.refreshProjects();
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.projectFiles]) {
       state.projectFiles = normalizeProjectFiles(changes[STORAGE_KEYS.projectFiles].newValue);
       if (state.ui) state.ui.refreshProjects();
+      pageConfigChanged = true;
     }
 
     if (changes[STORAGE_KEYS.whatsNewPending]) {
@@ -513,7 +521,7 @@ export function bindStorageChangeListener() {
 
     if (changes[STORAGE_KEYS.chatTags]) {
       state.chatTags = normalizeChatTags(changes[STORAGE_KEYS.chatTags].newValue);
-      
+
       // Update sidebar tag chips if search is active
       import("./ui/SidebarSearch.js").then(m => {
         if (typeof m.renderTagChips === 'function') {
@@ -521,7 +529,7 @@ export function bindStorageChangeListener() {
         }
       });
     }
-    
+
     if (changes[STORAGE_KEYS.savedItems]) {
       state.savedItems = normalizeSavedItems(changes[STORAGE_KEYS.savedItems].newValue);
       if (state.ui) state.ui.refreshSavedItems();
@@ -549,11 +557,9 @@ export function bindStorageChangeListener() {
     }
 
     if (changes[STORAGE_KEYS.remoteConfig]) {
-      const newConfig = changes[STORAGE_KEYS.remoteConfig].newValue;
-      if (newConfig && typeof newConfig === "object") {
-        remoteConfig.replaceRemote(newConfig);
-        state.remoteConfig = remoteConfig.raw;
-      }
+      // syncFromStorage NEVER writes back — it is the ownership boundary
+      remoteConfig.syncFromStorage(changes[STORAGE_KEYS.remoteConfig].newValue ?? {});
+      state.remoteConfig = remoteConfig.raw;
     }
 
     if (changes.bds_locale_updates) {
@@ -564,6 +570,8 @@ export function bindStorageChangeListener() {
       }
     }
 
-    pushConfigToPage();
+    if (pageConfigChanged) {
+      pushConfigToPage();
+    }
   });
 }

--- a/src/lib/deep-equal.js
+++ b/src/lib/deep-equal.js
@@ -1,0 +1,33 @@
+/**
+ * Deep structural equality.
+ *
+ * Returns true when `a` and `b` have the same JSON-serializable shape.
+ * Objects compared by sorted keys; arrays by index; primitives/null by ===.
+ * Key order independent for plain objects.
+ *
+ * Shared by remote-config manager, background persistence, and storage mock.
+ */
+
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false;
+    if (!deepEqual(a[aKeys[i]], b[bKeys[i]])) return false;
+  }
+  return true;
+}

--- a/src/lib/remote-config.svelte.js
+++ b/src/lib/remote-config.svelte.js
@@ -81,7 +81,8 @@ class RemoteConfigManager {
    * external syncs are read-only consumers.
    */
   syncFromStorage(value) {
-    const normalized = value && typeof value === "object" ? value : {};
+    // Normalize invalid roots (null, undefined, arrays, primitives) to {}
+    const normalized = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
     const prevRaw = this.raw;
     this.#remote = normalized;
     const nextRaw = this.raw;
@@ -109,9 +110,13 @@ class RemoteConfigManager {
   }
 
   resetToBuiltin() {
-    if (!this.#isStructurallyEqual(this.#remote, {})) {
-      this.#remote = {};
-      this.#clearStorage();
+    const hadOverrides = !this.#isStructurallyEqual(this.#remote, {});
+    this.#remote = {};
+    // Always clear persisted config + metadata, even when in-memory override
+    // is already empty — storage hygiene is unconditional.
+    this.#clearStorage();
+    // Suppress notification only when logical configuration did not change.
+    if (hadOverrides) {
       this.#notify();
     }
   }

--- a/src/lib/remote-config.svelte.js
+++ b/src/lib/remote-config.svelte.js
@@ -2,6 +2,15 @@ import { DEFAULT_REMOTE_CONFIG, STORAGE_KEYS } from "./constants.js";
 
 const EVENT_CONFIG_UPDATED = "bds:remote-config-updated";
 
+/**
+ * Normalize a remote-config root value. A root must be a non-array object;
+ * invalid roots (null, undefined, arrays, primitives) become {}.
+ * Nested arrays remain valid configuration values.
+ */
+function normalizeRoot(value) {
+  return (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
+}
+
 function deepMerge(target, source) {
   for (const key of Object.keys(source)) {
     if (
@@ -53,9 +62,7 @@ class RemoteConfigManager {
       if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
         const result = await chrome.storage.local.get([STORAGE_KEYS.remoteConfig]);
         const stored = result[STORAGE_KEYS.remoteConfig];
-        if (stored && typeof stored === "object") {
-          this.#remote = stored;
-        }
+        this.#remote = normalizeRoot(stored);
       }
     } catch (e) {
       console.warn("[BDS] Failed to load remote config from storage:", e);
@@ -81,8 +88,7 @@ class RemoteConfigManager {
    * external syncs are read-only consumers.
    */
   syncFromStorage(value) {
-    // Normalize invalid roots (null, undefined, arrays, primitives) to {}
-    const normalized = (value && typeof value === "object" && !Array.isArray(value)) ? value : {};
+    const normalized = normalizeRoot(value);
     const prevRaw = this.raw;
     this.#remote = normalized;
     const nextRaw = this.raw;
@@ -92,8 +98,9 @@ class RemoteConfigManager {
   }
 
   applyRemote(partial) {
+    const normalized = normalizeRoot(partial);
     const prevRemote = structuredClone(this.#remote);
-    deepMerge(this.#remote, partial);
+    deepMerge(this.#remote, normalized);
     if (!this.#isStructurallyEqual(prevRemote, this.#remote)) {
       this.#persist();
       this.#notify();
@@ -101,7 +108,7 @@ class RemoteConfigManager {
   }
 
   replaceRemote(full) {
-    const next = full && typeof full === "object" ? full : {};
+    const next = normalizeRoot(full);
     if (!this.#isStructurallyEqual(this.#remote, next)) {
       this.#remote = next;
       this.#persist();

--- a/src/lib/remote-config.svelte.js
+++ b/src/lib/remote-config.svelte.js
@@ -98,35 +98,40 @@ class RemoteConfigManager {
     }
   }
 
-  applyRemote(partial) {
+  async applyRemote(partial) {
     const normalized = normalizeRoot(partial);
     const prevRemote = structuredClone(this.#remote);
     deepMerge(this.#remote, normalized);
     if (!deepEqual(prevRemote, this.#remote)) {
-      this.#persist();
+      const persisted = this.#persist();
       this.#notify();
+      return persisted;
     }
+    return false;
   }
 
-  replaceRemote(full) {
+  async replaceRemote(full) {
     const next = normalizeRoot(full);
     if (!deepEqual(this.#remote, next)) {
       this.#remote = next;
-      this.#persist();
+      const persisted = this.#persist();
       this.#notify();
+      return persisted;
     }
+    return false;
   }
 
-  resetToBuiltin() {
+  async resetToBuiltin() {
     const hadOverrides = !deepEqual(this.#remote, {});
     this.#remote = {};
     // Always clear persisted config + metadata, even when in-memory override
     // is already empty — storage hygiene is unconditional.
-    this.#clearStorage();
+    const cleared = this.#clearStorage();
     // Suppress notification only when logical configuration did not change.
     if (hadOverrides) {
       this.#notify();
     }
+    return cleared;
   }
 
   onChange(callback) {
@@ -137,21 +142,33 @@ class RemoteConfigManager {
   #persist() {
     try {
       if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
-        chrome.storage.local.set({ [STORAGE_KEYS.remoteConfig]: this.#remote }).catch(() => {});
+        return chrome.storage.local
+          .set({ [STORAGE_KEYS.remoteConfig]: this.#remote })
+          .then(() => true, (error) => {
+            console.warn("[BDS] Failed to persist remote config:", error);
+            return false;
+          });
       }
     } catch (e) {
       console.warn("[BDS] Failed to persist remote config:", e);
     }
+    return Promise.resolve(false);
   }
 
   #clearStorage() {
     try {
       if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.local) {
-        chrome.storage.local.remove([STORAGE_KEYS.remoteConfig, STORAGE_KEYS.remoteConfigMeta]).catch(() => {});
+        return chrome.storage.local
+          .remove([STORAGE_KEYS.remoteConfig, STORAGE_KEYS.remoteConfigMeta])
+          .then(() => true, (error) => {
+            console.warn("[BDS] Failed to clear remote config:", error);
+            return false;
+          });
       }
     } catch (e) {
       console.warn("[BDS] Failed to clear remote config:", e);
     }
+    return Promise.resolve(false);
   }
 
   #notify() {

--- a/src/lib/remote-config.svelte.js
+++ b/src/lib/remote-config.svelte.js
@@ -72,27 +72,89 @@ class RemoteConfigManager {
     return resolvePath(this.raw, path.split("."));
   }
 
+  /**
+   * Accept an externally-sourced remote config value (from a storage change
+   * event). Replaces the internal #remote copy, notifies consumers only when
+   * the merged result actually differs, and NEVER writes back to storage.
+   *
+   * This is the ownership boundary: local/debug mutations own persistence;
+   * external syncs are read-only consumers.
+   */
+  syncFromStorage(value) {
+    const normalized = value && typeof value === "object" ? value : {};
+    const prevRaw = this.raw;
+    this.#remote = normalized;
+    const nextRaw = this.raw;
+    if (!this.#isStructurallyEqual(prevRaw, nextRaw)) {
+      this.#notify();
+    }
+  }
+
   applyRemote(partial) {
+    const prevRemote = structuredClone(this.#remote);
     deepMerge(this.#remote, partial);
-    this.#persist();
-    this.#notify();
+    if (!this.#isStructurallyEqual(prevRemote, this.#remote)) {
+      this.#persist();
+      this.#notify();
+    }
   }
 
   replaceRemote(full) {
-    this.#remote = full && typeof full === "object" ? full : {};
-    this.#persist();
-    this.#notify();
+    const next = full && typeof full === "object" ? full : {};
+    if (!this.#isStructurallyEqual(this.#remote, next)) {
+      this.#remote = next;
+      this.#persist();
+      this.#notify();
+    }
   }
 
   resetToBuiltin() {
-    this.#remote = {};
-    this.#clearStorage();
-    this.#notify();
+    if (!this.#isStructurallyEqual(this.#remote, {})) {
+      this.#remote = {};
+      this.#clearStorage();
+      this.#notify();
+    }
   }
 
   onChange(callback) {
     this.#callbacks.add(callback);
     return () => this.#callbacks.delete(callback);
+  }
+
+  /**
+   * Structural equality: arrays compare ordered, objects compare by key
+   * (key order ignored), primitives with SameValueZero. Used to suppress
+   * no-op persist + notify cycles.
+   */
+  #isStructurallyEqual(a, b) {
+    if (a === b) return true;
+    if (a == null || b == null) return a === b;
+    if (typeof a !== typeof b) return false;
+
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) {
+        if (!this.#isStructurallyEqual(a[i], b[i])) return false;
+      }
+      return true;
+    }
+
+    if (Array.isArray(a) || Array.isArray(b)) return false;
+
+    if (typeof a === "object") {
+      const keysA = Object.keys(a).sort();
+      const keysB = Object.keys(b).sort();
+      if (keysA.length !== keysB.length) return false;
+      for (let i = 0; i < keysA.length; i++) {
+        if (keysA[i] !== keysB[i]) return false;
+      }
+      for (const key of keysA) {
+        if (!this.#isStructurallyEqual(a[key], b[key])) return false;
+      }
+      return true;
+    }
+
+    return false;
   }
 
   #persist() {

--- a/src/lib/remote-config.svelte.js
+++ b/src/lib/remote-config.svelte.js
@@ -1,4 +1,5 @@
 import { DEFAULT_REMOTE_CONFIG, STORAGE_KEYS } from "./constants.js";
+import { deepEqual } from "./deep-equal.js";
 
 const EVENT_CONFIG_UPDATED = "bds:remote-config-updated";
 
@@ -92,7 +93,7 @@ class RemoteConfigManager {
     const prevRaw = this.raw;
     this.#remote = normalized;
     const nextRaw = this.raw;
-    if (!this.#isStructurallyEqual(prevRaw, nextRaw)) {
+    if (!deepEqual(prevRaw, nextRaw)) {
       this.#notify();
     }
   }
@@ -101,7 +102,7 @@ class RemoteConfigManager {
     const normalized = normalizeRoot(partial);
     const prevRemote = structuredClone(this.#remote);
     deepMerge(this.#remote, normalized);
-    if (!this.#isStructurallyEqual(prevRemote, this.#remote)) {
+    if (!deepEqual(prevRemote, this.#remote)) {
       this.#persist();
       this.#notify();
     }
@@ -109,7 +110,7 @@ class RemoteConfigManager {
 
   replaceRemote(full) {
     const next = normalizeRoot(full);
-    if (!this.#isStructurallyEqual(this.#remote, next)) {
+    if (!deepEqual(this.#remote, next)) {
       this.#remote = next;
       this.#persist();
       this.#notify();
@@ -117,7 +118,7 @@ class RemoteConfigManager {
   }
 
   resetToBuiltin() {
-    const hadOverrides = !this.#isStructurallyEqual(this.#remote, {});
+    const hadOverrides = !deepEqual(this.#remote, {});
     this.#remote = {};
     // Always clear persisted config + metadata, even when in-memory override
     // is already empty — storage hygiene is unconditional.
@@ -131,42 +132,6 @@ class RemoteConfigManager {
   onChange(callback) {
     this.#callbacks.add(callback);
     return () => this.#callbacks.delete(callback);
-  }
-
-  /**
-   * Structural equality: arrays compare ordered, objects compare by key
-   * (key order ignored), primitives with SameValueZero. Used to suppress
-   * no-op persist + notify cycles.
-   */
-  #isStructurallyEqual(a, b) {
-    if (a === b) return true;
-    if (a == null || b == null) return a === b;
-    if (typeof a !== typeof b) return false;
-
-    if (Array.isArray(a) && Array.isArray(b)) {
-      if (a.length !== b.length) return false;
-      for (let i = 0; i < a.length; i++) {
-        if (!this.#isStructurallyEqual(a[i], b[i])) return false;
-      }
-      return true;
-    }
-
-    if (Array.isArray(a) || Array.isArray(b)) return false;
-
-    if (typeof a === "object") {
-      const keysA = Object.keys(a).sort();
-      const keysB = Object.keys(b).sort();
-      if (keysA.length !== keysB.length) return false;
-      for (let i = 0; i < keysA.length; i++) {
-        if (keysA[i] !== keysB[i]) return false;
-      }
-      for (const key of keysA) {
-        if (!this.#isStructurallyEqual(a[key], b[key])) return false;
-      }
-      return true;
-    }
-
-    return false;
   }
 
   #persist() {

--- a/src/lib/remote-persistence.js
+++ b/src/lib/remote-persistence.js
@@ -1,0 +1,166 @@
+/**
+ * Remote-data persistence helpers.
+ *
+ * Pure functions for fetching remote config, status, and locales with
+ * structural no-op checks before writing to storage. Extracted from the
+ * background service worker so tests can inject fetch, storage, and time
+ * without importing the side-effectful entrypoint.
+ */
+
+import { deepEqual } from "./deep-equal.js";
+
+export const REMOTE_CONFIG_URL =
+  "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json";
+
+export const REMOTE_STATUS_URL =
+  "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json";
+
+export const LOCALE_BASE_URL =
+  "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales";
+
+/**
+ * Build a storage-update object containing only changed keys.
+ * Returns null when nothing changed.
+ */
+function buildStorageUpdate(storedData, newValues) {
+  /** @type {Record<string, any>} */
+  const updates = {};
+  let hasChanges = false;
+
+  for (const [key, newValue] of Object.entries(newValues)) {
+    const oldValue = storedData[key];
+    if (!deepEqual(oldValue, newValue)) {
+      updates[key] = newValue;
+      hasChanges = true;
+    }
+  }
+
+  return hasChanges ? updates : null;
+}
+
+/**
+ * Fetch and persist remote config.
+ *
+ * @param {{ fetch: typeof fetch, storage: { get: Function, set: Function } }} deps
+ * @param {{ now: number }}
+ * @returns {Promise<{ written: boolean }>}
+ */
+export async function persistRemoteConfig(deps, { now } = { now: Date.now() }) {
+  try {
+    const response = await deps.fetch(`${REMOTE_CONFIG_URL}?t=${now}`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return { written: false };
+
+    const config = await response.json();
+    // Accept only non-array plain objects as remote-config roots.
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+      return { written: false };
+    }
+
+    const { bds_remote_config: currentConfig } = await deps.storage.get("bds_remote_config");
+    const configUpdate = buildStorageUpdate(
+      { bds_remote_config: currentConfig },
+      { bds_remote_config: config },
+    );
+    if (configUpdate) {
+      await deps.storage.set(configUpdate);
+    }
+
+    const meta = { lastFetched: now, version: config.meta?.version || 0 };
+    const { bds_remote_config_meta: currentMeta } =
+      await deps.storage.get("bds_remote_config_meta");
+    const metaUpdate = buildStorageUpdate(
+      { bds_remote_config_meta: currentMeta },
+      { bds_remote_config_meta: meta },
+    );
+    if (metaUpdate) {
+      await deps.storage.set(metaUpdate);
+    }
+
+    return { written: !!configUpdate };
+  } catch {
+    return { written: false };
+  }
+}
+
+/**
+ * Fetch and persist remote status / announcements.
+ */
+export async function persistRemoteStatus(deps, { now } = { now: Date.now() }) {
+  try {
+    const response = await deps.fetch(`${REMOTE_STATUS_URL}?t=${now}`, {
+      cache: "no-store",
+    });
+    if (!response.ok) return { written: false };
+
+    let data = await response.json();
+    if (!data) return { written: false };
+
+    const announcements = Array.isArray(data) ? data : [data];
+    const { bds_remote_announcement: stored } =
+      await deps.storage.get("bds_remote_announcement");
+
+    const update = buildStorageUpdate(
+      { bds_remote_announcement: stored },
+      { bds_remote_announcement: announcements },
+    );
+    if (update) {
+      await deps.storage.set(update);
+    }
+
+    return { written: !!update };
+  } catch {
+    return { written: false };
+  }
+}
+
+/**
+ * Fetch and persist locale data for the given locale codes.
+ */
+export async function persistLocales(deps, localeCodes, { now } = { now: Date.now() }) {
+  try {
+    const results = await Promise.allSettled(
+      localeCodes.map((code) =>
+        deps
+          .fetch(`${LOCALE_BASE_URL}/${code}.json?t=${now}`, { cache: "no-store" })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => (data?.messages ? { [code]: data } : null)),
+      ),
+    );
+
+    const updates = {};
+    for (const result of results) {
+      if (result.status === "fulfilled" && result.value) {
+        Object.assign(updates, result.value);
+      }
+    }
+    if (Object.keys(updates).length === 0) {
+      return { success: false, error: "No valid locale files fetched" };
+    }
+
+    const { bds_locale_updates: stored } = await deps.storage.get("bds_locale_updates");
+    const localeUpdate = buildStorageUpdate(
+      { bds_locale_updates: stored },
+      { bds_locale_updates: updates },
+    );
+    if (localeUpdate) {
+      await deps.storage.set(localeUpdate);
+    }
+
+    const lastChecked = new Date(now).toLocaleDateString();
+    const { bds_locale_update_last_checked: storedLastChecked } =
+      await deps.storage.get("bds_locale_update_last_checked");
+    const metaUpdate = buildStorageUpdate(
+      { bds_locale_update_last_checked: storedLastChecked },
+      { bds_locale_update_last_checked: lastChecked },
+    );
+    if (metaUpdate) {
+      await deps.storage.set(metaUpdate);
+    }
+
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e?.message };
+  }
+}

--- a/src/lib/remote-persistence.js
+++ b/src/lib/remote-persistence.js
@@ -2,9 +2,11 @@
  * Remote-data persistence helpers.
  *
  * Pure functions for fetching remote config, status, and locales with
- * structural no-op checks before writing to storage. Extracted from the
- * background service worker so tests can inject fetch, storage, and time
- * without importing the side-effectful entrypoint.
+ * structural no-op checks before writing to storage. Each function:
+ *   - Fetches all relevant stored keys in one `storage.get`.
+ *   - Computes one combined update object containing only changed keys.
+ *   - Calls `storage.set()` at most once.
+ *   - Returns `{ success, writtenKeys, error }`.
  */
 
 import { deepEqual } from "./deep-equal.js";
@@ -18,105 +20,129 @@ export const REMOTE_STATUS_URL =
 export const LOCALE_BASE_URL =
   "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales";
 
+const STORAGE_KEY_CONFIG = "bds_remote_config";
+const STORAGE_KEY_CONFIG_META = "bds_remote_config_meta";
+const STORAGE_KEY_ANNOUNCEMENT = "bds_remote_announcement";
+const STORAGE_KEY_LOCALES = "bds_locale_updates";
+const STORAGE_KEY_LOCALE_CHECKED = "bds_locale_update_last_checked";
+
 /**
- * Build a storage-update object containing only changed keys.
+ * Build one object containing every key whose value changed.
  * Returns null when nothing changed.
  */
-function buildStorageUpdate(storedData, newValues) {
+function computeDiff(stored, incoming) {
   /** @type {Record<string, any>} */
-  const updates = {};
+  const diff = {};
   let hasChanges = false;
-
-  for (const [key, newValue] of Object.entries(newValues)) {
-    const oldValue = storedData[key];
-    if (!deepEqual(oldValue, newValue)) {
-      updates[key] = newValue;
+  for (const [key, value] of Object.entries(incoming)) {
+    if (!deepEqual(stored[key], value)) {
+      diff[key] = value;
       hasChanges = true;
     }
   }
-
-  return hasChanges ? updates : null;
+  return hasChanges ? diff : null;
 }
 
 /**
- * Fetch and persist remote config.
- *
+ * @typedef {{ success: boolean, writtenKeys: string[], error?: string }} PersistResult
+ */
+
+// ── Remote config ──
+
+/**
  * @param {{ fetch: typeof fetch, storage: { get: Function, set: Function } }} deps
- * @param {{ now: number }}
- * @returns {Promise<{ written: boolean }>}
+ * @param {{ now?: number }} [opts]
+ * @returns {Promise<PersistResult>}
  */
 export async function persistRemoteConfig(deps, { now } = { now: Date.now() }) {
   try {
     const response = await deps.fetch(`${REMOTE_CONFIG_URL}?t=${now}`, {
       cache: "no-store",
     });
-    if (!response.ok) return { written: false };
+    if (!response.ok) {
+      return { success: false, writtenKeys: [], error: `HTTP ${response.status}` };
+    }
 
     const config = await response.json();
     // Accept only non-array plain objects as remote-config roots.
     if (!config || typeof config !== "object" || Array.isArray(config)) {
-      return { written: false };
+      return { success: false, writtenKeys: [], error: "Invalid config root" };
     }
 
-    const { bds_remote_config: currentConfig } = await deps.storage.get("bds_remote_config");
-    const configUpdate = buildStorageUpdate(
-      { bds_remote_config: currentConfig },
-      { bds_remote_config: config },
-    );
-    if (configUpdate) {
-      await deps.storage.set(configUpdate);
-    }
-
+    // Fetch both stored keys in one call
+    const stored = await deps.storage.get([
+      STORAGE_KEY_CONFIG,
+      STORAGE_KEY_CONFIG_META,
+    ]);
     const meta = { lastFetched: now, version: config.meta?.version || 0 };
-    const { bds_remote_config_meta: currentMeta } =
-      await deps.storage.get("bds_remote_config_meta");
-    const metaUpdate = buildStorageUpdate(
-      { bds_remote_config_meta: currentMeta },
-      { bds_remote_config_meta: meta },
-    );
-    if (metaUpdate) {
-      await deps.storage.set(metaUpdate);
+
+    // Build one combined diff: config + metadata together → one set() call
+    const diff = computeDiff(stored, {
+      [STORAGE_KEY_CONFIG]: config,
+      [STORAGE_KEY_CONFIG_META]: meta,
+    });
+
+    if (diff) {
+      await deps.storage.set(diff);
+      return { success: true, writtenKeys: Object.keys(diff) };
     }
 
-    return { written: !!configUpdate };
-  } catch {
-    return { written: false };
+    return { success: true, writtenKeys: [] };
+  } catch (err) {
+    return { success: false, writtenKeys: [], error: err?.message || "Unknown error" };
   }
 }
 
+// ── Remote status / announcements ──
+
 /**
- * Fetch and persist remote status / announcements.
+ * @param {{ fetch: typeof fetch, storage: { get: Function, set: Function } }} deps
+ * @param {{ now?: number }} [opts]
+ * @returns {Promise<PersistResult>}
  */
 export async function persistRemoteStatus(deps, { now } = { now: Date.now() }) {
   try {
     const response = await deps.fetch(`${REMOTE_STATUS_URL}?t=${now}`, {
       cache: "no-store",
     });
-    if (!response.ok) return { written: false };
-
-    let data = await response.json();
-    if (!data) return { written: false };
-
-    const announcements = Array.isArray(data) ? data : [data];
-    const { bds_remote_announcement: stored } =
-      await deps.storage.get("bds_remote_announcement");
-
-    const update = buildStorageUpdate(
-      { bds_remote_announcement: stored },
-      { bds_remote_announcement: announcements },
-    );
-    if (update) {
-      await deps.storage.set(update);
+    if (!response.ok) {
+      return { success: false, writtenKeys: [], error: `HTTP ${response.status}` };
     }
 
-    return { written: !!update };
-  } catch {
-    return { written: false };
+    let data = await response.json();
+    if (!data) {
+      return { success: false, writtenKeys: [], error: "Empty status payload" };
+    }
+
+    const announcements = Array.isArray(data) ? data : [data];
+    const stored = await deps.storage.get(STORAGE_KEY_ANNOUNCEMENT);
+
+    const diff = computeDiff(stored, {
+      [STORAGE_KEY_ANNOUNCEMENT]: announcements,
+    });
+
+    if (diff) {
+      await deps.storage.set(diff);
+      return { success: true, writtenKeys: Object.keys(diff) };
+    }
+
+    return { success: true, writtenKeys: [] };
+  } catch (err) {
+    return { success: false, writtenKeys: [], error: err?.message || "Unknown error" };
   }
 }
 
+// ── Locales ──
+
 /**
- * Fetch and persist locale data for the given locale codes.
+ * Fetch and persist locale data. Preserves the last stored value for any
+ * locale code whose fetch or validation failed, so a transient failure does
+ * not erase previously loaded translations.
+ *
+ * @param {{ fetch: typeof fetch, storage: { get: Function, set: Function } }} deps
+ * @param {string[]} localeCodes
+ * @param {{ now?: number }} [opts]
+ * @returns {Promise<PersistResult>}
  */
 export async function persistLocales(deps, localeCodes, { now } = { now: Date.now() }) {
   try {
@@ -125,42 +151,47 @@ export async function persistLocales(deps, localeCodes, { now } = { now: Date.no
         deps
           .fetch(`${LOCALE_BASE_URL}/${code}.json?t=${now}`, { cache: "no-store" })
           .then((r) => (r.ok ? r.json() : null))
-          .then((data) => (data?.messages ? { [code]: data } : null)),
+          .then((data) => (data?.messages ? { code, data } : null)),
       ),
     );
 
-    const updates = {};
+    // Collect successfully fetched locales
+    /** @type {Record<string, any>} */
+    const fetched = {};
     for (const result of results) {
       if (result.status === "fulfilled" && result.value) {
-        Object.assign(updates, result.value);
+        fetched[result.value.code] = result.value.data;
       }
     }
-    if (Object.keys(updates).length === 0) {
-      return { success: false, error: "No valid locale files fetched" };
+
+    if (Object.keys(fetched).length === 0) {
+      return { success: false, writtenKeys: [], error: "No valid locale files fetched" };
     }
 
-    const { bds_locale_updates: stored } = await deps.storage.get("bds_locale_updates");
-    const localeUpdate = buildStorageUpdate(
-      { bds_locale_updates: stored },
-      { bds_locale_updates: updates },
-    );
-    if (localeUpdate) {
-      await deps.storage.set(localeUpdate);
-    }
+    // Read existing stored locales so we can merge (preserve failed codes)
+    const stored = await deps.storage.get([
+      STORAGE_KEY_LOCALES,
+      STORAGE_KEY_LOCALE_CHECKED,
+    ]);
+    const storedLocales = stored[STORAGE_KEY_LOCALES] || {};
+
+    // Merge: start from stored, overwrite with freshly fetched successes.
+    // Codes that failed to fetch keep their previous value.
+    const merged = { ...storedLocales, ...fetched };
 
     const lastChecked = new Date(now).toLocaleDateString();
-    const { bds_locale_update_last_checked: storedLastChecked } =
-      await deps.storage.get("bds_locale_update_last_checked");
-    const metaUpdate = buildStorageUpdate(
-      { bds_locale_update_last_checked: storedLastChecked },
-      { bds_locale_update_last_checked: lastChecked },
-    );
-    if (metaUpdate) {
-      await deps.storage.set(metaUpdate);
+
+    const diff = computeDiff(stored, {
+      [STORAGE_KEY_LOCALES]: merged,
+      [STORAGE_KEY_LOCALE_CHECKED]: lastChecked,
+    });
+
+    if (diff) {
+      await deps.storage.set(diff);
     }
 
-    return { success: true };
-  } catch (e) {
-    return { success: false, error: e?.message };
+    return { success: true, writtenKeys: diff ? Object.keys(diff) : [] };
+  } catch (err) {
+    return { success: false, writtenKeys: [], error: err?.message || "Unknown error" };
   }
 }

--- a/src/lib/remote-persistence.js
+++ b/src/lib/remote-persistence.js
@@ -43,6 +43,10 @@ function computeDiff(stored, incoming) {
   return hasChanges ? diff : null;
 }
 
+function isObjectRoot(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
  * @typedef {{ success: boolean, writtenKeys: string[], error?: string }} PersistResult
  */
@@ -65,7 +69,7 @@ export async function persistRemoteConfig(deps, { now = Date.now() } = {}) {
 
     const config = await response.json();
     // Accept only non-array plain objects as remote-config roots.
-    if (!config || typeof config !== "object" || Array.isArray(config)) {
+    if (!isObjectRoot(config)) {
       return { success: false, writtenKeys: [], error: "Invalid config root" };
     }
 
@@ -151,7 +155,11 @@ export async function persistLocales(deps, localeCodes, { now = Date.now() } = {
         deps
           .fetch(`${LOCALE_BASE_URL}/${code}.json?t=${now}`, { cache: "no-store" })
           .then((r) => (r.ok ? r.json() : null))
-          .then((data) => (data?.messages ? { code, data } : null)),
+          .then((data) => (
+            isObjectRoot(data) && isObjectRoot(data.messages)
+              ? { code, data }
+              : null
+          )),
       ),
     );
 

--- a/src/lib/remote-persistence.js
+++ b/src/lib/remote-persistence.js
@@ -54,7 +54,7 @@ function computeDiff(stored, incoming) {
  * @param {{ now?: number }} [opts]
  * @returns {Promise<PersistResult>}
  */
-export async function persistRemoteConfig(deps, { now } = { now: Date.now() }) {
+export async function persistRemoteConfig(deps, { now = Date.now() } = {}) {
   try {
     const response = await deps.fetch(`${REMOTE_CONFIG_URL}?t=${now}`, {
       cache: "no-store",
@@ -100,7 +100,7 @@ export async function persistRemoteConfig(deps, { now } = { now: Date.now() }) {
  * @param {{ now?: number }} [opts]
  * @returns {Promise<PersistResult>}
  */
-export async function persistRemoteStatus(deps, { now } = { now: Date.now() }) {
+export async function persistRemoteStatus(deps, { now = Date.now() } = {}) {
   try {
     const response = await deps.fetch(`${REMOTE_STATUS_URL}?t=${now}`, {
       cache: "no-store",
@@ -144,7 +144,7 @@ export async function persistRemoteStatus(deps, { now } = { now: Date.now() }) {
  * @param {{ now?: number }} [opts]
  * @returns {Promise<PersistResult>}
  */
-export async function persistLocales(deps, localeCodes, { now } = { now: Date.now() }) {
+export async function persistLocales(deps, localeCodes, { now = Date.now() } = {}) {
   try {
     const results = await Promise.allSettled(
       localeCodes.map((code) =>
@@ -173,11 +173,19 @@ export async function persistLocales(deps, localeCodes, { now } = { now: Date.no
       STORAGE_KEY_LOCALES,
       STORAGE_KEY_LOCALE_CHECKED,
     ]);
-    const storedLocales = stored[STORAGE_KEY_LOCALES] || {};
+    // Normalize: stored root must be a non-array object
+    const raw = stored[STORAGE_KEY_LOCALES];
+    const storedLocales =
+      raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
 
-    // Merge: start from stored, overwrite with freshly fetched successes.
-    // Codes that failed to fetch keep their previous value.
-    const merged = { ...storedLocales, ...fetched };
+    // Merge: start from fresh successes. For each REQUESTED code that failed,
+    // preserve its previous stored value. Do NOT retain unrequested stale codes.
+    const merged = { ...fetched };
+    for (const code of localeCodes) {
+      if (!(code in fetched) && storedLocales[code]) {
+        merged[code] = storedLocales[code];
+      }
+    }
 
     const lastChecked = new Date(now).toLocaleDateString();
 

--- a/tests/e2e-firefox/extension.spec.js
+++ b/tests/e2e-firefox/extension.spec.js
@@ -43,16 +43,20 @@ describe("Firefox extension", () => {
     const { driver } = fx;
     const ts = Date.now();
 
-    // Init event counter
+    // Start extension-realm storage probe
+    await driver.executeScript(`
+      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+        detail: JSON.stringify({id:"fx-probe-start",method:"startStorageProbe",args:[]})
+      }));
+    `);
+
+    // Init page-level event counter
     await driver.executeScript(`
       window.__bdsTestEvents = { remoteConfigUpdated: 0 };
       window.addEventListener("bds:remote-config-updated", () => {
         window.__bdsTestEvents.remoteConfigUpdated++;
       });
     `);
-    const eventsBefore = await driver.executeScript(
-      "return window.__bdsTestEvents.remoteConfigUpdated;",
-    );
 
     // Unique replaceRemote
     await driver.executeScript(
@@ -66,15 +70,14 @@ describe("Firefox extension", () => {
     const afterFirst = await driver.executeScript(
       "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
-    // Exactly one new event
-    expect(afterFirst).toBe(eventsBefore + 1);
+    expect(afterFirst).toBe(1);
 
-    // Idle window — count must remain stable (no background writes)
+    // Idle window — count must remain stable
     await driver.sleep(500);
     const afterIdle = await driver.executeScript(
       "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
-    expect(afterIdle).toBe(afterFirst);
+    expect(afterIdle).toBe(1);
 
     // Identical replacement — zero additional events
     await driver.executeScript(
@@ -88,108 +91,93 @@ describe("Firefox extension", () => {
     const afterRepeat = await driver.executeScript(
       "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
-    expect(afterRepeat).toBe(afterFirst);
+    expect(afterRepeat).toBe(1);
+
+    // Verify storage probe: exactly 1 remoteConfig event
+    const probeResult = await driver.executeScript(`
+      return new Promise(function(resolve) {
+        var handler = function(e) {
+          var detail = e.detail;
+          if (typeof detail === "string") detail = JSON.parse(detail);
+          if (detail.id === "fx-probe-get") { window.removeEventListener("bds:debug-api-response", handler); resolve(detail.result); }
+        };
+        window.addEventListener("bds:debug-api-response", handler);
+        window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+          detail: JSON.stringify({id:"fx-probe-get",method:"getStorageProbe",args:[]})
+        }));
+      });
+    `);
+
+    expect(probeResult).toBeTruthy();
+    expect(probeResult.remoteConfig).toBe(1);
+
+    // Stop probe
+    await driver.executeScript(`
+      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+        detail: JSON.stringify({id:"fx-probe-stop",method:"stopStorageProbe",args:[]})
+      }));
+    `);
   });
 
   // ── Contract 3: Performance (#105 fix) ──
   it("processes messages within time bounds at 200 and 2000 scale", async () => {
     const { driver } = fx;
-    const samples = { small: [], large: [] };
+    const median = (arr) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; };
 
-    // Baseline: 200 messages, verify settlement
+    // 200 baseline
     await driver.executeScript("window.__mockDeepSeek.clearMessages();");
     await driver.executeScript("window.__mockDeepSeek.seedMessages(200);");
-
-    // Wait until every message has data-bds-msg-id (proves processing settled)
-    await driver.sleep(3000);
-    const settled200 = await driver.executeScript(`
-      var msgs = document.querySelectorAll(".ds-message");
-      for (var i = 0; i < msgs.length; i++) {
-        if (!msgs[i].getAttribute("data-bds-msg-id")) return false;
-      }
-      return msgs.length;
-    `);
+    const settled200 = await driver.executeScript(
+      "return window.__mockDeepSeek.waitForAllMessagesProcessed(200, 30000);",
+    );
     expect(settled200).toBe(200);
 
-    // 5 timing samples at 200
+    const smallSamples = [];
     for (let i = 0; i < 5; i++) {
-      const start = Date.now();
-      await driver.executeScript(
-        'window.__mockDeepSeek.addAssistantMessage("Firefox timing sample " + ' + i + ');',
+      const result = await driver.executeScript(
+        "return window.__mockDeepSeek.appendAndMeasureProcessing('Firefox timing sample " + i + "', 5000);",
       );
-      // Wait for processing — poll for data-bds-msg-id on the new message
-      await driver.sleep(500);
-      const done = await driver.executeScript(`
-        var msgs = document.querySelectorAll(".ds-message");
-        var last = msgs[msgs.length - 1];
-        return !!(last && last.getAttribute("data-bds-msg-id"));
-      `);
-      const elapsed = Date.now() - start;
-      if (done) samples.small.push(elapsed);
-      // Each sample must complete within 2 seconds
-      expect(elapsed).toBeLessThan(2000);
+      smallSamples.push(result.duration);
+      expect(result.duration).toBeLessThan(2000);
     }
-    expect(samples.small.length).toBeGreaterThanOrEqual(3);
+    expect(smallSamples).toHaveLength(5);
 
-    // Scale to 2000
+    // 2000 baseline
     await driver.executeScript("window.__mockDeepSeek.clearMessages();");
     await driver.executeScript("window.__mockDeepSeek.seedMessages(2000);");
-
-    await driver.sleep(5000);
-    const settled2000 = await driver.executeScript(`
-      var msgs = document.querySelectorAll(".ds-message");
-      for (var i = 0; i < msgs.length; i++) {
-        if (!msgs[i].getAttribute("data-bds-msg-id")) return false;
-      }
-      return msgs.length;
-    `);
+    const settled2000 = await driver.executeScript(
+      "return window.__mockDeepSeek.waitForAllMessagesProcessed(2000, 60000);",
+    );
     expect(settled2000).toBe(2000);
 
-    // 5 timing samples at 2000
+    const largeSamples = [];
     for (let i = 0; i < 5; i++) {
-      const start = Date.now();
-      await driver.executeScript(
-        'window.__mockDeepSeek.addAssistantMessage("Firefox large sample " + ' + i + ');',
+      const result = await driver.executeScript(
+        "return window.__mockDeepSeek.appendAndMeasureProcessing('Firefox large sample " + i + "', 5000);",
       );
-      await driver.sleep(500);
-      const done = await driver.executeScript(`
-        var msgs = document.querySelectorAll(".ds-message");
-        var last = msgs[msgs.length - 1];
-        return !!(last && last.getAttribute("data-bds-msg-id"));
-      `);
-      const elapsed = Date.now() - start;
-      if (done) samples.large.push(elapsed);
-      expect(elapsed).toBeLessThan(2000);
+      largeSamples.push(result.duration);
+      expect(result.duration).toBeLessThan(2000);
     }
-    expect(samples.large.length).toBeGreaterThanOrEqual(3);
+    expect(largeSamples).toHaveLength(5);
 
-    // Performance ratios
-    const median = (arr) => {
-      const sorted = [...arr].sort((a, b) => a - b);
-      return sorted[Math.floor(sorted.length / 2)];
-    };
-    const smallMed = median(samples.small);
-    const largeMed = median(samples.large);
-    expect(largeMed).toBeLessThanOrEqual(smallMed * 2.5);
-    expect(largeMed - smallMed).toBeLessThanOrEqual(750);
-  }, 60000);
+    expect(median(largeSamples)).toBeLessThanOrEqual(median(smallSamples) * 2.5);
+    expect(median(largeSamples) - median(smallSamples)).toBeLessThanOrEqual(750);
+  }, 120000);
 
   // ── Contract 4: Host wrapper box model ──
   it("renders create_file download card in host wrapper with block-level box", async () => {
     const { driver } = fx;
     await driver.executeScript("window.__mockDeepSeek.clearMessages();");
 
-    // Add a real create_file message that produces .bds-download-card
     await driver.executeScript(`
       window.__mockDeepSeek.addAssistantMessage(
         '<BDS:CREATE_FILE fileName="test-firefox.txt">\\nHello Firefox E2E\\n</BDS:CREATE_FILE>'
       );
     `);
 
-    // Wait for parsing + overlay rendering
+    // Await download card observably
     await driver.sleep(3000);
 
-    // Must find download card inside host wrapper
     const card = await driver.findElement({ css: ".bds-download-card" });
     expect(card).toBeTruthy();
 
@@ -201,6 +189,7 @@ describe("Firefox extension", () => {
       wrapper,
     );
     expect(rect.w).toBeGreaterThan(0);
+    expect(rect.h).toBeGreaterThan(0);
 
     const display = await wrapper.getCssValue("display");
     expect(display).not.toBe("contents");

--- a/tests/e2e-firefox/extension.spec.js
+++ b/tests/e2e-firefox/extension.spec.js
@@ -2,90 +2,59 @@
  * Firefox E2E contracts — built-extension verification through Selenium + BiDi.
  *
  * Contracts:
- *   1. Extension boots on the deterministic fixture and exposes primary controls.
- *   2. A unique replaceRemote produces exactly one bds:remote-config-updated event
- *      over 750 ms; repeating the identical replacement produces zero additional events.
- *   3. With 2,000 settled messages, a newly appended message gains data-bds-msg-id.
- *   4. The message-host wrapper has nonzero box, is not display:contents, and
- *      retains sibling hosts when another host is removed.
- *
- * These tests require BiDi network interception to work (depends on Firefox +
- * Selenium WebDriver version pairing). When BiDi isn't functional, tests
- * skip with a diagnostic message.
+ *   1. Extension boots and exposes primary controls.
+ *   2. Storage quiescence: one unique replaceRemote → exactly 1 event;
+ *      identical repeat → 0 more events; idle window → stable count.
+ *   3. Performance: 200-msg baseline, 2000-msg scale. Every append < 2 s,
+ *      median ratio ≤ 2.5×, absolute increase ≤ 750 ms.
+ *   4. Host wrapper: real create_file message produces .bds-download-card
+ *      inside .bds-host-wrapper with block-level, nonzero box.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createFirefoxFixture } from "./helpers/firefox-fixture.js";
 
 describe("Firefox extension", () => {
-  /** @type {Awaited<ReturnType<typeof createFirefoxFixture>>} */
   let fx;
-  let fixtureReady = false;
 
   beforeAll(async () => {
-    try {
-      fx = await createFirefoxFixture();
-      // Verify the fixture loaded correctly by checking for the mock page structure
-      const html = await fx.getPageHtml();
-      if (html.includes('id="chat-messages"')) {
-        fixtureReady = true;
-      } else {
-        console.warn(
-          "[Firefox E2E] BiDi interception did not serve the mock fixture. " +
-          "The page shows: " + (html.match(/<title>([^<]*)<\/title>/) || [])[1] +
-          ". Skipping Firefox contracts. This is expected if BiDi is not fully " +
-          "supported in your Firefox + Selenium WebDriver version.",
-        );
-      }
-    } catch (e) {
-      console.warn("[Firefox E2E] Fixture setup failed:", e.message);
-    }
-  }, 45000);
+    fx = await createFirefoxFixture();
+  }, 60000);
 
   afterAll(async () => {
     if (fx) {
-      try { await fx.close(); } catch { /* Firefox may have exited */ }
+      const err = fx.getFixtureError();
+      try { await fx.close(); } catch { /* ignore */ }
+      if (err) throw err;
     }
   }, 15000);
 
   // ── Contract 1: Extension boots ──
   it("boots on the fixture and exposes primary controls", async () => {
-    if (!fixtureReady) {
-      console.warn("  Skipped: BiDi fixture not loaded");
-      return;
-    }
-    const { driver } = fx;
+    const toggle = await fx.driver.findElement({ css: "#bds-toggle" });
+    expect(await toggle.isDisplayed()).toBe(true);
 
-    const toggle = await driver.findElement({ css: "#bds-toggle" });
-    expect(toggle).toBeTruthy();
-    const displayed = await toggle.isDisplayed();
-    expect(displayed).toBe(true);
+    const plusBtn = await fx.driver.findElement({ css: ".bds-plus-btn" });
+    expect(plusBtn).toBeTruthy();
   });
 
   // ── Contract 2: Storage quiescence (#108 fix) ──
-  it("produces exactly one config-updated event for unique replaceRemote, zero for identical repeat", async () => {
-    if (!fixtureReady) {
-      console.warn("  Skipped: BiDi fixture not loaded");
-      return;
-    }
+  it("produces exactly one config-updated event, zero for identical repeat, stable during idle", async () => {
     const { driver } = fx;
+    const ts = Date.now();
 
-    // Set up event counter
+    // Init event counter
     await driver.executeScript(`
-      if (!window.__bdsTestEvents) {
-        window.__bdsTestEvents = { remoteConfigUpdated: 0 };
-        window.addEventListener("bds:remote-config-updated", () => {
-          window.__bdsTestEvents.remoteConfigUpdated++;
-        });
-      }
+      window.__bdsTestEvents = { remoteConfigUpdated: 0 };
+      window.addEventListener("bds:remote-config-updated", () => {
+        window.__bdsTestEvents.remoteConfigUpdated++;
+      });
     `);
-
     const eventsBefore = await driver.executeScript(
-      "return window.__bdsTestEvents ? window.__bdsTestEvents.remoteConfigUpdated : 0;",
+      "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
 
-    // Unique replaceRemote via debug API
-    const ts = Date.now();
+    // Unique replaceRemote
     await driver.executeScript(
       `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
         detail: JSON.stringify({id:"fx-1",method:"replaceRemote",
@@ -97,9 +66,17 @@ describe("Firefox extension", () => {
     const afterFirst = await driver.executeScript(
       "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
-    expect(afterFirst).toBeGreaterThanOrEqual(eventsBefore + 1);
+    // Exactly one new event
+    expect(afterFirst).toBe(eventsBefore + 1);
 
-    // Identical repeat → zero additional events
+    // Idle window — count must remain stable (no background writes)
+    await driver.sleep(500);
+    const afterIdle = await driver.executeScript(
+      "return window.__bdsTestEvents.remoteConfigUpdated;",
+    );
+    expect(afterIdle).toBe(afterFirst);
+
+    // Identical replacement — zero additional events
     await driver.executeScript(
       `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
         detail: JSON.stringify({id:"fx-2",method:"replaceRemote",
@@ -111,81 +88,121 @@ describe("Firefox extension", () => {
     const afterRepeat = await driver.executeScript(
       "return window.__bdsTestEvents.remoteConfigUpdated;",
     );
-    // The duplicate should not have incremented the counter
     expect(afterRepeat).toBe(afterFirst);
   });
 
-  // ── Contract 3: 2000-message processing (#105 fix) ──
-  it("processes a newly appended message after seeding 2000 settled messages", async () => {
-    if (!fixtureReady) {
-      console.warn("  Skipped: BiDi fixture not loaded");
-      return;
-    }
+  // ── Contract 3: Performance (#105 fix) ──
+  it("processes messages within time bounds at 200 and 2000 scale", async () => {
     const { driver } = fx;
+    const samples = { small: [], large: [] };
 
-    const seeded = await driver.executeScript(
-      "return window.__mockDeepSeek ? window.__mockDeepSeek.seedMessages(2000) : 0;",
-    );
-    if (seeded === 0) {
-      console.warn("  Skipped: __mockDeepSeek not injected (BiDi inline script limitation)");
-      return;
+    // Baseline: 200 messages, verify settlement
+    await driver.executeScript("window.__mockDeepSeek.clearMessages();");
+    await driver.executeScript("window.__mockDeepSeek.seedMessages(200);");
+
+    // Wait until every message has data-bds-msg-id (proves processing settled)
+    await driver.sleep(3000);
+    const settled200 = await driver.executeScript(`
+      var msgs = document.querySelectorAll(".ds-message");
+      for (var i = 0; i < msgs.length; i++) {
+        if (!msgs[i].getAttribute("data-bds-msg-id")) return false;
+      }
+      return msgs.length;
+    `);
+    expect(settled200).toBe(200);
+
+    // 5 timing samples at 200
+    for (let i = 0; i < 5; i++) {
+      const start = Date.now();
+      await driver.executeScript(
+        'window.__mockDeepSeek.addAssistantMessage("Firefox timing sample " + ' + i + ');',
+      );
+      // Wait for processing — poll for data-bds-msg-id on the new message
+      await driver.sleep(500);
+      const done = await driver.executeScript(`
+        var msgs = document.querySelectorAll(".ds-message");
+        var last = msgs[msgs.length - 1];
+        return !!(last && last.getAttribute("data-bds-msg-id"));
+      `);
+      const elapsed = Date.now() - start;
+      if (done) samples.small.push(elapsed);
+      // Each sample must complete within 2 seconds
+      expect(elapsed).toBeLessThan(2000);
     }
+    expect(samples.small.length).toBeGreaterThanOrEqual(3);
 
-    await driver.sleep(2000);
+    // Scale to 2000
+    await driver.executeScript("window.__mockDeepSeek.clearMessages();");
+    await driver.executeScript("window.__mockDeepSeek.seedMessages(2000);");
 
-    await driver.executeScript(
-      'window.__mockDeepSeek.addAssistantMessage("Firefox E2E: incremental after 2000 messages.");',
-    );
-    await driver.sleep(1500);
+    await driver.sleep(5000);
+    const settled2000 = await driver.executeScript(`
+      var msgs = document.querySelectorAll(".ds-message");
+      for (var i = 0; i < msgs.length; i++) {
+        if (!msgs[i].getAttribute("data-bds-msg-id")) return false;
+      }
+      return msgs.length;
+    `);
+    expect(settled2000).toBe(2000);
 
-    const msgs = await driver.findElements({ css: ".ds-message" });
-    if (msgs.length === 0) return; // Can't verify without messages
-    const lastMsg = msgs[msgs.length - 1];
-    const msgId = await lastMsg.getAttribute("data-bds-msg-id");
-    expect(msgId).toBeTruthy();
-  }, 45000);
-
-  // ── Contract 4: Extension UI box model ──
-  it("extension root has proper box model and is connected", async () => {
-    if (!fixtureReady) {
-      console.warn("  Skipped: BiDi fixture not loaded");
-      return;
+    // 5 timing samples at 2000
+    for (let i = 0; i < 5; i++) {
+      const start = Date.now();
+      await driver.executeScript(
+        'window.__mockDeepSeek.addAssistantMessage("Firefox large sample " + ' + i + ');',
+      );
+      await driver.sleep(500);
+      const done = await driver.executeScript(`
+        var msgs = document.querySelectorAll(".ds-message");
+        var last = msgs[msgs.length - 1];
+        return !!(last && last.getAttribute("data-bds-msg-id"));
+      `);
+      const elapsed = Date.now() - start;
+      if (done) samples.large.push(elapsed);
+      expect(elapsed).toBeLessThan(2000);
     }
+    expect(samples.large.length).toBeGreaterThanOrEqual(3);
+
+    // Performance ratios
+    const median = (arr) => {
+      const sorted = [...arr].sort((a, b) => a - b);
+      return sorted[Math.floor(sorted.length / 2)];
+    };
+    const smallMed = median(samples.small);
+    const largeMed = median(samples.large);
+    expect(largeMed).toBeLessThanOrEqual(smallMed * 2.5);
+    expect(largeMed - smallMed).toBeLessThanOrEqual(750);
+  }, 60000);
+
+  // ── Contract 4: Host wrapper box model ──
+  it("renders create_file download card in host wrapper with block-level box", async () => {
     const { driver } = fx;
+    await driver.executeScript("window.__mockDeepSeek.clearMessages();");
 
-    // Verify #bds-root has proper layout (not display:contents, nonzero box)
-    const rootInfo = await driver.executeScript(`
-      var root = document.querySelector("#bds-root");
-      if (!root) return null;
-      var cs = getComputedStyle(root);
-      var r = root.getBoundingClientRect();
-      return {
-        display: cs.display,
-        width: r.width,
-        height: r.height,
-        position: cs.position,
-        isConnected: root.isConnected,
-      };
+    // Add a real create_file message that produces .bds-download-card
+    await driver.executeScript(`
+      window.__mockDeepSeek.addAssistantMessage(
+        '<BDS:CREATE_FILE fileName="test-firefox.txt">\\nHello Firefox E2E\\n</BDS:CREATE_FILE>'
+      );
     `);
 
-    expect(rootInfo).toBeTruthy();
-    // #bds-root is fixed-position, should have dimensions
-    expect(rootInfo.isConnected).toBe(true);
-    expect(rootInfo.position).toBe("fixed");
+    // Wait for parsing + overlay rendering
+    await driver.sleep(3000);
 
-    // Verify any bds-host-wrapper elements have proper box
-    const wrapperInfo = await driver.executeScript(`
-      var wrappers = document.querySelectorAll(".bds-host-wrapper");
-      if (!wrappers.length) return "none";
-      var w = wrappers[wrappers.length - 1];
-      var cs = getComputedStyle(w);
-      return { display: cs.display, width: w.getBoundingClientRect().width };
-    `);
+    // Must find download card inside host wrapper
+    const card = await driver.findElement({ css: ".bds-download-card" });
+    expect(card).toBeTruthy();
 
-    if (wrapperInfo !== "none") {
-      // If wrappers exist, they must have nonzero width
-      expect(wrapperInfo.width).toBeGreaterThan(0);
-    }
-    // No wrappers is acceptable — depends on message processing pipeline
+    const wrapper = await driver.findElement({ css: ".bds-host-wrapper" });
+    expect(wrapper).toBeTruthy();
+
+    const rect = await driver.executeScript(
+      "var r = arguments[0].getBoundingClientRect(); return { w: r.width, h: r.height };",
+      wrapper,
+    );
+    expect(rect.w).toBeGreaterThan(0);
+
+    const display = await wrapper.getCssValue("display");
+    expect(display).not.toBe("contents");
   });
 });

--- a/tests/e2e-firefox/extension.spec.js
+++ b/tests/e2e-firefox/extension.spec.js
@@ -1,0 +1,191 @@
+/**
+ * Firefox E2E contracts — built-extension verification through Selenium + BiDi.
+ *
+ * Contracts:
+ *   1. Extension boots on the deterministic fixture and exposes primary controls.
+ *   2. A unique replaceRemote produces exactly one bds:remote-config-updated event
+ *      over 750 ms; repeating the identical replacement produces zero additional events.
+ *   3. With 2,000 settled messages, a newly appended message gains data-bds-msg-id.
+ *   4. The message-host wrapper has nonzero box, is not display:contents, and
+ *      retains sibling hosts when another host is removed.
+ *
+ * These tests require BiDi network interception to work (depends on Firefox +
+ * Selenium WebDriver version pairing). When BiDi isn't functional, tests
+ * skip with a diagnostic message.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createFirefoxFixture } from "./helpers/firefox-fixture.js";
+
+describe("Firefox extension", () => {
+  /** @type {Awaited<ReturnType<typeof createFirefoxFixture>>} */
+  let fx;
+  let fixtureReady = false;
+
+  beforeAll(async () => {
+    try {
+      fx = await createFirefoxFixture();
+      // Verify the fixture loaded correctly by checking for the mock page structure
+      const html = await fx.getPageHtml();
+      if (html.includes('id="chat-messages"')) {
+        fixtureReady = true;
+      } else {
+        console.warn(
+          "[Firefox E2E] BiDi interception did not serve the mock fixture. " +
+          "The page shows: " + (html.match(/<title>([^<]*)<\/title>/) || [])[1] +
+          ". Skipping Firefox contracts. This is expected if BiDi is not fully " +
+          "supported in your Firefox + Selenium WebDriver version.",
+        );
+      }
+    } catch (e) {
+      console.warn("[Firefox E2E] Fixture setup failed:", e.message);
+    }
+  }, 45000);
+
+  afterAll(async () => {
+    if (fx) {
+      try { await fx.close(); } catch { /* Firefox may have exited */ }
+    }
+  }, 15000);
+
+  // ── Contract 1: Extension boots ──
+  it("boots on the fixture and exposes primary controls", async () => {
+    if (!fixtureReady) {
+      console.warn("  Skipped: BiDi fixture not loaded");
+      return;
+    }
+    const { driver } = fx;
+
+    const toggle = await driver.findElement({ css: "#bds-toggle" });
+    expect(toggle).toBeTruthy();
+    const displayed = await toggle.isDisplayed();
+    expect(displayed).toBe(true);
+  });
+
+  // ── Contract 2: Storage quiescence (#108 fix) ──
+  it("produces exactly one config-updated event for unique replaceRemote, zero for identical repeat", async () => {
+    if (!fixtureReady) {
+      console.warn("  Skipped: BiDi fixture not loaded");
+      return;
+    }
+    const { driver } = fx;
+
+    // Set up event counter
+    await driver.executeScript(`
+      if (!window.__bdsTestEvents) {
+        window.__bdsTestEvents = { remoteConfigUpdated: 0 };
+        window.addEventListener("bds:remote-config-updated", () => {
+          window.__bdsTestEvents.remoteConfigUpdated++;
+        });
+      }
+    `);
+
+    const eventsBefore = await driver.executeScript(
+      "return window.__bdsTestEvents ? window.__bdsTestEvents.remoteConfigUpdated : 0;",
+    );
+
+    // Unique replaceRemote via debug API
+    const ts = Date.now();
+    await driver.executeScript(
+      `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+        detail: JSON.stringify({id:"fx-1",method:"replaceRemote",
+        args:[{features:{testFirefox:true,ts:${ts}}}]})
+      }));`,
+    );
+    await driver.sleep(750);
+
+    const afterFirst = await driver.executeScript(
+      "return window.__bdsTestEvents.remoteConfigUpdated;",
+    );
+    expect(afterFirst).toBeGreaterThanOrEqual(eventsBefore + 1);
+
+    // Identical repeat → zero additional events
+    await driver.executeScript(
+      `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+        detail: JSON.stringify({id:"fx-2",method:"replaceRemote",
+        args:[{features:{testFirefox:true,ts:${ts}}}]})
+      }));`,
+    );
+    await driver.sleep(750);
+
+    const afterRepeat = await driver.executeScript(
+      "return window.__bdsTestEvents.remoteConfigUpdated;",
+    );
+    // The duplicate should not have incremented the counter
+    expect(afterRepeat).toBe(afterFirst);
+  });
+
+  // ── Contract 3: 2000-message processing (#105 fix) ──
+  it("processes a newly appended message after seeding 2000 settled messages", async () => {
+    if (!fixtureReady) {
+      console.warn("  Skipped: BiDi fixture not loaded");
+      return;
+    }
+    const { driver } = fx;
+
+    const seeded = await driver.executeScript(
+      "return window.__mockDeepSeek ? window.__mockDeepSeek.seedMessages(2000) : 0;",
+    );
+    if (seeded === 0) {
+      console.warn("  Skipped: __mockDeepSeek not injected (BiDi inline script limitation)");
+      return;
+    }
+
+    await driver.sleep(2000);
+
+    await driver.executeScript(
+      'window.__mockDeepSeek.addAssistantMessage("Firefox E2E: incremental after 2000 messages.");',
+    );
+    await driver.sleep(1500);
+
+    const msgs = await driver.findElements({ css: ".ds-message" });
+    if (msgs.length === 0) return; // Can't verify without messages
+    const lastMsg = msgs[msgs.length - 1];
+    const msgId = await lastMsg.getAttribute("data-bds-msg-id");
+    expect(msgId).toBeTruthy();
+  }, 45000);
+
+  // ── Contract 4: Extension UI box model ──
+  it("extension root has proper box model and is connected", async () => {
+    if (!fixtureReady) {
+      console.warn("  Skipped: BiDi fixture not loaded");
+      return;
+    }
+    const { driver } = fx;
+
+    // Verify #bds-root has proper layout (not display:contents, nonzero box)
+    const rootInfo = await driver.executeScript(`
+      var root = document.querySelector("#bds-root");
+      if (!root) return null;
+      var cs = getComputedStyle(root);
+      var r = root.getBoundingClientRect();
+      return {
+        display: cs.display,
+        width: r.width,
+        height: r.height,
+        position: cs.position,
+        isConnected: root.isConnected,
+      };
+    `);
+
+    expect(rootInfo).toBeTruthy();
+    // #bds-root is fixed-position, should have dimensions
+    expect(rootInfo.isConnected).toBe(true);
+    expect(rootInfo.position).toBe("fixed");
+
+    // Verify any bds-host-wrapper elements have proper box
+    const wrapperInfo = await driver.executeScript(`
+      var wrappers = document.querySelectorAll(".bds-host-wrapper");
+      if (!wrappers.length) return "none";
+      var w = wrappers[wrappers.length - 1];
+      var cs = getComputedStyle(w);
+      return { display: cs.display, width: w.getBoundingClientRect().width };
+    `);
+
+    if (wrapperInfo !== "none") {
+      // If wrappers exist, they must have nonzero width
+      expect(wrapperInfo.width).toBeGreaterThan(0);
+    }
+    // No wrappers is acceptable — depends on message processing pipeline
+  });
+});

--- a/tests/e2e-firefox/extension.spec.js
+++ b/tests/e2e-firefox/extension.spec.js
@@ -8,7 +8,9 @@
  *   4. Host wrapper: .bds-download-card inside .bds-host-wrapper, block-level, nonzero.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { createFirefoxFixture } from "./helpers/firefox-fixture.js";
 
 describe("Firefox extension", () => {
@@ -25,6 +27,17 @@ describe("Firefox extension", () => {
     await fx.close();
     if (err) throw err;
   }, 15000);
+
+  afterEach(async (context) => {
+    if (!fx || context.task.result?.state !== "fail") return;
+    const outputDir = path.resolve("test-results-firefox");
+    const stem = context.task.name.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "").toLowerCase();
+    fs.mkdirSync(outputDir, { recursive: true });
+    try { await fx.takeScreenshot(path.join(outputDir, `${stem}.png`)); } catch {}
+    try {
+      fs.writeFileSync(path.join(outputDir, `${stem}.html`), await fx.getPageHtml(), "utf8");
+    } catch {}
+  });
 
   // Shared correlated debug request helper
   async function debugRequest(driver, id, method, args = []) {
@@ -48,6 +61,27 @@ describe("Firefox extension", () => {
     );
   }
 
+  async function waitForStorageQuiet(driver, label, quietMs = 250, timeoutMs = 5000) {
+    const startedAt = Date.now();
+    let last = await debugRequest(driver, `${label}-initial`, "getStorageProbe");
+    let stableSince = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      await driver.sleep(50);
+      const current = await debugRequest(driver, `${label}-${Date.now()}`, "getStorageProbe");
+      if (
+        current.total !== last.total ||
+        current.remoteConfig !== last.remoteConfig ||
+        current.events.length !== last.events.length
+      ) {
+        last = current;
+        stableSince = Date.now();
+      } else if (Date.now() - stableSince >= quietMs) {
+        return current;
+      }
+    }
+    throw new Error(`Storage did not become quiet within ${timeoutMs}ms`);
+  }
+
   it("boots on the fixture and exposes primary controls", async () => {
     const healthy = await fx.isDriverHealthy();
     expect(healthy).toBe(true);
@@ -64,46 +98,58 @@ describe("Firefox extension", () => {
     const ts = Date.now();
 
     try {
+      const startup = await debugRequest(driver, "startup-ready", "waitForStartup");
+      expect(startup, JSON.stringify(startup)).toMatchObject({ success: true });
+      await debugRequest(driver, "startup-probe-start", "startStorageProbe");
+      const startupProbe = await waitForStorageQuiet(driver, "startup-quiet");
+      expect(startupProbe.total).toBe(0);
+      expect(startupProbe.remoteConfig).toBe(0);
+      await debugRequest(driver, "startup-probe-stop", "stopStorageProbe");
+
       // Start the storage probe
       await debugRequest(driver, "probe-start", "startStorageProbe");
 
       // Init page-level event counter
       await driver.executeScript(`
-        window.__bdsFfEvents = { remoteConfigUpdated: 0 };
-        window.addEventListener("bds:remote-config-updated", () => {
-          window.__bdsFfEvents.remoteConfigUpdated++;
-        });
+        var listener = function() { window.__bdsFfEvents.remoteConfigUpdated += 1; };
+        window.__bdsFfEvents = { remoteConfigUpdated: 0, listener: listener };
+        window.addEventListener("bds:remote-config-updated", listener);
       `);
 
       // Unique replaceRemote
       await debugRequest(driver, "fx-1", "replaceRemote", [{ features: { testFirefox: true, ts } }]);
-      await driver.sleep(300);
+      const probe1 = await waitForStorageQuiet(driver, "first-write");
 
       const afterFirst = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
       expect(afterFirst).toBe(1);
 
       // Verify probe: exactly 1 total event, 1 remoteConfig event
-      const probe1 = await debugRequest(driver, "probe-get-1", "getStorageProbe");
       expect(probe1.total).toBe(1);
       expect(probe1.remoteConfig).toBe(1);
 
       // Idle window — counts must remain stable
-      await driver.sleep(500);
+      const idleProbe = await waitForStorageQuiet(driver, "idle-stability");
+      expect(idleProbe).toEqual(probe1);
       const afterIdle = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
       expect(afterIdle).toBe(1);
 
       // Identical replacement with reordered keys — zero additional events
       await debugRequest(driver, "fx-2", "replaceRemote", [{ features: { ts, testFirefox: true } }]);
-      await driver.sleep(500);
+      const probe2 = await waitForStorageQuiet(driver, "identical-repeat");
 
       const afterRepeat = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
       expect(afterRepeat).toBe(1);
 
-      const probe2 = await debugRequest(driver, "probe-get-2", "getStorageProbe");
       expect(probe2.total).toBe(1);
+      expect(probe2.remoteConfig).toBe(1);
     } finally {
       await debugRequest(driver, "probe-stop", "stopStorageProbe");
-      await driver.executeScript("window.__bdsFfEvents = null;");
+      await driver.executeScript(`
+        if (window.__bdsFfEvents && window.__bdsFfEvents.listener) {
+          window.removeEventListener("bds:remote-config-updated", window.__bdsFfEvents.listener);
+        }
+        window.__bdsFfEvents = null;
+      `);
     }
   });
 
@@ -171,24 +217,25 @@ describe("Firefox extension", () => {
     );
     expect(card).toBeTruthy();
 
-    const wrapper = await driver.findElement({ css: ".bds-host-wrapper" });
-    expect(wrapper).toBeTruthy();
-
-    // Card must be a descendant of the wrapper
-    const isDescendant = await driver.executeScript(
-      "return arguments[0].contains(arguments[1]);",
-      wrapper, card,
-    );
-    expect(isDescendant).toBe(true);
-
-    const rect = await driver.executeScript(
-      "var r = arguments[0].getBoundingClientRect(); return { w: r.width, h: r.height };",
-      wrapper,
-    );
-    expect(rect.w).toBeGreaterThan(0);
-    expect(rect.h).toBeGreaterThan(0);
-
-    const display = await wrapper.getCssValue("display");
-    expect(display).not.toBe("contents");
+    const hostContract = await driver.executeScript(`
+      var card = arguments[0];
+      var wrapper = card.closest(".bds-host-wrapper");
+      var message = wrapper && wrapper.previousElementSibling;
+      var rect = wrapper && wrapper.getBoundingClientRect();
+      return {
+        hasWrapper: !!wrapper,
+        adjacentToMessage: !!(message && message.classList.contains("ds-message")),
+        ownsExpectedMessage: !!(message && message.textContent.includes("Hello Firefox E2E")),
+        display: wrapper ? getComputedStyle(wrapper).display : null,
+        w: rect ? rect.width : 0,
+        h: rect ? rect.height : 0
+      };
+    `, card);
+    expect(hostContract.hasWrapper).toBe(true);
+    expect(hostContract.adjacentToMessage).toBe(true);
+    expect(hostContract.ownsExpectedMessage).toBe(true);
+    expect(hostContract.display).not.toBe("contents");
+    expect(hostContract.w).toBeGreaterThan(0);
+    expect(hostContract.h).toBeGreaterThan(0);
   });
 });

--- a/tests/e2e-firefox/extension.spec.js
+++ b/tests/e2e-firefox/extension.spec.js
@@ -3,12 +3,9 @@
  *
  * Contracts:
  *   1. Extension boots and exposes primary controls.
- *   2. Storage quiescence: one unique replaceRemote → exactly 1 event;
- *      identical repeat → 0 more events; idle window → stable count.
- *   3. Performance: 200-msg baseline, 2000-msg scale. Every append < 2 s,
- *      median ratio ≤ 2.5×, absolute increase ≤ 750 ms.
- *   4. Host wrapper: real create_file message produces .bds-download-card
- *      inside .bds-host-wrapper with block-level, nonzero box.
+ *   2. Storage quiescence (#108): probe-based, correlation-ID awaited, total===1.
+ *   3. Performance (#105): observable append timing.
+ *   4. Host wrapper: .bds-download-card inside .bds-host-wrapper, block-level, nonzero.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
@@ -22,15 +19,39 @@ describe("Firefox extension", () => {
   }, 60000);
 
   afterAll(async () => {
-    if (fx) {
-      const err = fx.getFixtureError();
-      try { await fx.close(); } catch { /* ignore */ }
-      if (err) throw err;
-    }
+    if (!fx) return;
+    const err = fx.getFixtureError();
+    // Don't catch close errors — must propagate
+    await fx.close();
+    if (err) throw err;
   }, 15000);
 
-  // ── Contract 1: Extension boots ──
+  // Shared correlated debug request helper
+  async function debugRequest(driver, id, method, args = []) {
+    return driver.executeScript(
+      `return new Promise((resolve, reject) => {
+        var timeout = setTimeout(() => reject(new Error("debugRequest ${id} timed out")), 10000);
+        var handler = function(e) {
+          var detail = e.detail;
+          if (typeof detail === "string") detail = JSON.parse(detail);
+          if (detail.id === "${id}") {
+            clearTimeout(timeout);
+            window.removeEventListener("bds:debug-api-response", handler);
+            resolve(detail.result);
+          }
+        };
+        window.addEventListener("bds:debug-api-response", handler);
+        window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+          detail: JSON.stringify({id:"${id}",method:"${method}",args:${JSON.stringify(args)}})
+        }));
+      });`
+    );
+  }
+
   it("boots on the fixture and exposes primary controls", async () => {
+    const healthy = await fx.isDriverHealthy();
+    expect(healthy).toBe(true);
+
     const toggle = await fx.driver.findElement({ css: "#bds-toggle" });
     expect(await toggle.isDisplayed()).toBe(true);
 
@@ -38,88 +59,54 @@ describe("Firefox extension", () => {
     expect(plusBtn).toBeTruthy();
   });
 
-  // ── Contract 2: Storage quiescence (#108 fix) ──
   it("produces exactly one config-updated event, zero for identical repeat, stable during idle", async () => {
     const { driver } = fx;
     const ts = Date.now();
 
-    // Start extension-realm storage probe
-    await driver.executeScript(`
-      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-        detail: JSON.stringify({id:"fx-probe-start",method:"startStorageProbe",args:[]})
-      }));
-    `);
+    try {
+      // Start the storage probe
+      await debugRequest(driver, "probe-start", "startStorageProbe");
 
-    // Init page-level event counter
-    await driver.executeScript(`
-      window.__bdsTestEvents = { remoteConfigUpdated: 0 };
-      window.addEventListener("bds:remote-config-updated", () => {
-        window.__bdsTestEvents.remoteConfigUpdated++;
-      });
-    `);
+      // Init page-level event counter
+      await driver.executeScript(`
+        window.__bdsFfEvents = { remoteConfigUpdated: 0 };
+        window.addEventListener("bds:remote-config-updated", () => {
+          window.__bdsFfEvents.remoteConfigUpdated++;
+        });
+      `);
 
-    // Unique replaceRemote
-    await driver.executeScript(
-      `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-        detail: JSON.stringify({id:"fx-1",method:"replaceRemote",
-        args:[{features:{testFirefox:true,ts:${ts}}}]})
-      }));`,
-    );
-    await driver.sleep(750);
+      // Unique replaceRemote
+      await debugRequest(driver, "fx-1", "replaceRemote", [{ features: { testFirefox: true, ts } }]);
+      await driver.sleep(300);
 
-    const afterFirst = await driver.executeScript(
-      "return window.__bdsTestEvents.remoteConfigUpdated;",
-    );
-    expect(afterFirst).toBe(1);
+      const afterFirst = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
+      expect(afterFirst).toBe(1);
 
-    // Idle window — count must remain stable
-    await driver.sleep(500);
-    const afterIdle = await driver.executeScript(
-      "return window.__bdsTestEvents.remoteConfigUpdated;",
-    );
-    expect(afterIdle).toBe(1);
+      // Verify probe: exactly 1 total event, 1 remoteConfig event
+      const probe1 = await debugRequest(driver, "probe-get-1", "getStorageProbe");
+      expect(probe1.total).toBe(1);
+      expect(probe1.remoteConfig).toBe(1);
 
-    // Identical replacement — zero additional events
-    await driver.executeScript(
-      `window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-        detail: JSON.stringify({id:"fx-2",method:"replaceRemote",
-        args:[{features:{testFirefox:true,ts:${ts}}}]})
-      }));`,
-    );
-    await driver.sleep(750);
+      // Idle window — counts must remain stable
+      await driver.sleep(500);
+      const afterIdle = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
+      expect(afterIdle).toBe(1);
 
-    const afterRepeat = await driver.executeScript(
-      "return window.__bdsTestEvents.remoteConfigUpdated;",
-    );
-    expect(afterRepeat).toBe(1);
+      // Identical replacement with reordered keys — zero additional events
+      await debugRequest(driver, "fx-2", "replaceRemote", [{ features: { ts, testFirefox: true } }]);
+      await driver.sleep(500);
 
-    // Verify storage probe: exactly 1 remoteConfig event
-    const probeResult = await driver.executeScript(`
-      return new Promise(function(resolve) {
-        var handler = function(e) {
-          var detail = e.detail;
-          if (typeof detail === "string") detail = JSON.parse(detail);
-          if (detail.id === "fx-probe-get") { window.removeEventListener("bds:debug-api-response", handler); resolve(detail.result); }
-        };
-        window.addEventListener("bds:debug-api-response", handler);
-        window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-          detail: JSON.stringify({id:"fx-probe-get",method:"getStorageProbe",args:[]})
-        }));
-      });
-    `);
+      const afterRepeat = await driver.executeScript("return window.__bdsFfEvents.remoteConfigUpdated;");
+      expect(afterRepeat).toBe(1);
 
-    expect(probeResult).toBeTruthy();
-    expect(probeResult.remoteConfig).toBe(1);
-
-    // Stop probe
-    await driver.executeScript(`
-      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-        detail: JSON.stringify({id:"fx-probe-stop",method:"stopStorageProbe",args:[]})
-      }));
-    `);
+      const probe2 = await debugRequest(driver, "probe-get-2", "getStorageProbe");
+      expect(probe2.total).toBe(1);
+    } finally {
+      await debugRequest(driver, "probe-stop", "stopStorageProbe");
+      await driver.executeScript("window.__bdsFfEvents = null;");
+    }
   });
 
-  // ── Contract 3: Performance (#105 fix) ──
   it("processes messages within time bounds at 200 and 2000 scale", async () => {
     const { driver } = fx;
     const median = (arr) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; };
@@ -135,7 +122,7 @@ describe("Firefox extension", () => {
     const smallSamples = [];
     for (let i = 0; i < 5; i++) {
       const result = await driver.executeScript(
-        "return window.__mockDeepSeek.appendAndMeasureProcessing('Firefox timing sample " + i + "', 5000);",
+        'return window.__mockDeepSeek.appendAndMeasureProcessing("Firefox timing ' + i + '", 5000);',
       );
       smallSamples.push(result.duration);
       expect(result.duration).toBeLessThan(2000);
@@ -153,7 +140,7 @@ describe("Firefox extension", () => {
     const largeSamples = [];
     for (let i = 0; i < 5; i++) {
       const result = await driver.executeScript(
-        "return window.__mockDeepSeek.appendAndMeasureProcessing('Firefox large sample " + i + "', 5000);",
+        'return window.__mockDeepSeek.appendAndMeasureProcessing("Firefox large ' + i + '", 5000);',
       );
       largeSamples.push(result.duration);
       expect(result.duration).toBeLessThan(2000);
@@ -164,7 +151,6 @@ describe("Firefox extension", () => {
     expect(median(largeSamples) - median(smallSamples)).toBeLessThanOrEqual(750);
   }, 120000);
 
-  // ── Contract 4: Host wrapper box model ──
   it("renders create_file download card in host wrapper with block-level box", async () => {
     const { driver } = fx;
     await driver.executeScript("window.__mockDeepSeek.clearMessages();");
@@ -175,14 +161,25 @@ describe("Firefox extension", () => {
       );
     `);
 
-    // Await download card observably
-    await driver.sleep(3000);
-
-    const card = await driver.findElement({ css: ".bds-download-card" });
+    // Await download card visibility with WebDriver wait
+    const card = await driver.wait(
+      async () => {
+        try { return await driver.findElement({ css: ".bds-download-card" }); } catch { return null; }
+      },
+      10000,
+      "Download card not found within 10s",
+    );
     expect(card).toBeTruthy();
 
     const wrapper = await driver.findElement({ css: ".bds-host-wrapper" });
     expect(wrapper).toBeTruthy();
+
+    // Card must be a descendant of the wrapper
+    const isDescendant = await driver.executeScript(
+      "return arguments[0].contains(arguments[1]);",
+      wrapper, card,
+    );
+    expect(isDescendant).toBe(true);
 
     const rect = await driver.executeScript(
       "var r = arguments[0].getBoundingClientRect(); return { w: r.width, h: r.height };",

--- a/tests/e2e-firefox/helpers/firefox-fixture.js
+++ b/tests/e2e-firefox/helpers/firefox-fixture.js
@@ -29,6 +29,9 @@ import {
   pricingJson,
   githubZip,
   githubCommits,
+  remoteConfigFixture,
+  remoteStatusFixture,
+  makeLocaleFixture,
 } from "../../e2e/fixtures/payloads.js";
 
 function toBase64(body) {
@@ -57,6 +60,18 @@ function resolveResponse(url) {
   if (url.startsWith("https://status.deepseek.com")) {
     return { statusCode: 200, body: '{"status":"ok"}', mediaType: "application/json; charset=utf-8" };
   }
+  // ── Background updater routes (#108 fix) ──
+  if (url.startsWith("https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json")) {
+    return { statusCode: 200, body: JSON.stringify(remoteConfigFixture), mediaType: "application/json; charset=utf-8" };
+  }
+  if (url.startsWith("https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json")) {
+    return { statusCode: 200, body: JSON.stringify(remoteStatusFixture), mediaType: "application/json; charset=utf-8" };
+  }
+  const localeMatch = url.match(/\/src\/locales\/(en|tr|ru|zh-cn)\.json/);
+  if (localeMatch) {
+    const code = localeMatch[1];
+    return { statusCode: 200, body: JSON.stringify(makeLocaleFixture(code)), mediaType: "application/json; charset=utf-8" };
+  }
   // AWS WAF / captcha subdomains — must be intercepted to prevent challenge loops
   if (url.includes("awswaf.com") || url.includes("captcha")) {
     return { statusCode: 200, body: "", mediaType: "text/plain" };
@@ -72,6 +87,20 @@ export async function createFirefoxFixture() {
   }
 
   const firefoxBin = process.env.FIREFOX_BIN || undefined;
+  if (firefoxBin) {
+    // Validate: must be an absolute path to an existing executable.
+    // Values like "firefox" (relative / command name) cause Selenium to fail.
+    if (!path.isAbsolute(firefoxBin)) {
+      throw new Error(
+        `FIREFOX_BIN must be an absolute path, got "${firefoxBin}". ` +
+        `Use the firefox-path output from browser-actions/setup-firefox in CI, ` +
+        `or set FIREFOX_BIN to an absolute path (e.g. "C:\\Program Files\\Firefox\\firefox.exe").`
+      );
+    }
+    if (!fs.existsSync(firefoxBin)) {
+      throw new Error(`FIREFOX_BIN path does not exist: ${firefoxBin}`);
+    }
+  }
   const firefoxOpts = new firefox.Options();
   if (firefoxBin) firefoxOpts.setBinary(firefoxBin);
   firefoxOpts.enableBidi();

--- a/tests/e2e-firefox/helpers/firefox-fixture.js
+++ b/tests/e2e-firefox/helpers/firefox-fixture.js
@@ -1,15 +1,9 @@
 /**
- * Firefox E2E fixture — Selenium WebDriver + BiDi network interception.
+ * Firefox E2E fixture — Selenium WebDriver + BiDi network.provideResponse.
  *
- * Launches Firefox with BiDi, temporarily installs the unsigned dist-firefox
- * extension (unmodified), and serves the deterministic mock fixture through
- * network.addIntercept + network.continueResponse.
- *
- * BiDi URL patterns use structured hostname matching (no globs — the *
- * character is forbidden). BiDi events are flat (no params wrapper).
- *
- * BiDi-served HTML does not execute inline scripts in Firefox, so the
- * mock API (window.__mockDeepSeek) is injected via executeScript.
+ * Launches Firefox with BiDi, installs the unsigned dist-firefox extension,
+ * and serves deterministic mock responses. Every intercepted URL must resolve;
+ * unexpected URLs fail immediately.
  *
  * Requirements:
  *   - Firefox Stable (set FIREFOX_BIN to override).
@@ -43,57 +37,34 @@ function toBase64(body) {
     : Buffer.from(body).toString("base64");
 }
 
+// ── Single shared response resolver ──
 function resolveResponse(url) {
-  // Mock fixture page
   if (url.startsWith("https://chat.deepseek.com")) {
     return { statusCode: 200, body: fixtureHtml, mediaType: "text/html; charset=utf-8" };
   }
-  // Pricing / docs
   if (url.startsWith("https://api-docs.deepseek.com")) {
     return { statusCode: 200, body: pricingHtml, mediaType: "text/html; charset=utf-8" };
   }
   if (url === "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json") {
     return { statusCode: 200, body: pricingJson, mediaType: "application/json; charset=utf-8" };
   }
-  // GitHub
   if (url.startsWith("https://codeload.github.com/octocat/Hello-World/zip/refs/heads/")) {
     return { statusCode: 200, body: githubZip, mediaType: "application/zip" };
   }
   if (url.startsWith("https://api.github.com/repos/octocat/Hello-World/commits")) {
     return { statusCode: 200, body: JSON.stringify(githubCommits), mediaType: "application/json; charset=utf-8" };
   }
-  // DeepSeek status API — return empty healthy response
   if (url.startsWith("https://status.deepseek.com")) {
     return { statusCode: 200, body: '{"status":"ok"}', mediaType: "application/json; charset=utf-8" };
   }
-  // AWS WAF / captcha — return empty 200 to prevent challenge redirects
-  if (url.includes("awswaf.com") || url.includes("captcha.awswaf.com")) {
+  // AWS WAF / captcha subdomains — must be intercepted to prevent challenge loops
+  if (url.includes("awswaf.com") || url.includes("captcha")) {
     return { statusCode: 200, body: "", mediaType: "text/plain" };
   }
+  // data: URLs and about: URLs are browser-internal, never intercepted
+  if (url.startsWith("data:") || url.startsWith("about:")) return null;
   return null;
 }
-
-const MOCK_API_SCRIPT = [
-  '(function(){',
-  'if(window.__mockDeepSeek)return;',
-  'function cn(role){var d=document.createElement("div");',
-  'd.className=role==="user"?"ds-message d29f3d7d _63c77b1":"ds-message _63c77b1";',
-  'd.setAttribute("data-message-author-role",role);return d;}',
-  'function ct(role,t){var n=cn(role);var m=document.createElement("div");',
-  'm.className=role==="user"?"fbb737a4 ds-markdown":"ds-markdown";',
-  'm.textContent=t;n.appendChild(m);return n;}',
-  'function ap(n){var c=document.querySelector("#chat-messages");',
-  'if(c)c.appendChild(n);return n;}',
-  'function sm(count){var c=document.querySelector("#chat-messages");',
-  'if(!c)return 0;var f=document.createDocumentFragment();',
-  'for(var i=0;i<count;i++){var r=i%2===0?"user":"assistant";',
-  'f.appendChild(ct(r,("Seed msg "+(i+1)+". ").repeat(8).trim()));}',
-  'c.appendChild(f);return c.querySelectorAll(".ds-message").length;}',
-  'window.__mockDeepSeek={addAssistantMessage:function(t){return ap(ct("assistant",t));},',
-  'addUserMessage:function(t){return ap(ct("user",t));},',
-  'seedMessages:sm,lastSubmittedText:""};',
-  '})();',
-].join("");
 
 export async function createFirefoxFixture() {
   if (!fs.existsSync(manifestPath)) {
@@ -114,87 +85,116 @@ export async function createFirefoxFixture() {
 
   let bidi = null;
   let extensionId = null;
-  let interceptActive = true;
+  let fixtureError = null;
 
-  try {
-    // CRITICAL: register BiDi intercepts BEFORE installing the extension.
-    // If the extension loads first, its background script may hit the real
-    // site before intercepts are active, caching the live page.
-    bidi = await driver.getBidi();
+  // Register BiDi intercepts BEFORE extension install
+  bidi = await driver.getBidi();
 
-    await bidi.send({
-      method: "network.addIntercept",
-      params: {
-        phases: ["beforeRequestSent"],
-        urlPatterns: [
-          { type: "pattern", hostname: "chat.deepseek.com" },
-          { type: "pattern", hostname: "api-docs.deepseek.com" },
-          { type: "pattern", hostname: "status.deepseek.com" },
-          { type: "pattern", hostname: "raw.githubusercontent.com" },
-          { type: "pattern", hostname: "codeload.github.com" },
-          { type: "pattern", hostname: "api.github.com" },
-        ],
-      },
-    });
+  await bidi.send({
+    method: "network.addIntercept",
+    params: {
+      phases: ["beforeRequestSent"],
+      urlPatterns: [
+        { type: "pattern", hostname: "chat.deepseek.com" },
+        { type: "pattern", hostname: "api-docs.deepseek.com" },
+        { type: "pattern", hostname: "status.deepseek.com" },
+        { type: "pattern", hostname: "raw.githubusercontent.com" },
+        { type: "pattern", hostname: "codeload.github.com" },
+        { type: "pattern", hostname: "api.github.com" },
+      ],
+    },
+  });
 
-    await bidi.subscribe("network.beforeRequestSent");
+  await bidi.subscribe("network.beforeRequestSent");
 
-    // BiDi events are flat — no `params` wrapper.
-    // Use network.provideResponse (not continueResponse) for mock responses.
-    bidi.on("network.beforeRequestSent", async (event) => {
-      if (!interceptActive) return;
-      const url = event?.request?.url || "";
-      const resolved = resolveResponse(url);
-      if (process.env.BDS_FX_DEBUG) console.log("[BDS-FX]", resolved ? "MATCH" : "SKIP", url.substring(0, 80));
-      if (!resolved) return;
+  bidi.on("network.beforeRequestSent", async (event) => {
+    const url = event?.request?.url || "";
+    // Skip browser-internal URLs
+    if (url.startsWith("data:") || url.startsWith("about:")) return;
+
+    const resolved = resolveResponse(url);
+    if (!resolved) {
+      // Unexpected URL — fail immediately
+      const msg = `[Firefox E2E] Unmatched intercepted URL: ${url}`;
+      fixtureError = new Error(msg);
+      console.error(msg);
+      // Still provide a terminal response so request doesn't hang
       try {
         await bidi.send({
           method: "network.provideResponse",
           params: {
             request: event.request.request,
-            statusCode: resolved.statusCode,
-            reasonPhrase: "OK",
-            headers: [
-              { name: "Content-Type", value: { type: "string", value: resolved.mediaType } },
-            ],
-            body: { type: "base64", value: toBase64(resolved.body) },
+            statusCode: 500,
+            reasonPhrase: "Fixture Error",
+            headers: [{ name: "Content-Type", value: { type: "string", value: "text/plain" } }],
+            body: { type: "base64", value: toBase64(msg) },
           },
         });
-      } catch (e) {
-        console.warn("[Firefox E2E] provideResponse failed:", e.message);
-      }
-    });
+      } catch { /* connection may be closing */ }
+      return;
+    }
 
-    // Install extension AFTER intercepts are active
-    extensionId = await driver.installAddon(extensionPath, true);
+    try {
+      await bidi.send({
+        method: "network.provideResponse",
+        params: {
+          request: event.request.request,
+          statusCode: resolved.statusCode,
+          reasonPhrase: "OK",
+          headers: [
+            { name: "Content-Type", value: { type: "string", value: resolved.mediaType } },
+          ],
+          body: { type: "base64", value: toBase64(resolved.body) },
+        },
+      });
+    } catch (e) {
+      fixtureError = new Error(`[Firefox E2E] provideResponse failed: ${e.message}`);
+      console.error(fixtureError.message);
+    }
+  });
 
-    // Navigate — intercepted to serve mock HTML
-    await driver.get("https://chat.deepseek.com/");
-    await driver.sleep(1500);
+  // Install extension after intercepts are active
+  extensionId = await driver.installAddon(extensionPath, true);
 
-    // Inject mock API (BiDi-served HTML inline scripts don't execute)
-    await driver.executeScript(MOCK_API_SCRIPT);
-    await driver.sleep(3000);
+  // Navigate to fixture
+  await driver.get("https://chat.deepseek.com/");
 
-    return {
-      driver,
-      bidi,
-      extensionId,
-      async close() {
-        interceptActive = false;
-        try { await driver.quit(); } catch { /* ignore */ }
-      },
-      async takeScreenshot(filename) {
-        const raw = await driver.takeScreenshot();
-        fs.writeFileSync(filename, raw, "base64");
-      },
-      async getPageHtml() {
-        return driver.getPageSource();
-      },
-    };
-  } catch (e) {
-    interceptActive = false;
-    try { await driver.quit(); } catch { /* ignore */ }
-    throw e;
+  // Wait for fixture DOM and extension bootstrap
+  // The fixture HTML's inline <script> sets up __mockDeepSeek on DOMContentLoaded.
+  // BiDi-served pages execute inline scripts in Firefox.
+  await driver.sleep(4000);
+
+  // Verify fixture loaded
+  const pageTitle = await driver.getTitle();
+  if (!pageTitle.includes("Mock DeepSeek")) {
+    throw new Error(
+      `Fixture did not load. Page title: "${pageTitle}". ` +
+      `Check that Firefox + Selenium WebDriver BiDi interception works.`,
+    );
   }
+
+  // Verify mock API is available
+  const hasApi = await driver.executeScript("return !!window.__mockDeepSeek;");
+  if (!hasApi) {
+    throw new Error("window.__mockDeepSeek not available after fixture load");
+  }
+
+  return {
+    driver,
+    bidi,
+    extensionId,
+    getFixtureError() {
+      return fixtureError;
+    },
+    async close() {
+      try { await driver.quit(); } catch { /* ignore */ }
+    },
+    async takeScreenshot(filename) {
+      const raw = await driver.takeScreenshot();
+      fs.writeFileSync(filename, raw, "base64");
+    },
+    async getPageHtml() {
+      return driver.getPageSource();
+    },
+  };
 }

--- a/tests/e2e-firefox/helpers/firefox-fixture.js
+++ b/tests/e2e-firefox/helpers/firefox-fixture.js
@@ -1,0 +1,200 @@
+/**
+ * Firefox E2E fixture — Selenium WebDriver + BiDi network interception.
+ *
+ * Launches Firefox with BiDi, temporarily installs the unsigned dist-firefox
+ * extension (unmodified), and serves the deterministic mock fixture through
+ * network.addIntercept + network.continueResponse.
+ *
+ * BiDi URL patterns use structured hostname matching (no globs — the *
+ * character is forbidden). BiDi events are flat (no params wrapper).
+ *
+ * BiDi-served HTML does not execute inline scripts in Firefox, so the
+ * mock API (window.__mockDeepSeek) is injected via executeScript.
+ *
+ * Requirements:
+ *   - Firefox Stable (set FIREFOX_BIN to override).
+ *   - dist-firefox built (`npm run build`).
+ *   - Selenium Manager auto-provisions GeckoDriver.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { Builder } from "selenium-webdriver";
+import firefox from "selenium-webdriver/firefox.js";
+
+const projectRoot = process.cwd();
+const extensionPath = path.resolve(projectRoot, "dist-firefox");
+const manifestPath = path.join(extensionPath, "manifest.json");
+const fixtureHtml = fs.readFileSync(
+  path.resolve(projectRoot, "tests/e2e/fixtures/mock-deepseek.html"),
+  "utf8",
+);
+
+import {
+  pricingHtml,
+  pricingJson,
+  githubZip,
+  githubCommits,
+} from "../../e2e/fixtures/payloads.js";
+
+function toBase64(body) {
+  return typeof body === "string"
+    ? Buffer.from(body).toString("base64")
+    : Buffer.from(body).toString("base64");
+}
+
+function resolveResponse(url) {
+  // Mock fixture page
+  if (url.startsWith("https://chat.deepseek.com")) {
+    return { statusCode: 200, body: fixtureHtml, mediaType: "text/html; charset=utf-8" };
+  }
+  // Pricing / docs
+  if (url.startsWith("https://api-docs.deepseek.com")) {
+    return { statusCode: 200, body: pricingHtml, mediaType: "text/html; charset=utf-8" };
+  }
+  if (url === "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json") {
+    return { statusCode: 200, body: pricingJson, mediaType: "application/json; charset=utf-8" };
+  }
+  // GitHub
+  if (url.startsWith("https://codeload.github.com/octocat/Hello-World/zip/refs/heads/")) {
+    return { statusCode: 200, body: githubZip, mediaType: "application/zip" };
+  }
+  if (url.startsWith("https://api.github.com/repos/octocat/Hello-World/commits")) {
+    return { statusCode: 200, body: JSON.stringify(githubCommits), mediaType: "application/json; charset=utf-8" };
+  }
+  // DeepSeek status API — return empty healthy response
+  if (url.startsWith("https://status.deepseek.com")) {
+    return { statusCode: 200, body: '{"status":"ok"}', mediaType: "application/json; charset=utf-8" };
+  }
+  // AWS WAF / captcha — return empty 200 to prevent challenge redirects
+  if (url.includes("awswaf.com") || url.includes("captcha.awswaf.com")) {
+    return { statusCode: 200, body: "", mediaType: "text/plain" };
+  }
+  return null;
+}
+
+const MOCK_API_SCRIPT = [
+  '(function(){',
+  'if(window.__mockDeepSeek)return;',
+  'function cn(role){var d=document.createElement("div");',
+  'd.className=role==="user"?"ds-message d29f3d7d _63c77b1":"ds-message _63c77b1";',
+  'd.setAttribute("data-message-author-role",role);return d;}',
+  'function ct(role,t){var n=cn(role);var m=document.createElement("div");',
+  'm.className=role==="user"?"fbb737a4 ds-markdown":"ds-markdown";',
+  'm.textContent=t;n.appendChild(m);return n;}',
+  'function ap(n){var c=document.querySelector("#chat-messages");',
+  'if(c)c.appendChild(n);return n;}',
+  'function sm(count){var c=document.querySelector("#chat-messages");',
+  'if(!c)return 0;var f=document.createDocumentFragment();',
+  'for(var i=0;i<count;i++){var r=i%2===0?"user":"assistant";',
+  'f.appendChild(ct(r,("Seed msg "+(i+1)+". ").repeat(8).trim()));}',
+  'c.appendChild(f);return c.querySelectorAll(".ds-message").length;}',
+  'window.__mockDeepSeek={addAssistantMessage:function(t){return ap(ct("assistant",t));},',
+  'addUserMessage:function(t){return ap(ct("user",t));},',
+  'seedMessages:sm,lastSubmittedText:""};',
+  '})();',
+].join("");
+
+export async function createFirefoxFixture() {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error("Missing dist-firefox build. Run `npm run build` first.");
+  }
+
+  const firefoxBin = process.env.FIREFOX_BIN || undefined;
+  const firefoxOpts = new firefox.Options();
+  if (firefoxBin) firefoxOpts.setBinary(firefoxBin);
+  firefoxOpts.enableBidi();
+  if (process.env.CI) firefoxOpts.addArguments("--headless");
+  firefoxOpts.setAcceptInsecureCerts(true);
+
+  const driver = await new Builder()
+    .forBrowser("firefox")
+    .setFirefoxOptions(firefoxOpts)
+    .build();
+
+  let bidi = null;
+  let extensionId = null;
+  let interceptActive = true;
+
+  try {
+    // CRITICAL: register BiDi intercepts BEFORE installing the extension.
+    // If the extension loads first, its background script may hit the real
+    // site before intercepts are active, caching the live page.
+    bidi = await driver.getBidi();
+
+    await bidi.send({
+      method: "network.addIntercept",
+      params: {
+        phases: ["beforeRequestSent"],
+        urlPatterns: [
+          { type: "pattern", hostname: "chat.deepseek.com" },
+          { type: "pattern", hostname: "api-docs.deepseek.com" },
+          { type: "pattern", hostname: "status.deepseek.com" },
+          { type: "pattern", hostname: "raw.githubusercontent.com" },
+          { type: "pattern", hostname: "codeload.github.com" },
+          { type: "pattern", hostname: "api.github.com" },
+        ],
+      },
+    });
+
+    await bidi.subscribe("network.beforeRequestSent");
+
+    // BiDi events are flat — no `params` wrapper.
+    // Use network.provideResponse (not continueResponse) for mock responses.
+    bidi.on("network.beforeRequestSent", async (event) => {
+      if (!interceptActive) return;
+      const url = event?.request?.url || "";
+      const resolved = resolveResponse(url);
+      if (process.env.BDS_FX_DEBUG) console.log("[BDS-FX]", resolved ? "MATCH" : "SKIP", url.substring(0, 80));
+      if (!resolved) return;
+      try {
+        await bidi.send({
+          method: "network.provideResponse",
+          params: {
+            request: event.request.request,
+            statusCode: resolved.statusCode,
+            reasonPhrase: "OK",
+            headers: [
+              { name: "Content-Type", value: { type: "string", value: resolved.mediaType } },
+            ],
+            body: { type: "base64", value: toBase64(resolved.body) },
+          },
+        });
+      } catch (e) {
+        console.warn("[Firefox E2E] provideResponse failed:", e.message);
+      }
+    });
+
+    // Install extension AFTER intercepts are active
+    extensionId = await driver.installAddon(extensionPath, true);
+
+    // Navigate — intercepted to serve mock HTML
+    await driver.get("https://chat.deepseek.com/");
+    await driver.sleep(1500);
+
+    // Inject mock API (BiDi-served HTML inline scripts don't execute)
+    await driver.executeScript(MOCK_API_SCRIPT);
+    await driver.sleep(3000);
+
+    return {
+      driver,
+      bidi,
+      extensionId,
+      async close() {
+        interceptActive = false;
+        try { await driver.quit(); } catch { /* ignore */ }
+      },
+      async takeScreenshot(filename) {
+        const raw = await driver.takeScreenshot();
+        fs.writeFileSync(filename, raw, "base64");
+      },
+      async getPageHtml() {
+        return driver.getPageSource();
+      },
+    };
+  } catch (e) {
+    interceptActive = false;
+    try { await driver.quit(); } catch { /* ignore */ }
+    throw e;
+  }
+}

--- a/tests/e2e-firefox/helpers/firefox-fixture.js
+++ b/tests/e2e-firefox/helpers/firefox-fixture.js
@@ -2,37 +2,42 @@
  * Firefox E2E fixture — Selenium WebDriver + BiDi network.provideResponse.
  *
  * Launches Firefox with BiDi, installs the unsigned dist-firefox extension,
- * and serves deterministic mock responses. Every intercepted URL must resolve;
- * unexpected URLs fail immediately.
- *
- * Requirements:
- *   - Firefox Stable (set FIREFOX_BIN to override).
- *   - dist-firefox built (`npm run build`).
- *   - Selenium Manager auto-provisions GeckoDriver.
+ * and serves deterministic mock responses through the shared fixture resolver.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { Builder } from "selenium-webdriver";
 import firefox from "selenium-webdriver/firefox.js";
+import { resolveFixtureRequest, createRequestLedger } from "../../e2e/fixtures/fixture-resolver.js";
 
 const projectRoot = process.cwd();
 const extensionPath = path.resolve(projectRoot, "dist-firefox");
 const manifestPath = path.join(extensionPath, "manifest.json");
-const fixtureHtml = fs.readFileSync(
-  path.resolve(projectRoot, "tests/e2e/fixtures/mock-deepseek.html"),
-  "utf8",
-);
 
-import {
-  pricingHtml,
-  pricingJson,
-  githubZip,
-  githubCommits,
-  remoteConfigFixture,
-  remoteStatusFixture,
-  makeLocaleFixture,
-} from "../../e2e/fixtures/payloads.js";
+// ── Firefox binary resolution ──
+
+/**
+ * Resolve the Firefox binary path from FIREFOX_BIN or Selenium Manager.
+ * @returns {string|undefined} absolute path or undefined
+ * @throws {Error} when FIREFOX_BIN is relative or nonexistent
+ */
+function resolveFirefoxBin() {
+  const raw = process.env.FIREFOX_BIN || undefined;
+  if (!raw) return undefined;
+
+  if (!path.isAbsolute(raw)) {
+    throw new Error(
+      `FIREFOX_BIN must be an absolute path, got "${raw}". ` +
+      `Use the firefox-path output from browser-actions/setup-firefox in CI, ` +
+      `or set FIREFOX_BIN to an absolute path (e.g. "C:\\Program Files\\Firefox\\firefox.exe").`
+    );
+  }
+  if (!fs.existsSync(raw)) {
+    throw new Error(`FIREFOX_BIN path does not exist: ${raw}`);
+  }
+  return raw;
+}
 
 function toBase64(body) {
   return typeof body === "string"
@@ -40,172 +45,198 @@ function toBase64(body) {
     : Buffer.from(body).toString("base64");
 }
 
-// ── Single shared response resolver ──
-function resolveResponse(url) {
-  if (url.startsWith("https://chat.deepseek.com")) {
-    return { statusCode: 200, body: fixtureHtml, mediaType: "text/html; charset=utf-8" };
-  }
-  if (url.startsWith("https://api-docs.deepseek.com")) {
-    return { statusCode: 200, body: pricingHtml, mediaType: "text/html; charset=utf-8" };
-  }
-  if (url === "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json") {
-    return { statusCode: 200, body: pricingJson, mediaType: "application/json; charset=utf-8" };
-  }
-  if (url.startsWith("https://codeload.github.com/octocat/Hello-World/zip/refs/heads/")) {
-    return { statusCode: 200, body: githubZip, mediaType: "application/zip" };
-  }
-  if (url.startsWith("https://api.github.com/repos/octocat/Hello-World/commits")) {
-    return { statusCode: 200, body: JSON.stringify(githubCommits), mediaType: "application/json; charset=utf-8" };
-  }
-  if (url.startsWith("https://status.deepseek.com")) {
-    return { statusCode: 200, body: '{"status":"ok"}', mediaType: "application/json; charset=utf-8" };
-  }
-  // ── Background updater routes (#108 fix) ──
-  if (url.startsWith("https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json")) {
-    return { statusCode: 200, body: JSON.stringify(remoteConfigFixture), mediaType: "application/json; charset=utf-8" };
-  }
-  if (url.startsWith("https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json")) {
-    return { statusCode: 200, body: JSON.stringify(remoteStatusFixture), mediaType: "application/json; charset=utf-8" };
-  }
-  const localeMatch = url.match(/\/src\/locales\/(en|tr|ru|zh-cn)\.json/);
-  if (localeMatch) {
-    const code = localeMatch[1];
-    return { statusCode: 200, body: JSON.stringify(makeLocaleFixture(code)), mediaType: "application/json; charset=utf-8" };
-  }
-  // AWS WAF / captcha subdomains — must be intercepted to prevent challenge loops
-  if (url.includes("awswaf.com") || url.includes("captcha")) {
-    return { statusCode: 200, body: "", mediaType: "text/plain" };
-  }
-  // data: URLs and about: URLs are browser-internal, never intercepted
-  if (url.startsWith("data:") || url.startsWith("about:")) return null;
-  return null;
-}
+// Per-fixture ledger
+let fixtureLedger = null;
 
 export async function createFirefoxFixture() {
   if (!fs.existsSync(manifestPath)) {
     throw new Error("Missing dist-firefox build. Run `npm run build` first.");
   }
 
-  const firefoxBin = process.env.FIREFOX_BIN || undefined;
-  if (firefoxBin) {
-    // Validate: must be an absolute path to an existing executable.
-    // Values like "firefox" (relative / command name) cause Selenium to fail.
-    if (!path.isAbsolute(firefoxBin)) {
-      throw new Error(
-        `FIREFOX_BIN must be an absolute path, got "${firefoxBin}". ` +
-        `Use the firefox-path output from browser-actions/setup-firefox in CI, ` +
-        `or set FIREFOX_BIN to an absolute path (e.g. "C:\\Program Files\\Firefox\\firefox.exe").`
-      );
-    }
-    if (!fs.existsSync(firefoxBin)) {
-      throw new Error(`FIREFOX_BIN path does not exist: ${firefoxBin}`);
-    }
-  }
+  fixtureLedger = createRequestLedger();
+
+  const firefoxBin = resolveFirefoxBin();
   const firefoxOpts = new firefox.Options();
   if (firefoxBin) firefoxOpts.setBinary(firefoxBin);
   firefoxOpts.enableBidi();
   if (process.env.CI) firefoxOpts.addArguments("--headless");
   firefoxOpts.setAcceptInsecureCerts(true);
 
-  const driver = await new Builder()
-    .forBrowser("firefox")
-    .setFirefoxOptions(firefoxOpts)
-    .build();
+  // Build driver — wrap failures
+  let driver;
+  try {
+    driver = await new Builder()
+      .forBrowser("firefox")
+      .setFirefoxOptions(firefoxOpts)
+      .build();
+  } catch (e) {
+    throw new Error(`Failed to create Firefox driver: ${e.message}`);
+  }
 
   let bidi = null;
   let extensionId = null;
   let fixtureError = null;
+  let closed = false;
 
-  // Register BiDi intercepts BEFORE extension install
-  bidi = await driver.getBidi();
+  async function safeClose() {
+    if (closed) return;
+    closed = true;
+    try {
+      await driver.quit();
+    } catch (e) {
+      const msg = e?.message || "";
+      if (
+        msg.includes("closed") ||
+        msg.includes("No such session") ||
+        msg.includes("Invalid session ID") ||
+        msg.includes("Connection refused")
+      ) {
+        // Already closed — safe to ignore
+      } else {
+        throw e;
+      }
+    }
+  }
 
-  await bidi.send({
-    method: "network.addIntercept",
-    params: {
-      phases: ["beforeRequestSent"],
-      urlPatterns: [
-        { type: "pattern", hostname: "chat.deepseek.com" },
-        { type: "pattern", hostname: "api-docs.deepseek.com" },
-        { type: "pattern", hostname: "status.deepseek.com" },
-        { type: "pattern", hostname: "raw.githubusercontent.com" },
-        { type: "pattern", hostname: "codeload.github.com" },
-        { type: "pattern", hostname: "api.github.com" },
-      ],
-    },
-  });
+  try {
+    // Register BiDi intercepts
+    bidi = await driver.getBidi();
+  } catch (e) {
+    await safeClose();
+    throw new Error(`Failed to get BiDi: ${e.message}`);
+  }
 
-  await bidi.subscribe("network.beforeRequestSent");
+  try {
+    await bidi.send({
+      method: "network.addIntercept",
+      params: {
+        phases: ["beforeRequestSent"],
+        urlPatterns: [
+          { type: "pattern", hostname: "chat.deepseek.com" },
+          { type: "pattern", hostname: "api-docs.deepseek.com" },
+          { type: "pattern", hostname: "status.deepseek.com" },
+          { type: "pattern", hostname: "raw.githubusercontent.com" },
+          { type: "pattern", hostname: "codeload.github.com" },
+          { type: "pattern", hostname: "api.github.com" },
+        ],
+      },
+    });
 
-  bidi.on("network.beforeRequestSent", async (event) => {
-    const url = event?.request?.url || "";
-    // Skip browser-internal URLs
-    if (url.startsWith("data:") || url.startsWith("about:")) return;
+    await bidi.subscribe("network.beforeRequestSent");
 
-    const resolved = resolveResponse(url);
-    if (!resolved) {
-      // Unexpected URL — fail immediately
-      const msg = `[Firefox E2E] Unmatched intercepted URL: ${url}`;
-      fixtureError = new Error(msg);
-      console.error(msg);
-      // Still provide a terminal response so request doesn't hang
+    bidi.on("network.beforeRequestSent", async (event) => {
+      const url = event?.request?.url || "";
+      // Skip browser-internal URLs
+      if (
+        url.startsWith("data:") ||
+        url.startsWith("about:") ||
+        url.startsWith("moz-extension:") ||
+        url.startsWith("chrome:")
+      ) {
+        return;
+      }
+
       try {
+        const resolved = resolveFixtureRequest(url);
+        if (!resolved) return; // internal URL
+
+        fixtureLedger.record(url, resolved.routeName, resolved.statusCode);
+
         await bidi.send({
           method: "network.provideResponse",
           params: {
             request: event.request.request,
-            statusCode: 500,
-            reasonPhrase: "Fixture Error",
-            headers: [{ name: "Content-Type", value: { type: "string", value: "text/plain" } }],
-            body: { type: "base64", value: toBase64(msg) },
+            statusCode: resolved.statusCode,
+            reasonPhrase: "OK",
+            headers: [
+              { name: "Content-Type", value: { type: "string", value: resolved.mediaType } },
+            ],
+            body: { type: "base64", value: toBase64(resolved.body) },
           },
         });
-      } catch { /* connection may be closing */ }
-      return;
-    }
-
-    try {
-      await bidi.send({
-        method: "network.provideResponse",
-        params: {
-          request: event.request.request,
-          statusCode: resolved.statusCode,
-          reasonPhrase: "OK",
-          headers: [
-            { name: "Content-Type", value: { type: "string", value: resolved.mediaType } },
-          ],
-          body: { type: "base64", value: toBase64(resolved.body) },
-        },
-      });
-    } catch (e) {
-      fixtureError = new Error(`[Firefox E2E] provideResponse failed: ${e.message}`);
-      console.error(fixtureError.message);
-    }
-  });
-
-  // Install extension after intercepts are active
-  extensionId = await driver.installAddon(extensionPath, true);
-
-  // Navigate to fixture
-  await driver.get("https://chat.deepseek.com/");
-
-  // Wait for fixture DOM and extension bootstrap
-  // The fixture HTML's inline <script> sets up __mockDeepSeek on DOMContentLoaded.
-  // BiDi-served pages execute inline scripts in Firefox.
-  await driver.sleep(4000);
-
-  // Verify fixture loaded
-  const pageTitle = await driver.getTitle();
-  if (!pageTitle.includes("Mock DeepSeek")) {
-    throw new Error(
-      `Fixture did not load. Page title: "${pageTitle}". ` +
-      `Check that Firefox + Selenium WebDriver BiDi interception works.`,
-    );
+      } catch (err) {
+        fixtureLedger.record(url, "unmatched", 500, err.message);
+        fixtureError = new Error(
+          `[Firefox E2E] Unmatched intercepted URL: ${url}\n${err.message}`
+        );
+        console.error(fixtureError.message);
+        // Provide terminal response
+        try {
+          await bidi.send({
+            method: "network.provideResponse",
+            params: {
+              request: event.request.request,
+              statusCode: 500,
+              reasonPhrase: "Fixture Error",
+              headers: [{ name: "Content-Type", value: { type: "string", value: "text/plain" } }],
+              body: { type: "base64", value: toBase64(fixtureError.message) },
+            },
+          });
+        } catch {}
+      }
+    });
+  } catch (e) {
+    await safeClose();
+    throw new Error(`Failed to register BiDi intercepts: ${e.message}`);
   }
 
-  // Verify mock API is available
-  const hasApi = await driver.executeScript("return !!window.__mockDeepSeek;");
-  if (!hasApi) {
-    throw new Error("window.__mockDeepSeek not available after fixture load");
+  // Install extension
+  try {
+    extensionId = await driver.installAddon(extensionPath, true);
+  } catch (e) {
+    await safeClose();
+    throw new Error(`Failed to install Firefox add-on: ${e.message}`);
+  }
+
+  // Navigate to fixture
+  try {
+    await driver.get("https://chat.deepseek.com/");
+  } catch (e) {
+    await safeClose();
+    throw new Error(`Failed to navigate to fixture: ${e.message}`);
+  }
+
+  // Verify fixture loaded + extension bootstrapped
+  try {
+    const pageTitle = await driver.getTitle();
+    if (!pageTitle.includes("Mock DeepSeek")) {
+      throw new Error(
+        `Fixture did not load. Page title: "${pageTitle}". ` +
+        `Check that Firefox + Selenium WebDriver BiDi interception works.`
+      );
+    }
+
+    const hasApi = await driver.executeScript("return !!window.__mockDeepSeek;");
+    if (!hasApi) {
+      throw new Error("window.__mockDeepSeek not available after fixture load");
+    }
+
+    // Wait for extension bootstrap — #bds-toggle must be present
+    await driver.wait(
+      async () => {
+        try {
+          await driver.findElement({ css: "#bds-toggle" });
+          return true;
+        } catch { return false; }
+      },
+      15000,
+      "Extension did not bootstrap: #bds-toggle not found within 15s",
+    );
+
+    // Wait for composer injection — .bds-plus-btn is extension-injected
+    await driver.wait(
+      async () => {
+        try {
+          await driver.findElement({ css: ".bds-plus-btn" });
+          return true;
+        } catch { return false; }
+      },
+      10000,
+      "Extension composer not injected: .bds-plus-btn not found within 10s",
+    );
+  } catch (e) {
+    await safeClose();
+    throw e;
   }
 
   return {
@@ -215,15 +246,34 @@ export async function createFirefoxFixture() {
     getFixtureError() {
       return fixtureError;
     },
+    getRequestLedger() {
+      return fixtureLedger ? fixtureLedger.entries() : [];
+    },
     async close() {
-      try { await driver.quit(); } catch { /* ignore */ }
+      await safeClose();
     },
     async takeScreenshot(filename) {
       const raw = await driver.takeScreenshot();
+      const dir = path.dirname(filename);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(filename, raw, "base64");
     },
     async getPageHtml() {
       return driver.getPageSource();
+    },
+    async getPageUrl() {
+      return driver.getCurrentUrl();
+    },
+    async getPageTitle() {
+      return driver.getTitle();
+    },
+    async isDriverHealthy() {
+      try {
+        await driver.getTitle();
+        return true;
+      } catch {
+        return false;
+      }
     },
   };
 }

--- a/tests/e2e-firefox/helpers/firefox-fixture.js
+++ b/tests/e2e-firefox/helpers/firefox-fixture.js
@@ -112,12 +112,8 @@ export async function createFirefoxFixture() {
       params: {
         phases: ["beforeRequestSent"],
         urlPatterns: [
-          { type: "pattern", hostname: "chat.deepseek.com" },
-          { type: "pattern", hostname: "api-docs.deepseek.com" },
-          { type: "pattern", hostname: "status.deepseek.com" },
-          { type: "pattern", hostname: "raw.githubusercontent.com" },
-          { type: "pattern", hostname: "codeload.github.com" },
-          { type: "pattern", hostname: "api.github.com" },
+          { type: "pattern", protocol: "http" },
+          { type: "pattern", protocol: "https" },
         ],
       },
     });
@@ -138,7 +134,13 @@ export async function createFirefoxFixture() {
 
       try {
         const resolved = resolveFixtureRequest(url);
-        if (!resolved) return; // internal URL
+        if (!resolved) {
+          await bidi.send({
+            method: "network.continueRequest",
+            params: { request: event.request.request },
+          });
+          return;
+        }
 
         fixtureLedger.record(url, resolved.routeName, resolved.statusCode);
 

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -678,78 +678,101 @@ test("performance #105: 200 and 2000 message append within time bounds", async (
 });
 
 test("storage #108: single write, zero on repeat, idle stability", async ({ page }) => {
-  // Start storage probe in extension realm via debug API
-  await page.evaluate(() => {
-    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-      detail: JSON.stringify({ id: "probe-start", method: "startStorageProbe", args: [] }),
-    }));
-  });
+  // Helper: send a debug request and await its correlated response
+  async function debugRequest(id, method, args = []) {
+    const result = await page.evaluate(({ id, method, args }) => {
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error(`debugRequest ${id} timed out`)), 10000);
+        const handler = (e) => {
+          let detail = e.detail;
+          if (typeof detail === "string") detail = JSON.parse(detail);
+          if (detail.id === id) {
+            clearTimeout(timeout);
+            window.removeEventListener("bds:debug-api-response", handler);
+            resolve(detail.result);
+          }
+        };
+        window.addEventListener("bds:debug-api-response", handler);
+        window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+          detail: JSON.stringify({ id, method, args }),
+        }));
+      });
+    }, { id, method, args });
+    return result;
+  }
 
-  // Start page-level event counter
-  await page.evaluate(() => {
-    window.__bdsTestEvents = { remoteConfigUpdated: 0 };
-    window.addEventListener("bds:remote-config-updated", () => {
-      window.__bdsTestEvents.remoteConfigUpdated++;
-    });
-  });
-
-  const ts = Date.now();
-
-  // Unique replaceRemote via debug API
-  await page.evaluate((ts) => {
-    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-      detail: JSON.stringify({ id: "cr-1", method: "replaceRemote",
-        args: [{ features: { testChrome: true, ts } }] }),
-    }));
-  }, ts);
-
-  // Wait for response + flush
-  await page.waitForTimeout(750);
-
-  const eventsAfterFirst = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
-  expect(eventsAfterFirst).toBe(1);
-
-  // Idle window — count must remain stable
+  // Wait for fixture startup quiescence: no storage events for 500ms.
+  // Seed a unique value first so we have a baseline.
+  const startupToken = `startup-${Date.now()}`;
+  await debugRequest("quiesce-seed", "replaceRemote", [{ features: { startupToken } }]);
   await page.waitForTimeout(500);
-  const eventsAfterIdle = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
-  expect(eventsAfterIdle).toBe(1);
-
-  // Identical replacement — zero additional events
-  await page.evaluate((ts) => {
-    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-      detail: JSON.stringify({ id: "cr-2", method: "replaceRemote",
-        args: [{ features: { testChrome: true, ts } }] }),
-    }));
-  }, ts);
+  await debugRequest("quiesce-start", "startStorageProbe");
   await page.waitForTimeout(750);
+  const startupProbe = await debugRequest("quiesce-check", "getStorageProbe");
+  // Startup probe should show 0 events after seeding (the seed was before probe start)
+  // If startup background fetches are still arriving, we'll see them here
+  await debugRequest("quiesce-stop", "stopStorageProbe");
 
-  const eventsAfterRepeat = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
-  expect(eventsAfterRepeat).toBe(1);
+  // ── Actual #108 contract ──
+  try {
+    // Start/reset the storage probe
+    await debugRequest("probe-start", "startStorageProbe");
 
-  // Get storage probe results
-  const probeResult = await page.evaluate(() => {
-    return new Promise((resolve) => {
-      const handler = (e) => {
-        let detail = e.detail;
-        if (typeof detail === "string") detail = JSON.parse(detail);
-        if (detail.id === "probe-get") resolve(detail.result);
-      };
-      window.addEventListener("bds:debug-api-response", handler, { once: true });
-      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-        detail: JSON.stringify({ id: "probe-get", method: "getStorageProbe", args: [] }),
-      }));
+    // Start page-level event counter
+    await page.evaluate(() => {
+      window.__bdsTestEvents = { remoteConfigUpdated: 0 };
+      window.addEventListener("bds:remote-config-updated", () => {
+        window.__bdsTestEvents.remoteConfigUpdated++;
+      });
     });
-  });
 
-  expect(probeResult).toBeTruthy();
-  expect(probeResult.remoteConfig).toBe(1);
+    const ts = Date.now();
+    const uniqueConfig = { features: { testChrome: true, ts } };
 
-  // Stop probe
-  await page.evaluate(() => {
-    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
-      detail: JSON.stringify({ id: "probe-stop", method: "stopStorageProbe", args: [] }),
-    }));
-  });
+    // Apply unique remote config and await correlated response
+    await debugRequest("cr-1", "replaceRemote", [uniqueConfig]);
+
+    // Allow a short flush window for storage events
+    await page.waitForTimeout(300);
+
+    const eventsAfterFirst = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+    expect(eventsAfterFirst).toBe(1);
+
+    // Get probe — total events must be exactly 1
+    const probeAfterFirst = await debugRequest("probe-get-1", "getStorageProbe");
+    expect(probeAfterFirst).toBeTruthy();
+    expect(probeAfterFirst.total).toBe(1);
+    expect(probeAfterFirst.remoteConfig).toBe(1);
+
+    // Idle window — counts must remain stable
+    await page.waitForTimeout(500);
+    const eventsAfterIdle = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+    expect(eventsAfterIdle).toBe(1);
+
+    // Reapply structurally identical config (with reordered keys)
+    const identicalConfig = { features: { ts, testChrome: true } };
+    await debugRequest("cr-2", "replaceRemote", [identicalConfig]);
+
+    await page.waitForTimeout(500);
+
+    // Zero additional events or writes
+    const eventsAfterRepeat = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+    expect(eventsAfterRepeat).toBe(1);
+
+    const probeAfterRepeat = await debugRequest("probe-get-2", "getStorageProbe");
+    expect(probeAfterRepeat.total).toBe(1);
+
+    // Verify stored data is correct via debug API
+    const storedConfig = await debugRequest("probe-get-raw", "getRaw");
+    expect(storedConfig).toBeTruthy();
+    expect(storedConfig.features.testChrome).toBe(true);
+
+  } finally {
+    // Always stop the probe
+    await debugRequest("probe-stop", "stopStorageProbe");
+    // Clean up event counter
+    await page.evaluate(() => { window.__bdsTestEvents = null; });
+  }
 });
 
 test("host wrapper: create_file download card in block-level nonzero wrapper", async ({ page }) => {

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -614,23 +614,13 @@ test("creates the PDF export iframe from the sidebar menu", async ({ page }) => 
 // The storage quiescence and performance contracts are verified in
 // the Firefox E2E lane with Selenium WebDriver + BiDi.
 
-test("storage quiescence: extension processes storage changes without DOM regression", async ({ page }) => {
-  // Verify the extension is stable after repeated DOM mutations.
-  // The #105/#108 fixes prevent quadratic slowdown and storage loops.
-  // We verify by: (1) the UI remains responsive after many mutations,
-  // (2) no duplicate overlays appear after repeated scans.
-
-  // Clear and seed 50 messages to stress the scanner
+test("scanner smoke: no duplicate overlays after repeated scans", async ({ page }) => {
+  // Scanner deduplication smoke test — distinct from #108 storage contract.
   await page.evaluate(() => window.__mockDeepSeek.clearMessages());
   await page.evaluate(() => window.__mockDeepSeek.seedMessages(50));
-  await page.waitForTimeout(2000);
+  await page.evaluate(() => window.__mockDeepSeek.waitForAllMessagesProcessed(50, 15000));
 
-  // The toggle should still be visible (extension didn't crash)
-  await expect(page.locator("#bds-toggle")).toBeVisible();
-
-  // No duplicate overlays — the scanner deduplicates
   const overlayCount = await page.locator(".bds-message-overlay").count();
-  // Add one tagged message and verify overlay appears exactly once
   await page.evaluate(() => {
     window.__mockDeepSeek.addAssistantMessage(
       '<BDS:VISUALIZER><div class="v-card"><h2>Storage Test</h2></div></BDS:VISUALIZER>',
@@ -648,64 +638,118 @@ test("storage quiescence: extension processes storage changes without DOM regres
   expect(afterRescanCount).toBe(newOverlayCount);
 });
 
-test("performance: 200 and 2000 message append within time bounds", async ({ page }) => {
-  const samples = { small: [], large: [] };
+test("performance #105: 200 and 2000 message append within time bounds", async ({ page }) => {
+  const median = (arr) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; };
 
-  // 200 baseline — wait for settlement
+  // 200 baseline
   await page.evaluate(() => window.__mockDeepSeek.clearMessages());
   await page.evaluate(() => window.__mockDeepSeek.seedMessages(200));
-  await page.waitForTimeout(3000);
-
-  const settled200 = await page.evaluate(() => {
-    const msgs = document.querySelectorAll(".ds-message");
-    for (const m of msgs) { if (!m.getAttribute("data-bds-msg-id")) return false; }
-    return msgs.length;
-  });
+  const settled200 = await page.evaluate(() => window.__mockDeepSeek.waitForAllMessagesProcessed(200, 30000));
   expect(settled200).toBe(200);
 
+  const smallSamples = [];
   for (let i = 0; i < 5; i++) {
-    const start = Date.now();
-    await page.evaluate((i) => window.__mockDeepSeek.addAssistantMessage("Chrome timing " + i), i);
-    await page.waitForTimeout(500);
-    const done = await page.evaluate(() => {
-      const msgs = document.querySelectorAll(".ds-message");
-      const last = msgs[msgs.length - 1];
-      return !!(last && last.getAttribute("data-bds-msg-id"));
-    });
-    if (done) samples.small.push(Date.now() - start);
-    expect(Date.now() - start).toBeLessThan(2000);
+    const result = await page.evaluate((i) =>
+      window.__mockDeepSeek.appendAndMeasureProcessing("Chrome timing " + i, 5000),
+    i);
+    smallSamples.push(result.duration);
+    expect(result.duration).toBeLessThan(2000);
   }
-  expect(samples.small.length).toBeGreaterThanOrEqual(3);
+  expect(smallSamples).toHaveLength(5);
 
-  // 2000 — wait for settlement
+  // 2000 baseline
   await page.evaluate(() => window.__mockDeepSeek.clearMessages());
   await page.evaluate(() => window.__mockDeepSeek.seedMessages(2000));
-  await page.waitForTimeout(5000);
-
-  const settled2000 = await page.evaluate(() => {
-    const msgs = document.querySelectorAll(".ds-message");
-    for (const m of msgs) { if (!m.getAttribute("data-bds-msg-id")) return false; }
-    return msgs.length;
-  });
+  const settled2000 = await page.evaluate(() => window.__mockDeepSeek.waitForAllMessagesProcessed(2000, 60000));
   expect(settled2000).toBe(2000);
 
+  const largeSamples = [];
   for (let i = 0; i < 5; i++) {
-    const start = Date.now();
-    await page.evaluate((i) => window.__mockDeepSeek.addAssistantMessage("Chrome large " + i), i);
-    await page.waitForTimeout(500);
-    const done = await page.evaluate(() => {
-      const msgs = document.querySelectorAll(".ds-message");
-      const last = msgs[msgs.length - 1];
-      return !!(last && last.getAttribute("data-bds-msg-id"));
-    });
-    if (done) samples.large.push(Date.now() - start);
-    expect(Date.now() - start).toBeLessThan(2000);
+    const result = await page.evaluate((i) =>
+      window.__mockDeepSeek.appendAndMeasureProcessing("Chrome large " + i, 5000),
+    i);
+    largeSamples.push(result.duration);
+    expect(result.duration).toBeLessThan(2000);
   }
-  expect(samples.large.length).toBeGreaterThanOrEqual(3);
+  expect(largeSamples).toHaveLength(5);
 
-  const median = (arr) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; };
-  expect(median(samples.large)).toBeLessThanOrEqual(median(samples.small) * 2.5);
-  expect(median(samples.large) - median(samples.small)).toBeLessThanOrEqual(750);
+  expect(median(largeSamples)).toBeLessThanOrEqual(median(smallSamples) * 2.5);
+  expect(median(largeSamples) - median(smallSamples)).toBeLessThanOrEqual(750);
+});
+
+test("storage #108: single write, zero on repeat, idle stability", async ({ page }) => {
+  // Start storage probe in extension realm via debug API
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+      detail: JSON.stringify({ id: "probe-start", method: "startStorageProbe", args: [] }),
+    }));
+  });
+
+  // Start page-level event counter
+  await page.evaluate(() => {
+    window.__bdsTestEvents = { remoteConfigUpdated: 0 };
+    window.addEventListener("bds:remote-config-updated", () => {
+      window.__bdsTestEvents.remoteConfigUpdated++;
+    });
+  });
+
+  const ts = Date.now();
+
+  // Unique replaceRemote via debug API
+  await page.evaluate((ts) => {
+    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+      detail: JSON.stringify({ id: "cr-1", method: "replaceRemote",
+        args: [{ features: { testChrome: true, ts } }] }),
+    }));
+  }, ts);
+
+  // Wait for response + flush
+  await page.waitForTimeout(750);
+
+  const eventsAfterFirst = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+  expect(eventsAfterFirst).toBe(1);
+
+  // Idle window — count must remain stable
+  await page.waitForTimeout(500);
+  const eventsAfterIdle = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+  expect(eventsAfterIdle).toBe(1);
+
+  // Identical replacement — zero additional events
+  await page.evaluate((ts) => {
+    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+      detail: JSON.stringify({ id: "cr-2", method: "replaceRemote",
+        args: [{ features: { testChrome: true, ts } }] }),
+    }));
+  }, ts);
+  await page.waitForTimeout(750);
+
+  const eventsAfterRepeat = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
+  expect(eventsAfterRepeat).toBe(1);
+
+  // Get storage probe results
+  const probeResult = await page.evaluate(() => {
+    return new Promise((resolve) => {
+      const handler = (e) => {
+        let detail = e.detail;
+        if (typeof detail === "string") detail = JSON.parse(detail);
+        if (detail.id === "probe-get") resolve(detail.result);
+      };
+      window.addEventListener("bds:debug-api-response", handler, { once: true });
+      window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+        detail: JSON.stringify({ id: "probe-get", method: "getStorageProbe", args: [] }),
+      }));
+    });
+  });
+
+  expect(probeResult).toBeTruthy();
+  expect(probeResult.remoteConfig).toBe(1);
+
+  // Stop probe
+  await page.evaluate(() => {
+    window.dispatchEvent(new CustomEvent("bds:debug-api-request", {
+      detail: JSON.stringify({ id: "probe-stop", method: "stopStorageProbe", args: [] }),
+    }));
+  });
 });
 
 test("host wrapper: create_file download card in block-level nonzero wrapper", async ({ page }) => {
@@ -715,9 +759,9 @@ test("host wrapper: create_file download card in block-level nonzero wrapper", a
       '<BDS:CREATE_FILE fileName="test-chrome.txt">\nHello Chrome E2E\n</BDS:CREATE_FILE>',
     );
   });
-  await page.waitForTimeout(3000);
+  // Await the download card observably instead of sleeping
+  await expect(page.locator(".bds-download-card")).toBeVisible({ timeout: 10000 });
 
-  await expect(page.locator(".bds-download-card")).toBeVisible();
   const wrapper = page.locator(".bds-host-wrapper").first();
   await expect(wrapper).toBeVisible();
 
@@ -728,4 +772,5 @@ test("host wrapper: create_file download card in block-level nonzero wrapper", a
     const r = el.getBoundingClientRect(); return { w: r.width, h: r.height };
   });
   expect(rect.w).toBeGreaterThan(0);
+  expect(rect.h).toBeGreaterThan(0);
 });

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -605,3 +605,127 @@ test("creates the PDF export iframe from the sidebar menu", async ({ page }) => 
 
   await expect(page.locator("#bds-print-iframe")).toHaveCount(1);
 });
+
+// ── Cross-browser contracts (Chrome parity with Firefox) ──
+// Note: Chrome contracts use DOM-based assertions because Playwright's
+// page.evaluate runs in the MAIN world, while chrome.storage is only
+// available in the extension's ISOLATED content-script world.
+// Firefox Selenium tests use executeScript which bridges both worlds.
+// The storage quiescence and performance contracts are verified in
+// the Firefox E2E lane with Selenium WebDriver + BiDi.
+
+test("storage quiescence: extension processes storage changes without DOM regression", async ({ page }) => {
+  // Verify the extension is stable after repeated DOM mutations.
+  // The #105/#108 fixes prevent quadratic slowdown and storage loops.
+  // We verify by: (1) the UI remains responsive after many mutations,
+  // (2) no duplicate overlays appear after repeated scans.
+
+  // Clear and seed 50 messages to stress the scanner
+  await page.evaluate(() => window.__mockDeepSeek.clearMessages());
+  await page.evaluate(() => window.__mockDeepSeek.seedMessages(50));
+  await page.waitForTimeout(2000);
+
+  // The toggle should still be visible (extension didn't crash)
+  await expect(page.locator("#bds-toggle")).toBeVisible();
+
+  // No duplicate overlays — the scanner deduplicates
+  const overlayCount = await page.locator(".bds-message-overlay").count();
+  // Add one tagged message and verify overlay appears exactly once
+  await page.evaluate(() => {
+    window.__mockDeepSeek.addAssistantMessage(
+      '<BDS:VISUALIZER><div class="v-card"><h2>Storage Test</h2></div></BDS:VISUALIZER>',
+    );
+  });
+  await page.waitForTimeout(1500);
+
+  const newOverlayCount = await page.locator(".bds-message-overlay").count();
+  expect(newOverlayCount).toBe(overlayCount + 1);
+
+  // Rescan should not create duplicate overlays
+  await page.evaluate(() => window.__mockDeepSeek.addAssistantMessage("Trigger rescan."));
+  await page.waitForTimeout(1500);
+  const afterRescanCount = await page.locator(".bds-message-overlay").count();
+  expect(afterRescanCount).toBe(newOverlayCount);
+});
+
+test("performance: 200 and 2000 message append within time bounds", async ({ page }) => {
+  const samples = { small: [], large: [] };
+
+  // 200 baseline — wait for settlement
+  await page.evaluate(() => window.__mockDeepSeek.clearMessages());
+  await page.evaluate(() => window.__mockDeepSeek.seedMessages(200));
+  await page.waitForTimeout(3000);
+
+  const settled200 = await page.evaluate(() => {
+    const msgs = document.querySelectorAll(".ds-message");
+    for (const m of msgs) { if (!m.getAttribute("data-bds-msg-id")) return false; }
+    return msgs.length;
+  });
+  expect(settled200).toBe(200);
+
+  for (let i = 0; i < 5; i++) {
+    const start = Date.now();
+    await page.evaluate((i) => window.__mockDeepSeek.addAssistantMessage("Chrome timing " + i), i);
+    await page.waitForTimeout(500);
+    const done = await page.evaluate(() => {
+      const msgs = document.querySelectorAll(".ds-message");
+      const last = msgs[msgs.length - 1];
+      return !!(last && last.getAttribute("data-bds-msg-id"));
+    });
+    if (done) samples.small.push(Date.now() - start);
+    expect(Date.now() - start).toBeLessThan(2000);
+  }
+  expect(samples.small.length).toBeGreaterThanOrEqual(3);
+
+  // 2000 — wait for settlement
+  await page.evaluate(() => window.__mockDeepSeek.clearMessages());
+  await page.evaluate(() => window.__mockDeepSeek.seedMessages(2000));
+  await page.waitForTimeout(5000);
+
+  const settled2000 = await page.evaluate(() => {
+    const msgs = document.querySelectorAll(".ds-message");
+    for (const m of msgs) { if (!m.getAttribute("data-bds-msg-id")) return false; }
+    return msgs.length;
+  });
+  expect(settled2000).toBe(2000);
+
+  for (let i = 0; i < 5; i++) {
+    const start = Date.now();
+    await page.evaluate((i) => window.__mockDeepSeek.addAssistantMessage("Chrome large " + i), i);
+    await page.waitForTimeout(500);
+    const done = await page.evaluate(() => {
+      const msgs = document.querySelectorAll(".ds-message");
+      const last = msgs[msgs.length - 1];
+      return !!(last && last.getAttribute("data-bds-msg-id"));
+    });
+    if (done) samples.large.push(Date.now() - start);
+    expect(Date.now() - start).toBeLessThan(2000);
+  }
+  expect(samples.large.length).toBeGreaterThanOrEqual(3);
+
+  const median = (arr) => { const s = [...arr].sort((a, b) => a - b); return s[Math.floor(s.length / 2)]; };
+  expect(median(samples.large)).toBeLessThanOrEqual(median(samples.small) * 2.5);
+  expect(median(samples.large) - median(samples.small)).toBeLessThanOrEqual(750);
+});
+
+test("host wrapper: create_file download card in block-level nonzero wrapper", async ({ page }) => {
+  await page.evaluate(() => window.__mockDeepSeek.clearMessages());
+  await page.evaluate(() => {
+    window.__mockDeepSeek.addAssistantMessage(
+      '<BDS:CREATE_FILE fileName="test-chrome.txt">\nHello Chrome E2E\n</BDS:CREATE_FILE>',
+    );
+  });
+  await page.waitForTimeout(3000);
+
+  await expect(page.locator(".bds-download-card")).toBeVisible();
+  const wrapper = page.locator(".bds-host-wrapper").first();
+  await expect(wrapper).toBeVisible();
+
+  const display = await wrapper.evaluate((el) => getComputedStyle(el).display);
+  expect(display).not.toBe("contents");
+
+  const rect = await wrapper.evaluate((el) => {
+    const r = el.getBoundingClientRect(); return { w: r.width, h: r.height };
+  });
+  expect(rect.w).toBeGreaterThan(0);
+});

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -788,6 +788,11 @@ test("host wrapper: create_file download card in block-level nonzero wrapper", a
   const wrapper = page.locator(".bds-host-wrapper").first();
   await expect(wrapper).toBeVisible();
 
+  // Card must be inside the correct wrapper
+  const card = page.locator(".bds-download-card").first();
+  const isDescendant = await wrapper.evaluate((el, child) => el.contains(child), await card.elementHandle());
+  expect(isDescendant).toBe(true);
+
   const display = await wrapper.evaluate((el) => getComputedStyle(el).display);
   expect(display).not.toBe("contents");
 

--- a/tests/e2e/extension.spec.js
+++ b/tests/e2e/extension.spec.js
@@ -701,17 +701,34 @@ test("storage #108: single write, zero on repeat, idle stability", async ({ page
     return result;
   }
 
-  // Wait for fixture startup quiescence: no storage events for 500ms.
-  // Seed a unique value first so we have a baseline.
-  const startupToken = `startup-${Date.now()}`;
-  await debugRequest("quiesce-seed", "replaceRemote", [{ features: { startupToken } }]);
-  await page.waitForTimeout(500);
-  await debugRequest("quiesce-start", "startStorageProbe");
-  await page.waitForTimeout(750);
-  const startupProbe = await debugRequest("quiesce-check", "getStorageProbe");
-  // Startup probe should show 0 events after seeding (the seed was before probe start)
-  // If startup background fetches are still arriving, we'll see them here
-  await debugRequest("quiesce-stop", "stopStorageProbe");
+  async function waitForStorageQuiet(label, quietMs = 250, timeoutMs = 5000) {
+    const startedAt = Date.now();
+    let last = await debugRequest(`${label}-initial`, "getStorageProbe");
+    let stableSince = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      await page.waitForTimeout(50);
+      const current = await debugRequest(`${label}-${Date.now()}`, "getStorageProbe");
+      if (
+        current.total !== last.total ||
+        current.remoteConfig !== last.remoteConfig ||
+        current.events.length !== last.events.length
+      ) {
+        last = current;
+        stableSince = Date.now();
+      } else if (Date.now() - stableSince >= quietMs) {
+        return current;
+      }
+    }
+    throw new Error(`Storage did not become quiet within ${timeoutMs}ms`);
+  }
+
+  const startup = await debugRequest("startup-ready", "waitForStartup");
+  expect(startup, JSON.stringify(startup)).toMatchObject({ success: true });
+  await debugRequest("startup-probe-start", "startStorageProbe");
+  const startupProbe = await waitForStorageQuiet("startup-quiet");
+  expect(startupProbe.total).toBe(0);
+  expect(startupProbe.remoteConfig).toBe(0);
+  await debugRequest("startup-probe-stop", "stopStorageProbe");
 
   // ── Actual #108 contract ──
   try {
@@ -720,10 +737,9 @@ test("storage #108: single write, zero on repeat, idle stability", async ({ page
 
     // Start page-level event counter
     await page.evaluate(() => {
-      window.__bdsTestEvents = { remoteConfigUpdated: 0 };
-      window.addEventListener("bds:remote-config-updated", () => {
-        window.__bdsTestEvents.remoteConfigUpdated++;
-      });
+      const listener = () => { window.__bdsTestEvents.remoteConfigUpdated += 1; };
+      window.__bdsTestEvents = { remoteConfigUpdated: 0, listener };
+      window.addEventListener("bds:remote-config-updated", listener);
     });
 
     const ts = Date.now();
@@ -731,36 +747,33 @@ test("storage #108: single write, zero on repeat, idle stability", async ({ page
 
     // Apply unique remote config and await correlated response
     await debugRequest("cr-1", "replaceRemote", [uniqueConfig]);
-
-    // Allow a short flush window for storage events
-    await page.waitForTimeout(300);
+    const probeAfterFirst = await waitForStorageQuiet("first-write");
 
     const eventsAfterFirst = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
     expect(eventsAfterFirst).toBe(1);
 
     // Get probe — total events must be exactly 1
-    const probeAfterFirst = await debugRequest("probe-get-1", "getStorageProbe");
     expect(probeAfterFirst).toBeTruthy();
     expect(probeAfterFirst.total).toBe(1);
     expect(probeAfterFirst.remoteConfig).toBe(1);
 
     // Idle window — counts must remain stable
-    await page.waitForTimeout(500);
+    const idleProbe = await waitForStorageQuiet("idle-stability");
+    expect(idleProbe).toEqual(probeAfterFirst);
     const eventsAfterIdle = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
     expect(eventsAfterIdle).toBe(1);
 
     // Reapply structurally identical config (with reordered keys)
     const identicalConfig = { features: { ts, testChrome: true } };
     await debugRequest("cr-2", "replaceRemote", [identicalConfig]);
-
-    await page.waitForTimeout(500);
+    const probeAfterRepeat = await waitForStorageQuiet("identical-repeat");
 
     // Zero additional events or writes
     const eventsAfterRepeat = await page.evaluate(() => window.__bdsTestEvents.remoteConfigUpdated);
     expect(eventsAfterRepeat).toBe(1);
 
-    const probeAfterRepeat = await debugRequest("probe-get-2", "getStorageProbe");
     expect(probeAfterRepeat.total).toBe(1);
+    expect(probeAfterRepeat.remoteConfig).toBe(1);
 
     // Verify stored data is correct via debug API
     const storedConfig = await debugRequest("probe-get-raw", "getRaw");
@@ -771,7 +784,12 @@ test("storage #108: single write, zero on repeat, idle stability", async ({ page
     // Always stop the probe
     await debugRequest("probe-stop", "stopStorageProbe");
     // Clean up event counter
-    await page.evaluate(() => { window.__bdsTestEvents = null; });
+    await page.evaluate(() => {
+      if (window.__bdsTestEvents?.listener) {
+        window.removeEventListener("bds:remote-config-updated", window.__bdsTestEvents.listener);
+      }
+      window.__bdsTestEvents = null;
+    });
   }
 });
 
@@ -785,20 +803,24 @@ test("host wrapper: create_file download card in block-level nonzero wrapper", a
   // Await the download card observably instead of sleeping
   await expect(page.locator(".bds-download-card")).toBeVisible({ timeout: 10000 });
 
-  const wrapper = page.locator(".bds-host-wrapper").first();
-  await expect(wrapper).toBeVisible();
-
-  // Card must be inside the correct wrapper
   const card = page.locator(".bds-download-card").first();
-  const isDescendant = await wrapper.evaluate((el, child) => el.contains(child), await card.elementHandle());
-  expect(isDescendant).toBe(true);
-
-  const display = await wrapper.evaluate((el) => getComputedStyle(el).display);
-  expect(display).not.toBe("contents");
-
-  const rect = await wrapper.evaluate((el) => {
-    const r = el.getBoundingClientRect(); return { w: r.width, h: r.height };
+  const hostContract = await card.evaluate((element) => {
+    const wrapper = element.closest(".bds-host-wrapper");
+    const message = wrapper?.previousElementSibling;
+    const rect = wrapper?.getBoundingClientRect();
+    return {
+      hasWrapper: Boolean(wrapper),
+      adjacentToMessage: Boolean(message?.classList.contains("ds-message")),
+      ownsExpectedMessage: Boolean(message?.textContent.includes("Hello Chrome E2E")),
+      display: wrapper ? getComputedStyle(wrapper).display : null,
+      w: rect?.width || 0,
+      h: rect?.height || 0,
+    };
   });
-  expect(rect.w).toBeGreaterThan(0);
-  expect(rect.h).toBeGreaterThan(0);
+  expect(hostContract.hasWrapper).toBe(true);
+  expect(hostContract.adjacentToMessage).toBe(true);
+  expect(hostContract.ownsExpectedMessage).toBe(true);
+  expect(hostContract.display).not.toBe("contents");
+  expect(hostContract.w).toBeGreaterThan(0);
+  expect(hostContract.h).toBeGreaterThan(0);
 });

--- a/tests/e2e/fixtures/fixture-resolver.js
+++ b/tests/e2e/fixtures/fixture-resolver.js
@@ -1,0 +1,249 @@
+/**
+ * Single shared fixture request resolver consumed by both Playwright (Chrome)
+ * and Selenium BiDi (Firefox) adapters.
+ *
+ * Every intercepted HTTP(S) request resolves through this module. Unknown
+ * external URLs receive a terminal response and mark the fixture failed.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  pricingHtml,
+  pricingJson,
+  githubZip,
+  githubCommits,
+  remoteConfigFixture,
+  remoteStatusFixture,
+  makeLocaleFixture,
+} from "./payloads.js";
+
+// ── Locale code discovery from actual source files ──
+
+const LOCALES_DIR = path.resolve(
+  process.cwd(),
+  "src",
+  "locales",
+);
+
+/** @type {string[]} */
+let _localeCodes = null;
+function getLocaleCodes() {
+  if (_localeCodes) return _localeCodes;
+  try {
+    _localeCodes = fs
+      .readdirSync(LOCALES_DIR)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => f.replace(/\.json$/, ""));
+  } catch {
+    _localeCodes = ["en", "tr", "ru", "zh-cn"];
+  }
+  return _localeCodes;
+}
+
+// ── Fixture HTML (read once) ──
+
+let _fixtureHtml = null;
+function getFixtureHtml() {
+  if (_fixtureHtml) return _fixtureHtml;
+  _fixtureHtml = fs.readFileSync(
+    path.resolve(process.cwd(), "tests/e2e/fixtures/mock-deepseek.html"),
+    "utf8",
+  );
+  return _fixtureHtml;
+}
+
+// ── URL matching ──
+
+/**
+ * Strip cache-busting query parameters for route matching.
+ * Returns { base, qs } where base is the URL without `?t=...` etc.
+ */
+function parseUrl(url) {
+  try {
+    const u = new URL(url);
+    const t = u.searchParams.get("t");
+    if (t) u.searchParams.delete("t");
+    const qs = u.searchParams.toString();
+    return { base: u.origin + u.pathname + (qs ? "?" + qs : ""), raw: url };
+  } catch {
+    return { base: url, raw: url };
+  }
+}
+
+const ROUTES = [
+  {
+    name: "deepseek-page",
+    match: (url) => url.startsWith("https://chat.deepseek.com"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "text/html; charset=utf-8",
+      body: getFixtureHtml(),
+    }),
+  },
+  {
+    name: "pricing-html",
+    match: (url) => url.startsWith("https://api-docs.deepseek.com"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "text/html; charset=utf-8",
+      body: pricingHtml,
+    }),
+  },
+  {
+    name: "pricing-json",
+    match: (url) =>
+      url.startsWith(
+        "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json",
+      ),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: pricingJson,
+    }),
+  },
+  {
+    name: "remote-config",
+    match: (url) =>
+      url.startsWith(
+        "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json",
+      ),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: JSON.stringify(remoteConfigFixture),
+    }),
+  },
+  {
+    name: "remote-status",
+    match: (url) =>
+      url.startsWith(
+        "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json",
+      ),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: JSON.stringify(remoteStatusFixture),
+    }),
+  },
+  {
+    name: "github-zip",
+    match: (url) =>
+      url.startsWith("https://codeload.github.com/octocat/Hello-World/zip/refs/heads/"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/zip",
+      body: githubZip,
+      binary: true,
+    }),
+  },
+  {
+    name: "github-commits",
+    match: (url) =>
+      url.startsWith("https://api.github.com/repos/octocat/Hello-World/commits"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: JSON.stringify(githubCommits),
+    }),
+  },
+  {
+    name: "status-check",
+    match: (url) => url.startsWith("https://status.deepseek.com"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: '{"status":"ok"}',
+    }),
+  },
+];
+
+/**
+ * Resolve a fixture response for an intercepted request URL.
+ *
+ * @param {string} url - full URL including query string
+ * @returns {{
+ *   statusCode: number,
+ *   mediaType: string,
+ *   body: string|Buffer,
+ *   binary?: boolean,
+ *   routeName: string
+ * } | null}
+ *   null when the URL is internal (data:, about:, chrome-extension:, moz-extension:)
+ * @throws {Error} on unmatched external URL
+ */
+export function resolveFixtureRequest(url) {
+  // Browser-internal URLs — never intercepted
+  if (
+    url.startsWith("data:") ||
+    url.startsWith("about:") ||
+    url.startsWith("chrome-extension:") ||
+    url.startsWith("moz-extension:") ||
+    url.startsWith("chrome:") ||
+    url.includes("://localhost")
+  ) {
+    return null;
+  }
+
+  // AWS WAF / captcha — harmless no-ops
+  if (url.includes("awswaf.com") || url.includes("captcha")) {
+    return {
+      statusCode: 200,
+      mediaType: "text/plain",
+      body: "",
+      routeName: "captcha-noop",
+    };
+  }
+
+  const { base } = parseUrl(url);
+
+  // Check static routes
+  for (const route of ROUTES) {
+    if (route.match(base)) {
+      return { ...route.response(), routeName: route.name };
+    }
+  }
+
+  // Dynamic locale routes — derived from actual locale files
+  const localeMatch = base.match(
+    /\/src\/locales\/([a-z]{2}(-[a-z]{2})?)\.json$/,
+  );
+  if (localeMatch) {
+    const code = localeMatch[1];
+    return {
+      statusCode: 200,
+      mediaType: "application/json; charset=utf-8",
+      body: JSON.stringify(makeLocaleFixture(code)),
+      routeName: `locale-${code}`,
+    };
+  }
+
+  throw new Error(
+    `[Fixture] Unmatched external URL: ${url}\n` +
+    `Parsed base: ${base}\n` +
+    `Known routes: ${ROUTES.map((r) => r.name).join(", ")}, locales (${getLocaleCodes().join(", ")})`,
+  );
+}
+
+/**
+ * Request ledger for tracking all intercepted requests.
+ */
+export function createRequestLedger() {
+  /** @type {Array<{url: string, routeName: string, statusCode: number, error?: string}>} */
+  const entries = [];
+
+  return {
+    record(url, routeName, statusCode, error) {
+      entries.push({ url, routeName, statusCode, error });
+    },
+    entries() {
+      return [...entries];
+    },
+    unmatchedCount() {
+      return entries.filter((e) => e.statusCode >= 500).length;
+    },
+    reset() {
+      entries.length = 0;
+    },
+  };
+}

--- a/tests/e2e/fixtures/fixture-resolver.js
+++ b/tests/e2e/fixtures/fixture-resolver.js
@@ -156,6 +156,15 @@ const ROUTES = [
       body: '{"status":"ok"}',
     }),
   },
+  {
+    name: "google-fonts-css",
+    match: (url) => url.startsWith("https://fonts.googleapis.com/"),
+    response: () => ({
+      statusCode: 200,
+      mediaType: "text/css; charset=utf-8",
+      body: "",
+    }),
+  },
 ];
 
 /**
@@ -210,6 +219,9 @@ export function resolveFixtureRequest(url) {
   );
   if (localeMatch) {
     const code = localeMatch[1];
+    if (!getLocaleCodes().includes(code)) {
+      throw new Error(`[Fixture] Unknown locale code: ${code}`);
+    }
     return {
       statusCode: 200,
       mediaType: "application/json; charset=utf-8",

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -516,15 +516,16 @@
           function appendAndMeasureProcessing(text, timeoutMs) {
             const deadline = timeoutMs || 5000;
             const node = createTextMessage("assistant", text);
-            appendMessage(node);
+            // Install observer and record start time BEFORE appending so
+            // append cost is included and no race exists.
             const start = performance.now();
+            let observer;
+            let timeoutId;
+            const cleanup = () => {
+              if (observer) observer.disconnect();
+              if (timeoutId) clearTimeout(timeoutId);
+            };
             return new Promise((resolve, reject) => {
-              let observer;
-              let timeoutId;
-              const cleanup = () => {
-                if (observer) observer.disconnect();
-                if (timeoutId) clearTimeout(timeoutId);
-              };
               observer = new MutationObserver(() => {
                 if (node.getAttribute("data-bds-msg-id")) {
                   cleanup();
@@ -539,6 +540,14 @@
                   "data-bds-msg-id within " + Math.round(deadline) + "ms"
                 ));
               }, deadline);
+              // Handle case where data-bds-msg-id is already set before observer fires
+              if (node.getAttribute("data-bds-msg-id")) {
+                cleanup();
+                resolve({ duration: performance.now() - start, id: node.getAttribute("data-bds-msg-id") });
+                return;
+              }
+              // Append after observer is fully set up
+              appendMessage(node);
             });
           }
 

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -477,6 +477,71 @@
             if (container) container.replaceChildren();
           }
 
+          // ── Observable timing helpers for #105/#108 contracts ──
+
+          function waitForAllMessagesProcessed(expectedCount, timeoutMs) {
+            const deadline = timeoutMs || 30000;
+            return new Promise((resolve, reject) => {
+              const start = performance.now();
+              function check() {
+                const msgs = document.querySelectorAll(".ds-message");
+                if (msgs.length !== expectedCount) {
+                  if (performance.now() - start > deadline) {
+                    return reject(new Error(
+                      "waitForAllMessagesProcessed timeout: expected " + expectedCount +
+                      " messages, got " + msgs.length + " after " + Math.round(deadline) + "ms"
+                    ));
+                  }
+                  requestAnimationFrame(check);
+                  return;
+                }
+                for (let i = 0; i < msgs.length; i++) {
+                  if (!msgs[i].getAttribute("data-bds-msg-id")) {
+                    if (performance.now() - start > deadline) {
+                      return reject(new Error(
+                        "waitForAllMessagesProcessed timeout: message " + i +
+                        " missing data-bds-msg-id after " + Math.round(deadline) + "ms"
+                      ));
+                    }
+                    requestAnimationFrame(check);
+                    return;
+                  }
+                }
+                resolve(msgs.length);
+              }
+              check();
+            });
+          }
+
+          function appendAndMeasureProcessing(text, timeoutMs) {
+            const deadline = timeoutMs || 5000;
+            const node = createTextMessage("assistant", text);
+            appendMessage(node);
+            const start = performance.now();
+            return new Promise((resolve, reject) => {
+              let observer;
+              let timeoutId;
+              const cleanup = () => {
+                if (observer) observer.disconnect();
+                if (timeoutId) clearTimeout(timeoutId);
+              };
+              observer = new MutationObserver(() => {
+                if (node.getAttribute("data-bds-msg-id")) {
+                  cleanup();
+                  resolve({ duration: performance.now() - start, id: node.getAttribute("data-bds-msg-id") });
+                }
+              });
+              observer.observe(node, { attributes: true, attributeFilter: ["data-bds-msg-id"] });
+              timeoutId = setTimeout(() => {
+                cleanup();
+                reject(new Error(
+                  "appendAndMeasureProcessing timeout: message did not receive " +
+                  "data-bds-msg-id within " + Math.round(deadline) + "ms"
+                ));
+              }, deadline);
+            });
+          }
+
           window.__mockDeepSeek = {
             addAssistantMessage(text) {
               return appendMessage(createTextMessage("assistant", text));
@@ -492,6 +557,8 @@
             replaceFileInput,
             seedMessages,
             clearMessages,
+            waitForAllMessagesProcessed,
+            appendAndMeasureProcessing,
             getSendCount() {
               return sendCount;
             },

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -472,6 +472,11 @@
             return container.querySelectorAll(".ds-message").length;
           }
 
+          function clearMessages() {
+            const container = document.querySelector("#chat-messages");
+            if (container) container.replaceChildren();
+          }
+
           window.__mockDeepSeek = {
             addAssistantMessage(text) {
               return appendMessage(createTextMessage("assistant", text));
@@ -486,6 +491,7 @@
             getAttachedFiles,
             replaceFileInput,
             seedMessages,
+            clearMessages,
             getSendCount() {
               return sendCount;
             },

--- a/tests/e2e/fixtures/mock-deepseek.html
+++ b/tests/e2e/fixtures/mock-deepseek.html
@@ -460,6 +460,18 @@
             }
           });
 
+          function seedMessages(count) {
+            const fragment = document.createDocumentFragment();
+            for (let i = 0; i < count; i++) {
+              const role = i % 2 === 0 ? "user" : "assistant";
+              const node = createTextMessage(role, `Seed message ${i + 1}. `.repeat(8).trim());
+              fragment.appendChild(node);
+            }
+            const container = document.querySelector("#chat-messages");
+            container.appendChild(fragment);
+            return container.querySelectorAll(".ds-message").length;
+          }
+
           window.__mockDeepSeek = {
             addAssistantMessage(text) {
               return appendMessage(createTextMessage("assistant", text));
@@ -473,6 +485,7 @@
             updateLastAssistantMessage,
             getAttachedFiles,
             replaceFileInput,
+            seedMessages,
             getSendCount() {
               return sendCount;
             },

--- a/tests/e2e/fixtures/payloads.js
+++ b/tests/e2e/fixtures/payloads.js
@@ -55,6 +55,25 @@ export const githubCommits = Array.from({ length: 3 }, (_, index) => ({
   },
 }));
 
+// ── Background updater fixtures (#108 fix) ──
+
+export const remoteConfigFixture = {
+  features: {
+    attachMenu: { enabled: true },
+    fileUpload: { enabled: true },
+  },
+  selectors: {},
+  api: { statusUrl: "https://status.deepseek.com/api/v1/status" },
+  modelMappings: {},
+  meta: { version: 1 },
+};
+
+export const remoteStatusFixture = [];
+
+export function makeLocaleFixture(code) {
+  return { messages: { testKey: `fixture-locale-${code}` } };
+}
+
 /**
  * Route patterns used by both Playwright and BiDi interception.
  */
@@ -63,6 +82,12 @@ export const ROUTES = {
   pricingHtml: "https://api-docs.deepseek.com/**",
   pricingJson:
     "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json",
+  remoteConfig:
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json",
+  remoteStatus:
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json",
+  locales:
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales/*.json",
   githubZip: "https://codeload.github.com/octocat/Hello-World/zip/refs/heads/*",
   githubCommits: "https://api.github.com/repos/octocat/Hello-World/commits**",
 };

--- a/tests/e2e/fixtures/payloads.js
+++ b/tests/e2e/fixtures/payloads.js
@@ -1,0 +1,68 @@
+/**
+ * Shared response payloads for browser E2E tests.
+ * Consumed by Chromium Playwright routing and Firefox BiDi interception.
+ */
+
+import { zipSync, strToU8 } from "fflate";
+
+export const pricingHtml = `<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Pricing</h1>
+    <table>
+      <tr><td>deepseek-v4-flash</td><td>$0.0028</td><td>$0.14</td><td>$0.28</td></tr>
+      <tr><td>deepseek-v4-pro</td><td>$0.0145</td><td>$0.435</td><td>$0.87</td></tr>
+    </table>
+  </body>
+</html>`;
+
+export const pricingJson = JSON.stringify({
+  updatedAt: "2026-05-06",
+  models: {
+    "deepseek-v4-flash": {
+      displayName: "DeepSeek V4 Flash",
+      inputPrice: 0.14,
+      inputCacheHitPrice: 0.0028,
+      outputPrice: 0.28,
+      contextLength: 1_000_000,
+    },
+    "deepseek-v4-pro": {
+      displayName: "DeepSeek V4 Pro",
+      inputPrice: 0.435,
+      inputCacheHitPrice: 0.0145,
+      outputPrice: 0.87,
+      contextLength: 1_000_000,
+    },
+  },
+});
+
+export const githubZip = Buffer.from(
+  zipSync({
+    "Hello-World-main/README.md": strToU8("# Hello World\n\nFixture repo.\n"),
+    "Hello-World-main/src/index.js": strToU8('console.log("fixture repo");\n'),
+    "Hello-World-main/.gitignore": strToU8("dist/\n"),
+  }),
+);
+
+export const githubCommits = Array.from({ length: 3 }, (_, index) => ({
+  sha: `abcdef${index}1234567890`,
+  commit: {
+    author: {
+      name: `Fixture Author ${index + 1}`,
+      date: `2026-05-0${index + 1}T10:00:00Z`,
+    },
+    message: `Fixture commit ${index + 1}`,
+  },
+}));
+
+/**
+ * Route patterns used by both Playwright and BiDi interception.
+ */
+export const ROUTES = {
+  deepseek: "https://chat.deepseek.com/**",
+  pricingHtml: "https://api-docs.deepseek.com/**",
+  pricingJson:
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json",
+  githubZip: "https://codeload.github.com/octocat/Hello-World/zip/refs/heads/*",
+  githubCommits: "https://api.github.com/repos/octocat/Hello-World/commits**",
+};

--- a/tests/e2e/helpers/extension.js
+++ b/tests/e2e/helpers/extension.js
@@ -7,6 +7,9 @@ import {
   pricingJson,
   githubZip,
   githubCommits,
+  remoteConfigFixture,
+  remoteStatusFixture,
+  makeLocaleFixture,
 } from "../fixtures/payloads.js";
 
 const projectRoot = process.cwd();
@@ -69,6 +72,45 @@ async function routeFixtureRequests(context) {
       });
     },
   );
+
+  // ── Background updater routes (#108 fix) ──
+
+  await context.route(
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json**",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json; charset=utf-8",
+        body: JSON.stringify(remoteConfigFixture),
+      });
+    },
+  );
+
+  await context.route(
+    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json**",
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json; charset=utf-8",
+        body: JSON.stringify(remoteStatusFixture),
+      });
+    },
+  );
+
+  // Locale files — en, tr, ru, zh-cn
+  const localeCodes = ["en", "tr", "ru", "zh-cn"];
+  for (const code of localeCodes) {
+    await context.route(
+      `https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales/${code}.json**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json; charset=utf-8",
+          body: JSON.stringify(makeLocaleFixture(code)),
+        });
+      },
+    );
+  }
 }
 
 async function createExtensionContext() {

--- a/tests/e2e/helpers/extension.js
+++ b/tests/e2e/helpers/extension.js
@@ -106,7 +106,18 @@ export const test = base.extend({
         // "Target page, context or browser has been closed". This is a
         // Playwright/Chromium Windows-only issue unrelated to test correctness.
       }
-      fs.rmSync(userDataDir, { recursive: true, force: true });
+      // Retry removal on Windows where file locks may persist briefly
+      const maxRetries = 5;
+      const retryDelay = 500;
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          fs.rmSync(userDataDir, { recursive: true, force: true });
+          break;
+        } catch (e) {
+          if (attempt === maxRetries - 1) throw e;
+          await new Promise((r) => setTimeout(r, retryDelay));
+        }
+      }
     }
   },
 

--- a/tests/e2e/helpers/extension.js
+++ b/tests/e2e/helpers/extension.js
@@ -93,6 +93,7 @@ export const test = base.extend({
     try {
       await use(context);
     } finally {
+      const teardownErrors = [];
       try {
         await context.close();
       } catch (e) {
@@ -104,9 +105,7 @@ export const test = base.extend({
           msg.includes("Connection closed")
         ) {
           // Expected teardown race on Windows — safe to ignore
-        } else {
-          throw e;
-        }
+        } else teardownErrors.push(e);
       }
       // Retry removal on Windows where file locks may persist briefly
       const maxRetries = 5;
@@ -116,9 +115,22 @@ export const test = base.extend({
           fs.rmSync(userDataDir, { recursive: true, force: true });
           break;
         } catch {
-          if (attempt === maxRetries - 1) throw new Error(`Failed to remove temp dir: ${userDataDir}`);
+          if (attempt === maxRetries - 1) {
+            teardownErrors.push(new Error(`Failed to remove temp dir: ${userDataDir}`));
+          }
           await new Promise((r) => setTimeout(r, retryDelay));
         }
+      }
+
+      const unmatched = fixtureLedger.entries().filter((entry) => entry.statusCode >= 500);
+      if (unmatched.length > 0) {
+        teardownErrors.push(new Error(
+          `[Fixture] ${unmatched.length} unmatched external request(s):\n` +
+          unmatched.map((entry) => `${entry.url}: ${entry.error || entry.statusCode}`).join("\n"),
+        ));
+      }
+      if (teardownErrors.length > 0) {
+        throw new AggregateError(teardownErrors, "Extension fixture teardown failed");
       }
     }
   },

--- a/tests/e2e/helpers/extension.js
+++ b/tests/e2e/helpers/extension.js
@@ -2,7 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test as base, chromium, expect } from "@playwright/test";
-import { zipSync, strToU8 } from "fflate";
+import {
+  pricingHtml,
+  pricingJson,
+  githubZip,
+  githubCommits,
+} from "../fixtures/payloads.js";
 
 const projectRoot = process.cwd();
 const extensionPath = path.resolve(projectRoot, "dist-chrome");
@@ -11,56 +16,6 @@ const fixtureHtml = fs.readFileSync(
   path.resolve(projectRoot, "tests/e2e/fixtures/mock-deepseek.html"),
   "utf8",
 );
-
-const pricingHtml = `<!DOCTYPE html>
-<html>
-  <body>
-    <h1>Pricing</h1>
-    <table>
-      <tr><td>deepseek-v4-flash</td><td>$0.0028</td><td>$0.14</td><td>$0.28</td></tr>
-      <tr><td>deepseek-v4-pro</td><td>$0.0145</td><td>$0.435</td><td>$0.87</td></tr>
-    </table>
-  </body>
-</html>`;
-
-const pricingJson = JSON.stringify({
-  updatedAt: "2026-05-06",
-  models: {
-    "deepseek-v4-flash": {
-      displayName: "DeepSeek V4 Flash",
-      inputPrice: 0.14,
-      inputCacheHitPrice: 0.0028,
-      outputPrice: 0.28,
-      contextLength: 1_000_000,
-    },
-    "deepseek-v4-pro": {
-      displayName: "DeepSeek V4 Pro",
-      inputPrice: 0.435,
-      inputCacheHitPrice: 0.0145,
-      outputPrice: 0.87,
-      contextLength: 1_000_000,
-    },
-  },
-});
-
-const githubZip = Buffer.from(
-  zipSync({
-    "Hello-World-main/README.md": strToU8("# Hello World\n\nFixture repo.\n"),
-    "Hello-World-main/src/index.js": strToU8('console.log("fixture repo");\n'),
-    "Hello-World-main/.gitignore": strToU8("dist/\n"),
-  }),
-);
-
-const githubCommits = Array.from({ length: 3 }, (_, index) => ({
-  sha: `abcdef${index}1234567890`,
-  commit: {
-    author: {
-      name: `Fixture Author ${index + 1}`,
-      date: `2026-05-0${index + 1}T10:00:00Z`,
-    },
-    message: `Fixture commit ${index + 1}`,
-  },
-}));
 
 async function routeFixtureRequests(context) {
   await context.route("https://chat.deepseek.com/**", async (route) => {

--- a/tests/e2e/helpers/extension.js
+++ b/tests/e2e/helpers/extension.js
@@ -2,115 +2,53 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test as base, chromium, expect } from "@playwright/test";
-import {
-  pricingHtml,
-  pricingJson,
-  githubZip,
-  githubCommits,
-  remoteConfigFixture,
-  remoteStatusFixture,
-  makeLocaleFixture,
-} from "../fixtures/payloads.js";
+import { resolveFixtureRequest, createRequestLedger } from "../fixtures/fixture-resolver.js";
 
 const projectRoot = process.cwd();
 const extensionPath = path.resolve(projectRoot, "dist-chrome");
 const manifestPath = path.join(extensionPath, "manifest.json");
-const fixtureHtml = fs.readFileSync(
-  path.resolve(projectRoot, "tests/e2e/fixtures/mock-deepseek.html"),
-  "utf8",
-);
+
+const fixtureLedger = createRequestLedger();
 
 async function routeFixtureRequests(context) {
-  await context.route("https://chat.deepseek.com/**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/html; charset=utf-8",
-      body: fixtureHtml,
-    });
+  // Catch-all: intercept every external request and resolve through shared resolver
+  await context.route("**/*", async (route) => {
+    const url = route.request().url();
+    // Skip browser-internal URLs
+    if (
+      url.startsWith("data:") ||
+      url.startsWith("about:") ||
+      url.startsWith("chrome-extension:") ||
+      url.startsWith("chrome:") ||
+      url.startsWith("blob:") ||
+      url.includes("://localhost")
+    ) {
+      return route.continue();
+    }
+
+    try {
+      const resolved = resolveFixtureRequest(url);
+      if (!resolved) {
+        // Internal URL — continue without interception
+        return route.continue();
+      }
+      fixtureLedger.record(url, resolved.routeName, resolved.statusCode);
+      await route.fulfill({
+        status: resolved.statusCode,
+        contentType: resolved.mediaType,
+        body: resolved.binary ? undefined : resolved.body,
+        ...(resolved.binary ? { body: resolved.body } : {}),
+      });
+    } catch (err) {
+      fixtureLedger.record(url, "unmatched", 500, err.message);
+      console.error(err.message);
+      await route.fulfill({
+        status: 500,
+        contentType: "text/plain",
+        body: err.message,
+      });
+    }
   });
-
-  await context.route("https://api-docs.deepseek.com/**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/html; charset=utf-8",
-      body: pricingHtml,
-    });
-  });
-
-  await context.route(
-    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/pricing.json",
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json; charset=utf-8",
-        body: pricingJson,
-      });
-    },
-  );
-
-  await context.route(
-    "https://codeload.github.com/octocat/Hello-World/zip/refs/heads/*",
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "content-type": "application/zip",
-          "content-length": String(githubZip.length),
-        },
-        body: githubZip,
-      });
-    },
-  );
-
-  await context.route(
-    "https://api.github.com/repos/octocat/Hello-World/commits**",
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json; charset=utf-8",
-        body: JSON.stringify(githubCommits),
-      });
-    },
-  );
-
-  // ── Background updater routes (#108 fix) ──
-
-  await context.route(
-    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/remote-config.json**",
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json; charset=utf-8",
-        body: JSON.stringify(remoteConfigFixture),
-      });
-    },
-  );
-
-  await context.route(
-    "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/extension/status.json**",
-    async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json; charset=utf-8",
-        body: JSON.stringify(remoteStatusFixture),
-      });
-    },
-  );
-
-  // Locale files — en, tr, ru, zh-cn
-  const localeCodes = ["en", "tr", "ru", "zh-cn"];
-  for (const code of localeCodes) {
-    await context.route(
-      `https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales/${code}.json**`,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json; charset=utf-8",
-          body: JSON.stringify(makeLocaleFixture(code)),
-        });
-      },
-    );
-  }
 }
 
 async function createExtensionContext() {
@@ -118,18 +56,33 @@ async function createExtensionContext() {
     throw new Error("Missing dist-chrome build. Run `npm run build:chrome` before Playwright.");
   }
 
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "bds-playwright-"));
-  const context = await chromium.launchPersistentContext(userDataDir, {
-    channel: "chromium",
-    headless: !!process.env.CI,
-    viewport: { width: 1440, height: 1100 },
-    args: [
-      `--disable-extensions-except=${extensionPath}`,
-      `--load-extension=${extensionPath}`,
-    ],
-  });
+  fixtureLedger.reset();
 
-  await routeFixtureRequests(context);
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "bds-playwright-"));
+  let context;
+  try {
+    context = await chromium.launchPersistentContext(userDataDir, {
+      channel: "chromium",
+      headless: !!process.env.CI,
+      viewport: { width: 1440, height: 1100 },
+      args: [
+        `--disable-extensions-except=${extensionPath}`,
+        `--load-extension=${extensionPath}`,
+      ],
+    });
+  } catch (e) {
+    // Cleanup on launch failure
+    try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+    throw e;
+  }
+
+  try {
+    await routeFixtureRequests(context);
+  } catch (e) {
+    try { await context.close(); } catch {}
+    try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+    throw e;
+  }
 
   return { context, userDataDir };
 }
@@ -142,11 +95,18 @@ export const test = base.extend({
     } finally {
       try {
         await context.close();
-      } catch {
-        // On Windows, a race in libuv's async-handle cleanup can cause the
-        // browser process to exit before context.close() resolves, surfacing
-        // "Target page, context or browser has been closed". This is a
-        // Playwright/Chromium Windows-only issue unrelated to test correctness.
+      } catch (e) {
+        // Suppress only known already-closed errors on Windows
+        const msg = e?.message || "";
+        if (
+          msg.includes("Target page, context or browser has been closed") ||
+          msg.includes("Browser has been closed") ||
+          msg.includes("Connection closed")
+        ) {
+          // Expected teardown race on Windows — safe to ignore
+        } else {
+          throw e;
+        }
       }
       // Retry removal on Windows where file locks may persist briefly
       const maxRetries = 5;
@@ -155,8 +115,8 @@ export const test = base.extend({
         try {
           fs.rmSync(userDataDir, { recursive: true, force: true });
           break;
-        } catch (e) {
-          if (attempt === maxRetries - 1) throw e;
+        } catch {
+          if (attempt === maxRetries - 1) throw new Error(`Failed to remove temp dir: ${userDataDir}`);
           await new Promise((r) => setTimeout(r, retryDelay));
         }
       }
@@ -175,4 +135,4 @@ export const test = base.extend({
   },
 });
 
-export { expect };
+export { expect, fixtureLedger };

--- a/tests/integration/background-persistence.test.js
+++ b/tests/integration/background-persistence.test.js
@@ -1,0 +1,218 @@
+/**
+ * Background persistence contract tests.
+ *
+ * Exercises the pure remote-persistence module with injected fetch/storage.
+ */
+// @vitest-environment node
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { resetChromeMock, installChromeMock, setChromeStorage, flushStorageChanges, setStorageMockMode } from "../mocks/chrome.js";
+import {
+  persistRemoteConfig,
+  persistRemoteStatus,
+  persistLocales,
+  REMOTE_CONFIG_URL,
+  REMOTE_STATUS_URL,
+} from "../../src/lib/remote-persistence.js";
+
+describe("persistRemoteConfig", () => {
+  let deps;
+
+  beforeEach(() => {
+    resetChromeMock();
+    installChromeMock();
+    deps = {
+      fetch: vi.fn(),
+      storage: {
+        get: (key) => chrome.storage.local.get(key),
+        set: (values) => chrome.storage.local.set(values),
+      },
+    };
+  });
+
+  afterEach(async () => {
+    await flushStorageChanges();
+  });
+
+  it("writes bds_remote_config on initial fetch", async () => {
+    const config = { features: { test: true }, meta: { version: 1 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(true);
+    const stored = await chrome.storage.local.get("bds_remote_config");
+    expect(stored.bds_remote_config).toEqual(config);
+  });
+
+  it("does not write on identical fetch", async () => {
+    const config = { features: { test: true }, meta: { version: 1 } };
+    setChromeStorage({ bds_remote_config: config });
+
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+    const setCalls = chrome.storage.local.set.mock.calls;
+    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
+    expect(configWrites).toHaveLength(0);
+  });
+
+  it("does not write when keys reordered (structural equality)", async () => {
+    const stored = { meta: { version: 1 }, features: { test: true } };
+    setChromeStorage({ bds_remote_config: stored });
+
+    const fetched = { features: { test: true }, meta: { version: 1 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+    const setCalls = chrome.storage.local.set.mock.calls;
+    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
+    expect(configWrites).toHaveLength(0);
+  });
+
+  it("writes when nested value changes", async () => {
+    const stored = { features: { test: true }, meta: { version: 1 } };
+    setChromeStorage({ bds_remote_config: stored });
+
+    const fetched = { features: { test: false }, meta: { version: 1 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
+
+    await persistRemoteConfig(deps);
+    const storedAfter = await chrome.storage.local.get("bds_remote_config");
+    expect(storedAfter.bds_remote_config.features.test).toBe(false);
+  });
+
+  it("writes when meta.version changes (complete config comparison)", async () => {
+    const stored = { features: { test: true }, meta: { version: 1 } };
+    setChromeStorage({ bds_remote_config: stored });
+
+    const fetched = { features: { test: true }, meta: { version: 2 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
+
+    await persistRemoteConfig(deps);
+    const storedAfter = await chrome.storage.local.get("bds_remote_config");
+    expect(storedAfter.bds_remote_config.meta.version).toBe(2);
+  });
+
+  it("rejects arrays as config roots", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => [{ features: {} }] });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+    const setCalls = chrome.storage.local.set.mock.calls;
+    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
+    expect(configWrites).toHaveLength(0);
+  });
+
+  it("rejects null config", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => null });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+  });
+
+  it("rejects primitive config roots", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => "not-an-object" });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+  });
+
+  it("no write on non-ok response", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("no write on JSON parse failure", async () => {
+    deps.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => { throw new Error("JSON parse error"); },
+    });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteConfig(deps);
+    expect(result.written).toBe(false);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("persistRemoteStatus", () => {
+  let deps;
+
+  beforeEach(() => {
+    resetChromeMock();
+    installChromeMock();
+    deps = {
+      fetch: vi.fn(),
+      storage: {
+        get: (key) => chrome.storage.local.get(key),
+        set: (values) => chrome.storage.local.set(values),
+      },
+    };
+  });
+
+  it("writes on initial fetch", async () => {
+    const announcements = [{ id: "a1", text: "Test" }];
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => announcements });
+
+    const result = await persistRemoteStatus(deps);
+    expect(result.written).toBe(true);
+    const stored = await chrome.storage.local.get("bds_remote_announcement");
+    expect(stored.bds_remote_announcement).toEqual(announcements);
+  });
+
+  it("no write on identical fetch", async () => {
+    const announcements = [{ id: "a1", text: "Test" }];
+    setChromeStorage({ bds_remote_announcement: announcements });
+
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => announcements });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteStatus(deps);
+    expect(result.written).toBe(false);
+    const setCalls = chrome.storage.local.set.mock.calls;
+    const announcementWrites = setCalls.filter((c) => "bds_remote_announcement" in (c[0] || {}));
+    expect(announcementWrites).toHaveLength(0);
+  });
+
+  it("wraps single object in array", async () => {
+    const single = { id: "a1", text: "Test" };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => single });
+
+    await persistRemoteStatus(deps);
+    const stored = await chrome.storage.local.get("bds_remote_announcement");
+    expect(stored.bds_remote_announcement).toEqual([single]);
+  });
+
+  it("no write on null data", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => null });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistRemoteStatus(deps);
+    expect(result.written).toBe(false);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("no feedback loop", () => {
+  it("external sync under Firefox mode does not cause write-back in loop prevention", async () => {
+    resetChromeMock();
+    installChromeMock();
+    setStorageMockMode("firefox");
+    setChromeStorage({ bds_remote_config: { features: { test: true }, meta: { version: 1 } } });
+
+    // External sync (simulating content-script syncFromStorage) must not write back
+    chrome.storage.local.set.mockClear();
+    // This is effectively what syncFromStorage does — uses memory, no storage write
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/background-persistence.test.js
+++ b/tests/integration/background-persistence.test.js
@@ -327,4 +327,22 @@ describe("persistLocales", () => {
     expect(r.error).toBe("No valid locale files fetched");
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["array", []],
+    ["string", "translations"],
+    ["number", 42],
+  ])("rejects a %s messages root", async (_label, messages) => {
+    mockLocaleFetch("en", { messages });
+    chrome.storage.local.set.mockClear();
+
+    const result = await persistLocales(deps, ["en"]);
+
+    expect(result).toEqual({
+      success: false,
+      writtenKeys: [],
+      error: "No valid locale files fetched",
+    });
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
 });

--- a/tests/integration/background-persistence.test.js
+++ b/tests/integration/background-persistence.test.js
@@ -10,178 +10,201 @@ import {
   persistRemoteConfig,
   persistRemoteStatus,
   persistLocales,
-  REMOTE_CONFIG_URL,
-  REMOTE_STATUS_URL,
 } from "../../src/lib/remote-persistence.js";
+
+// ── Helpers ──
+
+function makeDeps() {
+  return {
+    fetch: vi.fn(),
+    storage: {
+      get: (key) => chrome.storage.local.get(key),
+      set: (values) => chrome.storage.local.set(values),
+    },
+  };
+}
+
+// ── persistRemoteConfig ──
 
 describe("persistRemoteConfig", () => {
   let deps;
 
-  beforeEach(() => {
-    resetChromeMock();
-    installChromeMock();
-    deps = {
-      fetch: vi.fn(),
-      storage: {
-        get: (key) => chrome.storage.local.get(key),
-        set: (values) => chrome.storage.local.set(values),
-      },
-    };
-  });
+  beforeEach(() => { resetChromeMock(); installChromeMock(); deps = makeDeps(); });
+  afterEach(async () => { await flushStorageChanges(); });
 
-  afterEach(async () => {
-    await flushStorageChanges();
-  });
-
-  it("writes bds_remote_config on initial fetch", async () => {
+  it("initial fetch writes config and meta in one operation", async () => {
     const config = { features: { test: true }, meta: { version: 1 } };
     deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
 
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(true);
-    const stored = await chrome.storage.local.get("bds_remote_config");
-    expect(stored.bds_remote_config).toEqual(config);
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys.sort()).toEqual(["bds_remote_config", "bds_remote_config_meta"]);
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
   });
 
-  it("does not write on identical fetch", async () => {
+  it("identical config at later time writes only meta", async () => {
     const config = { features: { test: true }, meta: { version: 1 } };
-    setChromeStorage({ bds_remote_config: config });
-
+    setChromeStorage({
+      bds_remote_config: config,
+      bds_remote_config_meta: { lastFetched: 1000, version: 1 },
+    });
     deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
+
     chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
-    const setCalls = chrome.storage.local.set.mock.calls;
-    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
-    expect(configWrites).toHaveLength(0);
+    const r = await persistRemoteConfig(deps, { now: 2000 });
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual(["bds_remote_config_meta"]);
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
   });
 
-  it("does not write when keys reordered (structural equality)", async () => {
-    const stored = { meta: { version: 1 }, features: { test: true } };
-    setChromeStorage({ bds_remote_config: stored });
+  it("identical config with identical metadata writes nothing", async () => {
+    const config = { features: { test: true }, meta: { version: 1 } };
+    setChromeStorage({
+      bds_remote_config: config,
+      bds_remote_config_meta: { lastFetched: 2000, version: 1 },
+    });
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
 
-    const fetched = { features: { test: true }, meta: { version: 1 } };
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
     chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
-    const setCalls = chrome.storage.local.set.mock.calls;
-    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
-    expect(configWrites).toHaveLength(0);
-  });
-
-  it("writes when nested value changes", async () => {
-    const stored = { features: { test: true }, meta: { version: 1 } };
-    setChromeStorage({ bds_remote_config: stored });
-
-    const fetched = { features: { test: false }, meta: { version: 1 } };
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
-
-    await persistRemoteConfig(deps);
-    const storedAfter = await chrome.storage.local.get("bds_remote_config");
-    expect(storedAfter.bds_remote_config.features.test).toBe(false);
-  });
-
-  it("writes when meta.version changes (complete config comparison)", async () => {
-    const stored = { features: { test: true }, meta: { version: 1 } };
-    setChromeStorage({ bds_remote_config: stored });
-
-    const fetched = { features: { test: true }, meta: { version: 2 } };
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => fetched });
-
-    await persistRemoteConfig(deps);
-    const storedAfter = await chrome.storage.local.get("bds_remote_config");
-    expect(storedAfter.bds_remote_config.meta.version).toBe(2);
-  });
-
-  it("rejects arrays as config roots", async () => {
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => [{ features: {} }] });
-    chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
-    const setCalls = chrome.storage.local.set.mock.calls;
-    const configWrites = setCalls.filter((c) => "bds_remote_config" in (c[0] || {}));
-    expect(configWrites).toHaveLength(0);
-  });
-
-  it("rejects null config", async () => {
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => null });
-    chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
-  });
-
-  it("rejects primitive config roots", async () => {
-    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => "not-an-object" });
-    chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
-  });
-
-  it("no write on non-ok response", async () => {
-    deps.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
-    chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
+    const r = await persistRemoteConfig(deps, { now: 2000 });
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual([]);
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
 
-  it("no write on JSON parse failure", async () => {
+  it("meta.version change updates both config and meta atomically", async () => {
+    const oldConfig = { features: { test: true }, meta: { version: 1 } };
+    setChromeStorage({ bds_remote_config: oldConfig });
+    const newConfig = { features: { test: true }, meta: { version: 2 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => newConfig });
+
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys.sort()).toEqual(["bds_remote_config", "bds_remote_config_meta"]);
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
+    const call = chrome.storage.local.set.mock.calls[0][0];
+    expect(call.bds_remote_config).toEqual(newConfig);
+  });
+
+  it("key reorder is structural equality — no config write", async () => {
+    setChromeStorage({
+      bds_remote_config: { meta: { version: 1 }, features: { test: true } },
+      bds_remote_config_meta: { lastFetched: 2000, version: 1 },
+    });
+    deps.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ features: { test: true }, meta: { version: 1 } }),
+    });
+
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps, { now: 2000 });
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual([]);
+  });
+
+  it("rejects array root", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => [{ features: {} }] });
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
+    expect(r.writtenKeys).toEqual([]);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects null root", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => null });
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects primitive root", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => "not-an-object" });
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("non-ok response returns failure", async () => {
+    deps.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("HTTP 500");
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("JSON parse failure returns failure", async () => {
     deps.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => { throw new Error("JSON parse error"); },
     });
     chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteConfig(deps);
-    expect(result.written).toBe(false);
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
+
+  it("storage rejection is surfaced", async () => {
+    const config = { features: { test: true }, meta: { version: 1 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
+    deps.storage.set = vi.fn(async () => { throw new Error("Storage full"); });
+
+    const r = await persistRemoteConfig(deps);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("Storage full");
+  });
+
+  it("Firefox mode: single set produces exactly one event with both keys", async () => {
+    setStorageMockMode("firefox");
+    const config = { features: { test: true }, meta: { version: 1 } };
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => config });
+
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local") events.push(changes);
+    });
+
+    await persistRemoteConfig(deps);
+    await flushStorageChanges();
+
+    expect(events).toHaveLength(1);
+    expect(Object.keys(events[0]).sort()).toEqual(["bds_remote_config", "bds_remote_config_meta"]);
+  });
 });
+
+// ── persistRemoteStatus ──
 
 describe("persistRemoteStatus", () => {
   let deps;
 
-  beforeEach(() => {
-    resetChromeMock();
-    installChromeMock();
-    deps = {
-      fetch: vi.fn(),
-      storage: {
-        get: (key) => chrome.storage.local.get(key),
-        set: (values) => chrome.storage.local.set(values),
-      },
-    };
-  });
+  beforeEach(() => { resetChromeMock(); installChromeMock(); deps = makeDeps(); });
+  afterEach(async () => { await flushStorageChanges(); });
 
-  it("writes on initial fetch", async () => {
+  it("initial fetch writes announcements", async () => {
     const announcements = [{ id: "a1", text: "Test" }];
     deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => announcements });
 
-    const result = await persistRemoteStatus(deps);
-    expect(result.written).toBe(true);
+    const r = await persistRemoteStatus(deps);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual(["bds_remote_announcement"]);
     const stored = await chrome.storage.local.get("bds_remote_announcement");
     expect(stored.bds_remote_announcement).toEqual(announcements);
   });
 
-  it("no write on identical fetch", async () => {
+  it("identical fetch writes nothing", async () => {
     const announcements = [{ id: "a1", text: "Test" }];
     setChromeStorage({ bds_remote_announcement: announcements });
-
     deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => announcements });
-    chrome.storage.local.set.mockClear();
 
-    const result = await persistRemoteStatus(deps);
-    expect(result.written).toBe(false);
-    const setCalls = chrome.storage.local.set.mock.calls;
-    const announcementWrites = setCalls.filter((c) => "bds_remote_announcement" in (c[0] || {}));
-    expect(announcementWrites).toHaveLength(0);
+    chrome.storage.local.set.mockClear();
+    const r = await persistRemoteStatus(deps);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual([]);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
 
   it("wraps single object in array", async () => {
@@ -193,26 +216,115 @@ describe("persistRemoteStatus", () => {
     expect(stored.bds_remote_announcement).toEqual([single]);
   });
 
-  it("no write on null data", async () => {
+  it("empty array clears announcements", async () => {
+    setChromeStorage({ bds_remote_announcement: [{ id: "old" }] });
+    deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    const r = await persistRemoteStatus(deps);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual(["bds_remote_announcement"]);
+    const stored = await chrome.storage.local.get("bds_remote_announcement");
+    expect(stored.bds_remote_announcement).toEqual([]);
+  });
+
+  it("null data returns failure without write", async () => {
     deps.fetch.mockResolvedValueOnce({ ok: true, json: async () => null });
     chrome.storage.local.set.mockClear();
-
-    const result = await persistRemoteStatus(deps);
-    expect(result.written).toBe(false);
+    const r = await persistRemoteStatus(deps);
+    expect(r.success).toBe(false);
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
 });
 
-describe("no feedback loop", () => {
-  it("external sync under Firefox mode does not cause write-back in loop prevention", async () => {
-    resetChromeMock();
-    installChromeMock();
-    setStorageMockMode("firefox");
-    setChromeStorage({ bds_remote_config: { features: { test: true }, meta: { version: 1 } } });
+// ── persistLocales ──
 
-    // External sync (simulating content-script syncFromStorage) must not write back
+describe("persistLocales", () => {
+  let deps;
+
+  beforeEach(() => { resetChromeMock(); installChromeMock(); deps = makeDeps(); });
+  afterEach(async () => { await flushStorageChanges(); });
+
+  function mockLocaleFetch(code, data) {
+    deps.fetch.mockImplementation((url) => {
+      if (url.includes(`/${code}.json`)) {
+        return Promise.resolve({ ok: true, json: async () => data });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ messages: {} }) });
+    });
+  }
+
+  it("initial fetch writes locale data and last-checked atomically", async () => {
+    mockLocaleFetch("en", { messages: { hello: "Hello" } });
+
     chrome.storage.local.set.mockClear();
-    // This is effectively what syncFromStorage does — uses memory, no storage write
+    const r = await persistLocales(deps, ["en"]);
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys.sort()).toEqual(["bds_locale_update_last_checked", "bds_locale_updates"]);
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
+
+    const stored = await chrome.storage.local.get("bds_locale_updates");
+    expect(stored.bds_locale_updates.en.messages.hello).toBe("Hello");
+  });
+
+  it("preserves existing locale when fetch fails for that code", async () => {
+    setChromeStorage({
+      bds_locale_updates: { en: { messages: { hello: "Hello" } }, tr: { messages: { merhaba: "Merhaba" } } },
+    });
+
+    // en succeeds, tr fails
+    deps.fetch.mockImplementation((url) => {
+      if (url.includes("/en.json")) {
+        return Promise.resolve({ ok: true, json: async () => ({ messages: { hello: "Updated" } }) });
+      }
+      if (url.includes("/tr.json")) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ messages: {} }) });
+    });
+
+    const r = await persistLocales(deps, ["en", "tr"]);
+    expect(r.success).toBe(true);
+
+    const stored = await chrome.storage.local.get("bds_locale_updates");
+    // en updated, tr preserved from previous value
+    expect(stored.bds_locale_updates.en.messages.hello).toBe("Updated");
+    expect(stored.bds_locale_updates.tr.messages.merhaba).toBe("Merhaba");
+  });
+
+  it("all-locale-failure returns error without writing", async () => {
+    deps.fetch.mockResolvedValue({ ok: false, status: 500 });
+    chrome.storage.local.set.mockClear();
+
+    const r = await persistLocales(deps, ["en", "tr"]);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("No valid locale files fetched");
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("identical locale data writes nothing", async () => {
+    setChromeStorage({
+      bds_locale_updates: { en: { messages: { hello: "Hello" } } },
+      bds_locale_update_last_checked: new Date(2000).toLocaleDateString(),
+    });
+    mockLocaleFetch("en", { messages: { hello: "Hello" } });
+
+    chrome.storage.local.set.mockClear();
+    const r = await persistLocales(deps, ["en"], { now: 2000 });
+    expect(r.success).toBe(true);
+    expect(r.writtenKeys).toEqual([]);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("non-messages data is ignored for that code", async () => {
+    // Data without a .messages key is invalid locale data
+    deps.fetch.mockImplementation((url) => {
+      return Promise.resolve({ ok: true, json: async () => ({ noMessages: true }) });
+    });
+    chrome.storage.local.set.mockClear();
+
+    const r = await persistLocales(deps, ["en"]);
+    expect(r.success).toBe(false);
+    expect(r.error).toBe("No valid locale files fetched");
     expect(chrome.storage.local.set).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/bridge.test.js
+++ b/tests/integration/bridge.test.js
@@ -343,8 +343,7 @@ describe("handleHistoryMessages validation", () => {
       __bdsExplicit: true,
     });
 
-    // At least one completion event (multiple listeners may fire from prior describe blocks)
-    expect(handler).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it("valid REPLACE replaces existing cache", async () => {

--- a/tests/integration/bridge.test.js
+++ b/tests/integration/bridge.test.js
@@ -145,3 +145,302 @@ describe("bridge integration", () => {
     expect(document.getElementById("bds-injected-hook")).toBeNull();
   });
 });
+
+describe("handleHistoryMessages validation", () => {
+  beforeAll(() => {
+    setupBridgeEvents();
+  });
+
+  beforeEach(async () => {
+    resetAppState();
+    vi.useFakeTimers();
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+    retainOnlyHistorySession(null);
+    // jsdom doesn't support navigation — mock location.href via property descriptor
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.deepseek.com/chat/s/test-session-1" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function dispatchHistory(data) {
+    window.dispatchEvent(new CustomEvent("bds:history-msgs", {
+      detail: typeof data === "string" ? data : JSON.stringify(data),
+    }));
+  }
+
+  function makeMsg(id, extra) {
+    return { message_id: id, role: "assistant", fragments: [], ...(extra || {}) };
+  }
+
+  it("ignores wrong-session history (sessionId !== current URL)", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+    const prevSize = state.chatMessagesBySession.size;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "wrong-session" },
+          chat_messages: [makeMsg("m1")],
+        },
+      },
+      __bdsExplicit: true,
+    });
+
+    // No cache mutation for wrong session
+    expect(state.chatMessagesBySession.has("wrong-session")).toBe(false);
+    expect(state.chatMessagesBySession.size).toBe(prevSize);
+  });
+
+  it("ignores non-array chat_messages", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: "not-an-array",
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("ignores missing chat_messages", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("rejects an entry that is an array (not a plain object)", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m1"), ["not-an-object"]],
+        },
+      },
+    });
+
+    // Entire payload rejected — no cache mutation
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("rejects an entry with null message_id", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: null, role: "user" }],
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("rejects an entry with non-string message_id", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: 12345, role: "user" }],
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("rejects an entry with empty string message_id", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: "", role: "user" }],
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("rejects an entry with whitespace-only message_id", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: "   ", role: "user" }],
+        },
+      },
+    });
+
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+
+  it("later valid response accepted after malformed response", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    // Malformed first
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: "", role: "user" }],
+        },
+      },
+    });
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+
+    // Valid second — should be accepted
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m1")],
+        },
+      },
+    });
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(true);
+    expect(state.chatMessagesBySession.get("test-session-1")).toHaveLength(1);
+  });
+
+  it("valid explicit empty array emits exactly one completion event", async () => {
+    const handler = vi.fn();
+    window.addEventListener("bds:history-msgs-loaded", handler);
+
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [],
+        },
+      },
+      __bdsExplicit: true,
+    });
+
+    // At least one completion event (multiple listeners may fire from prior describe blocks)
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it("valid REPLACE replaces existing cache", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    // First: seed with APPEND
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m1")],
+          cache_control: "APPEND",
+        },
+      },
+    });
+    expect(state.chatMessagesBySession.get("test-session-1")).toHaveLength(1);
+
+    // Second: REPLACE should clear and replace
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m2"), makeMsg("m3")],
+          cache_control: "REPLACE",
+        },
+      },
+    });
+    expect(state.chatMessagesBySession.get("test-session-1")).toHaveLength(2);
+    expect(state.chatMessagesBySession.get("test-session-1")[0].message_id).toBe("m2");
+  });
+
+  it("valid APPEND deduplicates by message_id", async () => {
+    const state = (await import("../../src/content/state.js")).default;
+
+    // Seed initial messages
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m1"), makeMsg("m2")],
+        },
+      },
+    });
+    expect(state.chatMessagesBySession.get("test-session-1")).toHaveLength(2);
+
+    // Append with duplicate m1 + new m3
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [makeMsg("m1"), makeMsg("m3")],
+          cache_control: "APPEND",
+        },
+      },
+    });
+    // Only m3 is new
+    const msgs = state.chatMessagesBySession.get("test-session-1");
+    expect(msgs).toHaveLength(3);
+    expect(msgs.map(m => m.message_id).sort()).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("malformed response does not complete a pending load-all-history request", async () => {
+    // Set up the load-all-history module to create a pending request
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+    retainOnlyHistorySession(null);
+
+    // Simulate: dispatch request event (this is what injected script does)
+    window.dispatchEvent(new CustomEvent("bds:request-history-msgs", {
+      detail: JSON.stringify({ sessionId: "test-session-1" }),
+    }));
+
+    // Start loadAllHistory — it should dispatch bds:request-history-msgs
+    // and wait for bds:history-msgs-loaded
+    const loadPromise = loadAllHistory();
+
+    // Dispatch malformed response
+    dispatchHistory({
+      data: {
+        biz_data: {
+          chat_session: { id: "test-session-1" },
+          chat_messages: [{ message_id: "", role: "user" }],
+        },
+      },
+      __bdsExplicit: true,
+    });
+
+    // The load promise should NOT resolve from the malformed response
+    // Advance past timeout to verify it resolves to null
+    vi.advanceTimersByTime(11000);
+
+    const result = await loadPromise;
+    expect(result).toBeNull();
+
+    // Cache should not be populated
+    const state = (await import("../../src/content/state.js")).default;
+    expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
+  });
+});

--- a/tests/integration/bridge.test.js
+++ b/tests/integration/bridge.test.js
@@ -443,3 +443,55 @@ describe("handleHistoryMessages validation", () => {
     expect(state.chatMessagesBySession.has("test-session-1")).toBe(false);
   });
 });
+
+describe("setupBridgeEvents lifecycle", () => {
+  let setupBridgeEvents;
+
+  beforeAll(async () => {
+    ({ setupBridgeEvents } = await import("../../src/content/bridge.js"));
+  });
+
+  it("repeated setup returns same active cleanup", () => {
+    const c1 = setupBridgeEvents();
+    const c2 = setupBridgeEvents();
+    expect(c1).toBe(c2);
+    c1(); // cleanup
+  });
+
+  it("cleanup removes listeners so reinstall creates fresh handle", () => {
+    const c1 = setupBridgeEvents();
+    c1(); // cleanup gen 1
+
+    const c2 = setupBridgeEvents(); // gen 2
+    expect(c2).not.toBe(c1);
+    c2(); // cleanup
+  });
+
+  it("setup after cleanup installs exactly one fresh set", () => {
+    const c1 = setupBridgeEvents();
+    c1();
+
+    const c2 = setupBridgeEvents();
+    const c3 = setupBridgeEvents();
+    expect(c2).toBe(c3);
+    c2();
+  });
+
+  it("stale cleanup from gen 1 does not clear gen 2", () => {
+    const c1 = setupBridgeEvents();
+    c1(); // cleanup gen 1
+
+    const c2 = setupBridgeEvents(); // gen 2 active
+    c1(); // stale call — must NOT null gen 2
+    const c3 = setupBridgeEvents(); // still gen 2
+    expect(c3).toBe(c2);
+    c2();
+  });
+
+  it("repeated cleanup is harmless (no throw)", () => {
+    const c = setupBridgeEvents();
+    c();
+    c();
+    c();
+  });
+});

--- a/tests/integration/deep-equal.test.js
+++ b/tests/integration/deep-equal.test.js
@@ -1,0 +1,57 @@
+/**
+ * Shared deepEqual contract tests.
+ */
+import { describe, expect, it } from "vitest";
+import { deepEqual } from "../../src/lib/deep-equal.js";
+
+describe("deepEqual", () => {
+  it("primitives equal", () => {
+    expect(deepEqual(1, 1)).toBe(true);
+    expect(deepEqual("a", "a")).toBe(true);
+    expect(deepEqual(true, true)).toBe(true);
+  });
+
+  it("primitives unequal", () => {
+    expect(deepEqual(1, 2)).toBe(false);
+    expect(deepEqual("a", "b")).toBe(false);
+    expect(deepEqual(true, false)).toBe(false);
+  });
+
+  it("null equality", () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(null, undefined)).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+  });
+
+  it("nested objects equal", () => {
+    expect(deepEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } })).toBe(true);
+  });
+
+  it("nested objects unequal", () => {
+    expect(deepEqual({ a: { b: { c: 1 } } }, { a: { b: { c: 2 } } })).toBe(false);
+  });
+
+  it("key reordering is equal", () => {
+    expect(deepEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+
+  it("different key counts unequal", () => {
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  it("arrays equal", () => {
+    expect(deepEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+  });
+
+  it("arrays unequal (different order)", () => {
+    expect(deepEqual([1, 2, 3], [1, 3, 2])).toBe(false);
+  });
+
+  it("array vs object unequal", () => {
+    expect(deepEqual([1, 2], { 0: 1, 1: 2 })).toBe(false);
+  });
+
+  it("nested arrays equal", () => {
+    expect(deepEqual({ a: [1, { b: 2 }] }, { a: [1, { b: 2 }] })).toBe(true);
+  });
+});

--- a/tests/integration/fixture-resolver.test.js
+++ b/tests/integration/fixture-resolver.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveFixtureRequest } from "../e2e/fixtures/fixture-resolver.js";
+
+describe("shared E2E fixture resolver", () => {
+  it("serves the Google Fonts stylesheet without using the network", () => {
+    const result = resolveFixtureRequest(
+      "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
+    );
+
+    expect(result.routeName).toBe("google-fonts-css");
+    expect(result.statusCode).toBe(200);
+    expect(result.mediaType).toContain("text/css");
+  });
+
+  it("serves only locale codes that exist in the repository", () => {
+    expect(resolveFixtureRequest(
+      "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales/en.json?t=1",
+    ).routeName).toBe("locale-en");
+
+    expect(() => resolveFixtureRequest(
+      "https://raw.githubusercontent.com/EdgeTypE/better-deepseek/main/src/locales/zz.json?t=1",
+    )).toThrow(/Unknown locale code|Unmatched external URL/);
+  });
+
+  it("rejects every other external URL", () => {
+    expect(() => resolveFixtureRequest("https://example.com/unexpected"))
+      .toThrow(/Unmatched external URL/);
+  });
+});

--- a/tests/integration/host.test.js
+++ b/tests/integration/host.test.js
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getOrCreateWrapper,
+  getOrCreateHost,
+  removeMessageHost,
+  removeAllMessageHosts,
+} from "../../src/content/dom/host.js";
+
+describe("host wrapper", () => {
+  let msg;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    msg = document.createElement("div");
+    msg.className = "ds-message _63c77b1";
+    document.body.appendChild(msg);
+  });
+
+  it("repeated wrapper creation for one message returns same wrapper", () => {
+    const w1 = getOrCreateWrapper(msg);
+    const w2 = getOrCreateWrapper(msg);
+    expect(w1).toBe(w2);
+    expect(w1.className).toBe("bds-host-wrapper");
+    // Wrapper inserted after the message
+    expect(msg.nextElementSibling).toBe(w1);
+  });
+
+  it("multiple feature hosts share same wrapper", () => {
+    const hostA = getOrCreateHost(msg, "bds-overlay-host");
+    const hostB = getOrCreateHost(msg, "bds-file-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    expect(hostA.parentElement).toBe(wrapper);
+    expect(hostB.parentElement).toBe(wrapper);
+    expect(wrapper.childElementCount).toBe(2);
+  });
+
+  it("repeated host creation for same class deduplicates", () => {
+    const host1 = getOrCreateHost(msg, "bds-overlay-host");
+    const host2 = getOrCreateHost(msg, "bds-overlay-host");
+    expect(host1).toBe(host2);
+    expect(getOrCreateWrapper(msg).childElementCount).toBe(1);
+  });
+
+  it("removing one feature host preserves sibling and unknown hosts", () => {
+    const hostA = getOrCreateHost(msg, "bds-overlay-host");
+    const hostB = getOrCreateHost(msg, "bds-file-host");
+    const unknown = document.createElement("div");
+    unknown.className = "some-other-thing";
+    getOrCreateWrapper(msg).appendChild(unknown);
+
+    removeMessageHost(msg, "bds-overlay-host");
+    expect(document.contains(hostA)).toBe(false);
+    expect(document.contains(hostB)).toBe(true);
+    expect(document.contains(unknown)).toBe(true);
+  });
+
+  it("removing last child removes wrapper and clears ownership", () => {
+    const host = getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    removeMessageHost(msg, "bds-overlay-host");
+    expect(document.contains(wrapper)).toBe(false);
+
+    // New call creates a fresh wrapper
+    const fresh = getOrCreateWrapper(msg);
+    expect(fresh).not.toBe(wrapper);
+  });
+
+  it("pre-existing adjacent wrapper is rediscovered", () => {
+    const existing = document.createElement("div");
+    existing.className = "bds-host-wrapper";
+    msg.insertAdjacentElement("afterend", existing);
+
+    const wrapper = getOrCreateWrapper(msg);
+    expect(wrapper).toBe(existing);
+  });
+
+  it("full disposal removes wrapper and all feature hosts", () => {
+    getOrCreateHost(msg, "bds-overlay-host");
+    getOrCreateHost(msg, "bds-file-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    removeAllMessageHosts(msg);
+
+    expect(document.contains(wrapper)).toBe(false);
+    // New call creates a fresh wrapper
+    const fresh = getOrCreateWrapper(msg);
+    expect(fresh).not.toBe(wrapper);
+  });
+
+  it("ownership remains correct after message reparenting", () => {
+    const host = getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    // Move message to a new parent
+    const newParent = document.createElement("div");
+    newParent.id = "new-area";
+    document.body.appendChild(newParent);
+    newParent.appendChild(msg);
+
+    // Wrapper should be rediscovered (still next to msg in new parent)
+    const refound = getOrCreateWrapper(msg);
+    expect(refound).toBe(wrapper);
+  });
+
+  it("wrapper creation for different messages is independent", () => {
+    const msg2 = document.createElement("div");
+    msg2.className = "ds-message _63c77b1";
+    document.body.appendChild(msg2);
+
+    const w1 = getOrCreateWrapper(msg);
+    const w2 = getOrCreateWrapper(msg2);
+
+    expect(w1).not.toBe(w2);
+    expect(msg.nextElementSibling).toBe(w1);
+    expect(msg2.nextElementSibling).toBe(w2);
+  });
+});

--- a/tests/integration/host.test.js
+++ b/tests/integration/host.test.js
@@ -90,9 +90,13 @@ describe("host wrapper", () => {
     expect(fresh).not.toBe(wrapper);
   });
 
-  it("ownership remains correct after message reparenting", () => {
-    const host = getOrCreateHost(msg, "bds-overlay-host");
+  it("reparenting moves wrapper into new parent adjacent to message", () => {
+    getOrCreateHost(msg, "bds-overlay-host");
     const wrapper = getOrCreateWrapper(msg);
+
+    // Verify initial adjacency
+    expect(msg.nextElementSibling).toBe(wrapper);
+    expect(wrapper.previousElementSibling).toBe(msg);
 
     // Move message to a new parent
     const newParent = document.createElement("div");
@@ -100,9 +104,26 @@ describe("host wrapper", () => {
     document.body.appendChild(newParent);
     newParent.appendChild(msg);
 
-    // Wrapper should be rediscovered (still next to msg in new parent)
+    // Wrapper should be moved into new parent, adjacent to msg
     const refound = getOrCreateWrapper(msg);
     expect(refound).toBe(wrapper);
+    expect(wrapper.parentElement).toBe(newParent);
+    expect(msg.nextElementSibling).toBe(wrapper);
+    expect(wrapper.previousElementSibling).toBe(msg);
+  });
+
+  it("wrapper owned by one message is not adopted by another", () => {
+    const wrapper = getOrCreateWrapper(msg);
+
+    const msg2 = document.createElement("div");
+    msg2.className = "ds-message _63c77b1";
+    document.body.appendChild(msg2);
+
+    // msg2 should get its own wrapper, not adopt msg's
+    const wrapper2 = getOrCreateWrapper(msg2);
+    expect(wrapper2).not.toBe(wrapper);
+    expect(msg.nextElementSibling).toBe(wrapper);
+    expect(msg2.nextElementSibling).toBe(wrapper2);
   });
 
   it("wrapper creation for different messages is independent", () => {

--- a/tests/integration/host.test.js
+++ b/tests/integration/host.test.js
@@ -138,4 +138,69 @@ describe("host wrapper", () => {
     expect(msg.nextElementSibling).toBe(w1);
     expect(msg2.nextElementSibling).toBe(w2);
   });
+
+  it("detach removes wrapper from DOM but preserves it off-DOM", () => {
+    const host = getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+    expect(document.contains(wrapper)).toBe(true);
+
+    // Detach message — wrapper (sibling) stays in DOM until getOrCreateWrapper runs
+    msg.remove();
+    expect(document.contains(msg)).toBe(false);
+
+    // getOrCreateWrapper detects detached message, removes wrapper from DOM
+    const refound = getOrCreateWrapper(msg);
+    expect(refound).toBe(wrapper);
+    expect(document.contains(wrapper)).toBe(false);
+    // Wrapper still tracked for message off-DOM
+  });
+
+  it("reconnect reinserts same wrapper adjacent to message", () => {
+    const host = getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    msg.remove();
+    // Call getOrCreateWrapper to trigger wrapper detachment from DOM
+    getOrCreateWrapper(msg);
+    expect(document.contains(wrapper)).toBe(false);
+
+    // Reconnect to a different parent
+    const newParent = document.createElement("div");
+    document.body.appendChild(newParent);
+    newParent.appendChild(msg);
+
+    const refound = getOrCreateWrapper(msg);
+    expect(refound).toBe(wrapper);
+    expect(document.contains(wrapper)).toBe(true);
+    expect(wrapper.parentElement).toBe(newParent);
+    expect(msg.nextElementSibling).toBe(wrapper);
+  });
+
+  it("feature host removal works on detached wrapper", () => {
+    const host = getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    msg.remove();
+    // Trigger wrapper detachment from DOM
+    getOrCreateWrapper(msg);
+    expect(document.contains(wrapper)).toBe(false);
+
+    // Should still be able to remove a feature host from detached wrapper
+    removeMessageHost(msg, "bds-overlay-host");
+    expect(wrapper.querySelector(".bds-overlay-host")).toBeNull();
+    // Only feature host was removed, wrapper still detached (childless → removed)
+    expect(document.contains(wrapper)).toBe(false);
+  });
+
+  it("permanent disposal clears ownership from both maps", () => {
+    getOrCreateHost(msg, "bds-overlay-host");
+    const wrapper = getOrCreateWrapper(msg);
+
+    removeAllMessageHosts(msg);
+
+    expect(document.contains(wrapper)).toBe(false);
+    // Fresh call creates a new wrapper
+    const fresh = getOrCreateWrapper(msg);
+    expect(fresh).not.toBe(wrapper);
+  });
 });

--- a/tests/integration/load-all-history.test.js
+++ b/tests/integration/load-all-history.test.js
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetAppState } from "../helpers/app-state.js";
+import { resetChromeMock, installChromeMock } from "../mocks/chrome.js";
+import state from "../../src/content/state.js";
+
+describe("load-all-history", () => {
+  beforeEach(() => {
+    resetAppState();
+    resetChromeMock();
+    installChromeMock();
+  });
+
+  it("isLoadInProgress is false when no requests are pending", async () => {
+    const { isLoadInProgress } = await import("../../src/content/load-all-history.js");
+    expect(isLoadInProgress()).toBe(false);
+  });
+
+  it("retainOnlyHistorySession with null clears all caches", async () => {
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+
+    state.chatMessagesBySession.set("s1", [{ message_id: "m1", role: "user", fragments: [] }]);
+    state.chatMessagesBySession.set("s2", [{ message_id: "m2", role: "assistant", fragments: [] }]);
+
+    retainOnlyHistorySession(null);
+
+    expect(state.chatMessagesBySession.size).toBe(0);
+  });
+
+  it("retainOnlyHistorySession keeps only target session", async () => {
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+
+    state.chatMessagesBySession.set("session-A", [{ message_id: "a", role: "user", fragments: [] }]);
+    state.chatMessagesBySession.set("session-B", [{ message_id: "b", role: "assistant", fragments: [] }]);
+
+    retainOnlyHistorySession("session-A");
+
+    expect(state.chatMessagesBySession.has("session-A")).toBe(true);
+    expect(state.chatMessagesBySession.has("session-B")).toBe(false);
+    expect(state.chatMessagesBySession.size).toBe(1);
+  });
+
+  it("retainOnlyHistorySession with same session preserves cached data", async () => {
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+
+    state.chatMessagesBySession.set("session-A", [{ message_id: "a", role: "user", fragments: [] }]);
+
+    retainOnlyHistorySession("session-A");
+
+    expect(state.chatMessagesBySession.has("session-A")).toBe(true);
+    expect(state.chatMessagesBySession.get("session-A").length).toBe(1);
+  });
+
+  it("loadAllHistory returns null on non-session URL", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+    const result = await loadAllHistory();
+    expect(result).toBeNull();
+  });
+});

--- a/tests/integration/load-all-history.test.js
+++ b/tests/integration/load-all-history.test.js
@@ -290,7 +290,7 @@ describe("load-all-history async flow", () => {
     expect(result2).toEqual(messages);
   });
 
-  it("requests for different sessions do not share pending state", async () => {
+  it("cross-session: old pending cancelled, only new session cached", async () => {
     const { loadAllHistory, isLoadInProgress } = await import("../../src/content/load-all-history.js");
 
     // Load session A
@@ -298,32 +298,33 @@ describe("load-all-history async flow", () => {
     const promiseA = loadAllHistory();
     await Promise.resolve();
 
-    // Switch URL to session B and load
+    expect(isLoadInProgress()).toBe(true);
+
+    // Switch URL to session B — retainOnlyHistorySession should cancel session A
     Object.defineProperty(window, "location", {
       value: { href: "https://chat.deepseek.com/chat/s/test-session-b" },
       writable: true,
       configurable: true,
     });
 
+    // Simulate handleHistoryMessages: retainOnlyHistorySession is called with
+    // new session ID when session B data arrives, evicting session A.
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+    retainOnlyHistorySession("test-session-b");
+
+    // Session A promise cancelled — resolves to null
+    const resultA = await promiseA;
+    expect(resultA).toBeNull();
+
+    // Session A cache evicted
+    expect(state.chatMessagesBySession.has(sessionIdA)).toBe(false);
+
+    // Session B can load normally
     const promiseB = loadAllHistory();
     await Promise.resolve();
-
-    // Both should be pending independently
-    expect(isLoadInProgress()).toBe(true);
-
-    // Resolve session A — session B still pending
-    simulateResponse(sessionIdA, [makeMsg("a-m1")]);
-    const resultA = await promiseA;
-    expect(resultA).toHaveLength(1);
-
-    // Session B still pending (different session)
-    // Resolve it
     simulateResponse("test-session-b", [makeMsg("b-m1")]);
     const resultB = await promiseB;
     expect(resultB).toHaveLength(1);
-
-    // Both caches independent
-    expect(state.chatMessagesBySession.get(sessionIdA)).toHaveLength(1);
     expect(state.chatMessagesBySession.get("test-session-b")).toHaveLength(1);
   });
 });

--- a/tests/integration/load-all-history.test.js
+++ b/tests/integration/load-all-history.test.js
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { resetAppState } from "../helpers/app-state.js";
 import { resetChromeMock, installChromeMock } from "../mocks/chrome.js";
 import state from "../../src/content/state.js";
@@ -55,5 +55,275 @@ describe("load-all-history", () => {
     const { loadAllHistory } = await import("../../src/content/load-all-history.js");
     const result = await loadAllHistory();
     expect(result).toBeNull();
+  });
+});
+
+describe("load-all-history async flow", () => {
+  beforeEach(async () => {
+    resetAppState();
+    resetChromeMock();
+    installChromeMock();
+    vi.useFakeTimers();
+    // Reset module-level state in load-all-history
+    state.chatMessagesBySession.clear();
+    const { retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+    retainOnlyHistorySession(null);
+    // Mock location.href to a session URL
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.deepseek.com/chat/s/test-session-async" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function simulateResponse(sessionId, messages) {
+    // Simulate what handleHistoryMessages does: populate cache + dispatch loaded event.
+    // handleHistoryMessages is triggered by bds:history-msgs (not bds:history-msgs-loaded),
+    // but for these tests we simulate the outcome directly.
+    if (messages !== null && messages !== undefined) {
+      state.chatMessagesBySession.set(sessionId, messages);
+    }
+    window.dispatchEvent(new CustomEvent("bds:history-msgs-loaded", {
+      detail: JSON.stringify({ sessionId, count: messages ? messages.length : 0 }),
+    }));
+  }
+
+  function makeMsg(id) {
+    return { message_id: id, role: "assistant", fragments: [] };
+  }
+
+  it("dispatches one bds:request-history-msgs event for a session URL", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+    const handler = vi.fn();
+    window.addEventListener("bds:request-history-msgs", handler);
+
+    // Start load (don't await — it'll timeout)
+    const promise = loadAllHistory();
+
+    // Wait for microtasks so the event is dispatched
+    await Promise.resolve();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Clean up — advance past timeout so promise resolves
+    vi.advanceTimersByTime(11000);
+    await promise;
+  });
+
+  it("sets isLoadInProgress to true while a request is pending", async () => {
+    const { loadAllHistory, isLoadInProgress } = await import("../../src/content/load-all-history.js");
+
+    const promise = loadAllHistory();
+    await Promise.resolve();
+
+    expect(isLoadInProgress()).toBe(true);
+
+    vi.advanceTimersByTime(11000);
+    await promise;
+    expect(isLoadInProgress()).toBe(false);
+  });
+
+  it("valid explicit response resolves with cached messages and resets pending", async () => {
+    const { loadAllHistory, isLoadInProgress } = await import("../../src/content/load-all-history.js");
+
+    const sessionId = "test-session-async";
+    const messages = [makeMsg("m1"), makeMsg("m2")];
+
+    const promise = loadAllHistory();
+
+    // Simulate the injected script dispatching request and response
+    await Promise.resolve();
+    simulateResponse(sessionId, messages);
+
+    const result = await promise;
+    expect(result).toEqual(messages);
+    expect(isLoadInProgress()).toBe(false);
+  });
+
+  it("explicit empty array resolves to null and is not re-requested", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+
+    const sessionId = "test-session-async";
+
+    // First call: empty response
+    const promise1 = loadAllHistory();
+    await Promise.resolve();
+    simulateResponse(sessionId, []);
+
+    const result1 = await promise1;
+    expect(result1).toBeNull();
+
+    // Second call: should NOT dispatch another request (cached as completed)
+    const handler = vi.fn();
+    window.addEventListener("bds:request-history-msgs", handler);
+
+    const promise2 = loadAllHistory();
+    await Promise.resolve();
+
+    expect(handler).not.toHaveBeenCalled();
+    const result2 = await promise2;
+    expect(result2).toBeNull();
+  });
+
+  it("10-second timeout resolves null and permits later retry", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+
+    // Start load, don't simulate response → timeout
+    const promise1 = loadAllHistory();
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(11000);
+    const result1 = await promise1;
+    expect(result1).toBeNull();
+
+    // Retry: should dispatch a new request
+    const handler = vi.fn();
+    window.addEventListener("bds:request-history-msgs", handler);
+
+    const sessionId = "test-session-async";
+    const promise2 = loadAllHistory();
+
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Clean up
+    simulateResponse(sessionId, [makeMsg("retry-m1")]);
+    const result2 = await promise2;
+    expect(result2).toHaveLength(1);
+  });
+
+  it("retainOnlyHistorySession cancels in-flight request for evicted session", async () => {
+    const { loadAllHistory, retainOnlyHistorySession, isLoadInProgress } = await import("../../src/content/load-all-history.js");
+
+    const sessionId = "test-session-async";
+    const promise = loadAllHistory();
+    await Promise.resolve();
+
+    expect(isLoadInProgress()).toBe(true);
+
+    // Evict this session
+    retainOnlyHistorySession("other-session");
+
+    // The promise should resolve to null (cancelled)
+    const result = await promise;
+    expect(result).toBeNull();
+    expect(isLoadInProgress()).toBe(false);
+  });
+
+  it("response arriving after cancellation is ignored by the cancelled waiter", async () => {
+    const { loadAllHistory, retainOnlyHistorySession } = await import("../../src/content/load-all-history.js");
+
+    const sessionId = "test-session-async";
+    const promise = loadAllHistory();
+    await Promise.resolve();
+
+    // Cancel by evicting this session
+    retainOnlyHistorySession("other-session");
+
+    // Switch URL so handleHistoryMessages would also ignore this session
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.deepseek.com/chat/s/other-session" },
+      writable: true,
+      configurable: true,
+    });
+
+    // Late response arrives — simulateResponse dispatches loaded event but
+    // handleHistoryMessages would ignore it (wrong URL). We dispatch loaded
+    // without setting cache to model the real behavior.
+    window.dispatchEvent(new CustomEvent("bds:history-msgs-loaded", {
+      detail: JSON.stringify({ sessionId, count: 1 }),
+    }));
+
+    // Cancelled request resolves to null even if loaded event fires
+    const result = await promise;
+    expect(result).toBeNull();
+    // Cache was never populated (handleHistoryMessages filtered by URL)
+    expect(state.chatMessagesBySession.has(sessionId)).toBe(false);
+  });
+
+  it("two concurrent calls for same session dispatch once and resolve to same data", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+
+    const handler = vi.fn();
+    window.addEventListener("bds:request-history-msgs", handler);
+
+    const sessionId = "test-session-async";
+    const messages = [makeMsg("shared-m1")];
+
+    const promise1 = loadAllHistory();
+    const promise2 = loadAllHistory();
+
+    await Promise.resolve();
+
+    // Only one request event dispatched
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    simulateResponse(sessionId, messages);
+
+    const [r1, r2] = await Promise.all([promise1, promise2]);
+    expect(r1).toEqual(messages);
+    expect(r2).toEqual(messages);
+  });
+
+  it("cached completed history reused without another request", async () => {
+    const { loadAllHistory } = await import("../../src/content/load-all-history.js");
+
+    const sessionId = "test-session-async";
+    const messages = [makeMsg("cached-m1")];
+
+    // First load: complete successfully
+    const promise1 = loadAllHistory();
+    await Promise.resolve();
+    simulateResponse(sessionId, messages);
+    await promise1;
+
+    // Second load: should return cached immediately
+    const handler = vi.fn();
+    window.addEventListener("bds:request-history-msgs", handler);
+
+    const result2 = await loadAllHistory();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result2).toEqual(messages);
+  });
+
+  it("requests for different sessions do not share pending state", async () => {
+    const { loadAllHistory, isLoadInProgress } = await import("../../src/content/load-all-history.js");
+
+    // Load session A
+    const sessionIdA = "test-session-async";
+    const promiseA = loadAllHistory();
+    await Promise.resolve();
+
+    // Switch URL to session B and load
+    Object.defineProperty(window, "location", {
+      value: { href: "https://chat.deepseek.com/chat/s/test-session-b" },
+      writable: true,
+      configurable: true,
+    });
+
+    const promiseB = loadAllHistory();
+    await Promise.resolve();
+
+    // Both should be pending independently
+    expect(isLoadInProgress()).toBe(true);
+
+    // Resolve session A — session B still pending
+    simulateResponse(sessionIdA, [makeMsg("a-m1")]);
+    const resultA = await promiseA;
+    expect(resultA).toHaveLength(1);
+
+    // Session B still pending (different session)
+    // Resolve it
+    simulateResponse("test-session-b", [makeMsg("b-m1")]);
+    const resultB = await promiseB;
+    expect(resultB).toHaveLength(1);
+
+    // Both caches independent
+    expect(state.chatMessagesBySession.get(sessionIdA)).toHaveLength(1);
+    expect(state.chatMessagesBySession.get("test-session-b")).toHaveLength(1);
   });
 });

--- a/tests/integration/message-processor.test.js
+++ b/tests/integration/message-processor.test.js
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   isLatestAssistantMessage: vi.fn((node) => node.dataset.latest === "1"),
   isAbsoluteLastMessage: vi.fn((node) => node.dataset.absoluteLast === "1"),
   scheduleScan: vi.fn(),
+  scheduleMessageScan: vi.fn(),
   collectMessageNodes: vi.fn(() => []),
   extractMessageRawText: vi.fn((node) => node.dataset.rawText || ""),
   injectPythonRunButtons: vi.fn(),
@@ -43,6 +44,7 @@ vi.mock("../../src/content/scanner.js", () => ({
   isLatestAssistantMessage: mocks.isLatestAssistantMessage,
   isAbsoluteLastMessage: mocks.isAbsoluteLastMessage,
   scheduleScan: mocks.scheduleScan,
+  scheduleMessageScan: mocks.scheduleMessageScan,
   collectMessageNodes: mocks.collectMessageNodes,
 }));
 vi.mock("../../src/content/dom/message-text.js", async () => {

--- a/tests/integration/message-processor.test.js
+++ b/tests/integration/message-processor.test.js
@@ -88,7 +88,11 @@ vi.mock("svelte", async () => {
   return { ...actual, mount: mocks.mount, unmount: mocks.unmount };
 });
 
-import { processMessageNode } from "../../src/content/message-processor.svelte.js";
+import {
+  disposeMessageNode,
+  processMessageNode,
+  resetMessagePricing,
+} from "../../src/content/message-processor.svelte.js";
 
 function createMessageNode(rawText, role = "assistant") {
   const node = document.createElement("div");
@@ -110,6 +114,7 @@ function createMessageNode(rawText, role = "assistant") {
 describe("message processor integration", () => {
   beforeEach(() => {
     resetAppState();
+    resetMessagePricing();
     Object.values(mocks).forEach((mock) => {
       if (typeof mock?.mockReset === "function") mock.mockReset();
     });
@@ -155,6 +160,55 @@ describe("message processor integration", () => {
     expect(mocks.mount).toHaveBeenCalledOnce();
     expect(mocks.mount.mock.calls[0][1].props.text).toBe("Updated intro\n\x00BLOCK:0\x00");
     expect(document.querySelectorAll(".mock-overlay")).toHaveLength(1);
+  });
+
+  it("moves an existing wrapper when an unchanged message is reparented", () => {
+    const node = createMessageNode(
+      "Intro\n<BDS:VISUALIZER><div>viz</div></BDS:VISUALIZER>",
+    );
+    const nodes = [node];
+    const context = {
+      latestAssistantNode: node,
+      absoluteLastNode: node,
+      systemGenerating: false,
+    };
+    processMessageNode(node, 0, nodes, context);
+    const wrapper = node.nextElementSibling;
+
+    const newParent = document.createElement("section");
+    document.body.appendChild(newParent);
+    newParent.appendChild(node);
+    processMessageNode(node, 0, nodes, context);
+
+    expect(node.nextElementSibling).toBe(wrapper);
+    expect(wrapper.parentElement).toBe(newParent);
+    expect(document.querySelectorAll(".bds-host-wrapper")).toHaveLength(1);
+  });
+
+  it("updates token totals without re-enumerating every message", () => {
+    state.settings.tokenPriceDisplay = true;
+    mocks.collectMessageNodes.mockImplementation(() => {
+      throw new Error("whole-chat enumeration is forbidden during incremental pricing");
+    });
+
+    const nodes = Array.from({ length: 40 }, (_, index) =>
+      createMessageNode(`user message ${index}`, "user"),
+    );
+    const context = {
+      latestAssistantNode: null,
+      absoluteLastNode: nodes.at(-1),
+      systemGenerating: false,
+    };
+
+    nodes.forEach((node, index) => processMessageNode(node, index, nodes, context));
+
+    expect(mocks.collectMessageNodes).not.toHaveBeenCalled();
+    expect(state.pricing.sessionInputTokens).toBeGreaterThan(0);
+    expect(state.pricing.sessionOutputTokens).toBe(0);
+
+    const beforeDispose = state.pricing.sessionInputTokens;
+    disposeMessageNode(nodes[0]);
+    expect(state.pricing.sessionInputTokens).toBeLessThan(beforeDispose);
   });
 
   it("removes stale DOM overlays before mounting a replacement", () => {

--- a/tests/integration/remote-config.test.js
+++ b/tests/integration/remote-config.test.js
@@ -435,12 +435,15 @@ describe("RemoteConfigManager", () => {
       window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
     });
 
-    it("resetToBuiltin skips persist and notify when already at defaults", () => {
-      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+    it("resetToBuiltin always clears storage but skips notification when already at defaults", () => {
       const handler = vi.fn();
       window.addEventListener(REMOTE_CONFIG_EVENT, handler);
       remoteConfig.resetToBuiltin();
-      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+      // Always clears persisted config + metadata
+      expect(chromeMock.storage.local.remove).toHaveBeenCalledWith(
+        [STORAGE_KEYS.remoteConfig, STORAGE_KEYS.remoteConfigMeta],
+      );
+      // No notification when config didn't change
       expect(handler).not.toHaveBeenCalled();
       window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
     });

--- a/tests/integration/remote-config.test.js
+++ b/tests/integration/remote-config.test.js
@@ -199,6 +199,7 @@ describe("RemoteConfigManager", () => {
     });
 
     it("notifies on Reset", () => {
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
       const cb = vi.fn();
       remoteConfig.onChange(cb);
       remoteConfig.resetToBuiltin();
@@ -224,6 +225,7 @@ describe("RemoteConfigManager", () => {
     });
 
     it("fires callback on resetToBuiltin", () => {
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
       const cb = vi.fn();
       remoteConfig.onChange(cb);
       remoteConfig.resetToBuiltin();
@@ -282,6 +284,7 @@ describe("RemoteConfigManager", () => {
     });
 
     it("dispatches REMOTE_CONFIG_EVENT on resetToBuiltin", () => {
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
       const handler = vi.fn();
       window.addEventListener(REMOTE_CONFIG_EVENT, handler);
       remoteConfig.resetToBuiltin();
@@ -352,6 +355,107 @@ describe("RemoteConfigManager", () => {
     it("applyRemote writes to chrome.storage.local", () => {
       remoteConfig.applyRemote({ features: { attachMenu: { enabled: false } } });
       expect(chromeMock.storage.local.set).toHaveBeenCalled();
+    });
+  });
+
+  // ── syncFromStorage (external sync, no persistence) ──
+
+  describe("syncFromStorage", () => {
+    it("updates merged config from external value with zero storage writes", () => {
+      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      expect(getFlag("features.attachMenu.enabled")).toBe(false);
+      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+    });
+
+    it("normalizes invalid values to {} without writing", () => {
+      remoteConfig.syncFromStorage(null);
+      expect(getFlag("features.attachMenu.enabled")).toBe(true);
+      remoteConfig.syncFromStorage(undefined);
+      expect(getFlag("features.attachMenu.enabled")).toBe(true);
+      remoteConfig.syncFromStorage("not-an-object");
+      expect(getFlag("features.attachMenu.enabled")).toBe(true);
+    });
+
+    it("emits notification when merged config actually changes", () => {
+      const handler = vi.fn();
+      window.addEventListener(REMOTE_CONFIG_EVENT, handler);
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      expect(handler).toHaveBeenCalledOnce();
+      window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
+    });
+
+    it("emits zero notifications when external data is structurally identical", () => {
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      const handler = vi.fn();
+      window.addEventListener(REMOTE_CONFIG_EVENT, handler);
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      expect(handler).not.toHaveBeenCalled();
+      window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
+    });
+
+    it("restores built-ins when storage is removed (empty value)", () => {
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      expect(getFlag("features.attachMenu.enabled")).toBe(false);
+      remoteConfig.syncFromStorage({});
+      expect(getFlag("features.attachMenu.enabled")).toBe(true);
+    });
+
+    it("never calls chrome.storage.local.set", () => {
+      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+      remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+      remoteConfig.syncFromStorage({});
+      remoteConfig.syncFromStorage(null);
+      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+    });
+  });
+
+  // ── Structural equality guard ──
+
+  describe("structural equality", () => {
+    it("replaceRemote skips persist and notify for identical value", () => {
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+      const handler = vi.fn();
+      window.addEventListener(REMOTE_CONFIG_EVENT, handler);
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+      expect(handler).not.toHaveBeenCalled();
+      window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
+    });
+
+    it("applyRemote skips persist and notify for no-op merge", () => {
+      remoteConfig.applyRemote({ features: { attachMenu: { enabled: false } } });
+      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+      const handler = vi.fn();
+      window.addEventListener(REMOTE_CONFIG_EVENT, handler);
+      remoteConfig.applyRemote({ features: { attachMenu: { enabled: false } } });
+      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+      expect(handler).not.toHaveBeenCalled();
+      window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
+    });
+
+    it("resetToBuiltin skips persist and notify when already at defaults", () => {
+      const setCallsBefore = chromeMock.storage.local.set.mock.calls.length;
+      const handler = vi.fn();
+      window.addEventListener(REMOTE_CONFIG_EVENT, handler);
+      remoteConfig.resetToBuiltin();
+      expect(chromeMock.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+      expect(handler).not.toHaveBeenCalled();
+      window.removeEventListener(REMOTE_CONFIG_EVENT, handler);
+    });
+
+    it("local mutation APIs still persist exactly once when value changes", () => {
+      const cb = vi.fn();
+      remoteConfig.onChange(cb);
+      remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+      expect(chromeMock.storage.local.set).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledOnce();
+
+      chromeMock.storage.local.set.mockClear();
+      remoteConfig.applyRemote({ features: { fileUpload: { enabled: false } } });
+      expect(chromeMock.storage.local.set).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { resetAppState } from "../helpers/app-state.js";
 
 const mountMock = vi.hoisted(() => vi.fn(() => ({})));
@@ -9,12 +9,20 @@ const attachMenuMock = vi.hoisted(() => ({ name: "AttachMenu" }));
 const expandToggleMock = vi.hoisted(() => ({ name: "ExpandToggle" }));
 const ragPreviewMock = vi.hoisted(() => ({ name: "RagPreview" }));
 
+const processMessageNodeMock = vi.hoisted(() => vi.fn());
+const disposeMessageNodeMock = vi.hoisted(() => vi.fn());
+const disposeDetachedMessageOverlaysMock = vi.hoisted(() => vi.fn());
+const isSystemGeneratingMock = vi.hoisted(() => vi.fn(() => false));
+
 vi.mock("svelte", () => ({
   mount: mountMock,
 }));
 
 vi.mock("../../src/content/message-processor.svelte.js", () => ({
-  processMessageNode: vi.fn(),
+  processMessageNode: processMessageNodeMock,
+  disposeMessageNode: disposeMessageNodeMock,
+  disposeDetachedMessageOverlays: disposeDetachedMessageOverlaysMock,
+  isSystemGenerating: isSystemGeneratingMock,
 }));
 
 vi.mock("../../src/content/ui/AttachMenu.svelte", () => ({
@@ -316,5 +324,186 @@ describe("scanner input controls", () => {
 
     expect(document.querySelector(".bds-deep-research-mount")).toBeTruthy();
     expect(mountMock).toHaveBeenCalled();
+  });
+});
+
+describe("scanner scheduling", () => {
+  beforeEach(async () => {
+    resetAppState();
+    vi.useFakeTimers();
+    mountMock.mockClear();
+    processMessageNodeMock.mockClear();
+    disposeMessageNodeMock.mockClear();
+    disposeDetachedMessageOverlaysMock.mockClear();
+    isSystemGeneratingMock.mockReturnValue(false);
+    document.body.innerHTML = "";
+    // Reset module-level scan state between tests
+    const { resetIncrementalState } = await import("../../src/content/scanner.js");
+    resetIncrementalState();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeMessage(role, text = "Hello") {
+    const div = document.createElement("div");
+    div.className = "ds-message _63c77b1";
+    div.dataset.role = role;
+    div.dataset.rawText = text;
+    if (role === "user") div.classList.add("d29f3d7d");
+    return div;
+  }
+
+  it("explicit scheduleScan processes all messages exactly once", async () => {
+    const msg1 = makeMessage("user", "hi");
+    const msg2 = makeMessage("assistant", "hello");
+    document.body.append(msg1, msg2);
+
+    const { scheduleScan } = await import("../../src/content/scanner.js");
+    scheduleScan();
+
+    vi.advanceTimersByTime(200);
+
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("scheduleMessageScan processes bounded set not every message", async () => {
+    const messages = [];
+    for (let i = 0; i < 50; i++) {
+      const msg = makeMessage(i % 2 === 0 ? "user" : "assistant", `msg${i}`);
+      document.body.appendChild(msg);
+      messages.push(msg);
+    }
+
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    scheduleMessageScan(messages[10]);
+
+    vi.advanceTimersByTime(200);
+
+    // Should process only the target + transition nodes, not all 50
+    const callCount = processMessageNodeMock.mock.calls.length;
+    expect(callCount).toBeLessThan(50);
+    expect(callCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("full scan supersedes targeted work", async () => {
+    const messages = [];
+    for (let i = 0; i < 20; i++) {
+      const msg = makeMessage("user", `msg${i}`);
+      document.body.appendChild(msg);
+      messages.push(msg);
+    }
+
+    const { scheduleMessageScan, scheduleScan } = await import("../../src/content/scanner.js");
+    scheduleMessageScan(messages[5]);
+    scheduleScan(); // full scan should supersede
+
+    vi.advanceTimersByTime(200);
+
+    // Full scan: all 20 messages processed
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(20);
+  });
+
+  it("removed node is disposed even when full scan supersedes targeted", async () => {
+    const msg1 = makeMessage("user", "hi");
+    const msg2 = makeMessage("assistant", "hello");
+    document.body.append(msg1, msg2);
+
+    const { scheduleScan, observeChatDom } = await import("../../src/content/scanner.js");
+
+    // Set up observer to track mutations
+    observeChatDom();
+
+    // Remove msg2 from DOM
+    msg2.remove();
+
+    // Flush microtasks so MutationObserver callback fires and populates removedNodes
+    await Promise.resolve();
+
+    // Full scan supersedes
+    scheduleScan();
+
+    vi.advanceTimersByTime(200);
+
+    // msg2 was removed — should be disposed
+    expect(disposeMessageNodeMock).toHaveBeenCalledWith(msg2);
+  });
+
+  it("reparented node still connected at flush is not disposed", async () => {
+    const msg1 = makeMessage("user", "hi");
+    document.body.appendChild(msg1);
+
+    const { scheduleScan, observeChatDom } = await import("../../src/content/scanner.js");
+    observeChatDom();
+
+    // Remove then re-add to simulate move
+    msg1.remove();
+    document.body.appendChild(msg1);
+
+    // Flush microtasks so observer processes the remove/add
+    await Promise.resolve();
+
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+
+    // msg1 is still connected — should NOT be disposed
+    expect(disposeMessageNodeMock).not.toHaveBeenCalledWith(msg1);
+  });
+
+  it("processMessageNode receives context with systemGenerating", async () => {
+    isSystemGeneratingMock.mockReturnValue(true);
+    const msg1 = makeMessage("assistant", "streaming");
+    document.body.appendChild(msg1);
+
+    const { scheduleScan } = await import("../../src/content/scanner.js");
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+
+    const callArgs = processMessageNodeMock.mock.calls[0];
+    const context = callArgs[3];
+    expect(context).toBeDefined();
+    expect(context.systemGenerating).toBe(true);
+    expect(context.latestAssistantNode).toBeDefined();
+    expect(context.absoluteLastNode).toBeDefined();
+  });
+
+  it("duplicate scheduleMessageScan calls for same node deduplicate", async () => {
+    const msg1 = makeMessage("assistant", "hello");
+    document.body.appendChild(msg1);
+
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+
+    // Call scheduleMessageScan twice for same node
+    scheduleMessageScan(msg1);
+    scheduleMessageScan(msg1);
+
+    vi.advanceTimersByTime(200);
+
+    // Should process the node only once despite being scheduled twice
+    const calls = processMessageNodeMock.mock.calls.filter(c => c[0] === msg1);
+    expect(calls.length).toBe(1);
+  });
+
+  it("appending a message refreshes latest-assistant and absolute-last state", async () => {
+    const msg1 = makeMessage("assistant", "first");
+    document.body.appendChild(msg1);
+
+    const { scheduleScan } = await import("../../src/content/scanner.js");
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(1);
+
+    processMessageNodeMock.mockClear();
+
+    // Append a new user message
+    const msg2 = makeMessage("user", "second");
+    document.body.appendChild(msg2);
+
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+
+    // Both messages should be re-processed in a full scan
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -327,6 +327,133 @@ describe("scanner input controls", () => {
   });
 });
 
+describe("scanner #bds-root isolation", () => {
+  beforeEach(async () => {
+    resetAppState();
+    vi.useFakeTimers();
+    mountMock.mockClear();
+    processMessageNodeMock.mockClear();
+    disposeMessageNodeMock.mockClear();
+    disposeDetachedMessageOverlaysMock.mockClear();
+    isSystemGeneratingMock.mockReturnValue(false);
+    document.body.innerHTML = "";
+    const { resetIncrementalState } = await import("../../src/content/scanner.js");
+    resetIncrementalState();
+  });
+
+  afterEach(async () => {
+    const state = (await import("../../src/content/state.js")).default;
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
+    if (state.scanTimer) {
+      clearTimeout(state.scanTimer);
+      state.scanTimer = 0;
+    }
+    const { resetIncrementalState } = await import("../../src/content/scanner.js");
+    resetIncrementalState();
+    vi.useRealTimers();
+  });
+
+  function makeMessage(role, text = "Hello") {
+    const div = document.createElement("div");
+    div.className = "ds-message _63c77b1";
+    div.dataset.role = role;
+    div.dataset.rawText = text;
+    if (role === "user") div.classList.add("d29f3d7d");
+    return div;
+  }
+
+  it("adding #bds-root to body arms no timer", async () => {
+    const { observeChatDom } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+    observeChatDom();
+
+    const root = document.createElement("div");
+    root.id = "bds-root";
+    document.body.appendChild(root);
+    await Promise.resolve();
+
+    // No timer armed — scanTimer should still be 0
+    expect(state.scanTimer).toBe(0);
+  });
+
+  it("removing #bds-root arms no timer", async () => {
+    const { observeChatDom } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const root = document.createElement("div");
+    root.id = "bds-root";
+    document.body.appendChild(root);
+
+    observeChatDom();
+    await Promise.resolve();
+
+    root.remove();
+    await Promise.resolve();
+
+    expect(state.scanTimer).toBe(0);
+  });
+
+  it("changes wholly within #bds-root remain ignored", async () => {
+    const { observeChatDom } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const root = document.createElement("div");
+    root.id = "bds-root";
+    document.body.appendChild(root);
+
+    observeChatDom();
+    await Promise.resolve();
+
+    // Add a child element inside #bds-root
+    const child = document.createElement("span");
+    child.className = "ds-message _63c77b1";
+    root.appendChild(child);
+    await Promise.resolve();
+
+    expect(state.scanTimer).toBe(0);
+    expect(processMessageNodeMock).not.toHaveBeenCalled();
+  });
+
+  it("batch with root + external message schedules one scan", async () => {
+    const { observeChatDom } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const root = document.createElement("div");
+    root.id = "bds-root";
+    document.body.appendChild(root);
+
+    observeChatDom();
+    await Promise.resolve();
+
+    // Simultaneous: add child to root + add external message
+    const rootChild = document.createElement("span");
+    root.appendChild(rootChild);
+
+    const extMsg = makeMessage("assistant", "external");
+    document.body.appendChild(extMsg);
+
+    await Promise.resolve();
+
+    // Timer should be armed exactly once
+    expect(state.scanTimer).toBeTruthy();
+    // Only external message should be processed (after timer fires)
+    vi.advanceTimersByTime(200);
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(1);
+    expect(processMessageNodeMock).toHaveBeenCalledWith(
+      extMsg, expect.any(Number), expect.any(Array), expect.any(Object),
+    );
+    // Root child should not be processed
+    // Only extMsg should have been passed to processMessageNode
+    expect(processMessageNodeMock).toHaveBeenCalledTimes(1);
+    expect(processMessageNodeMock).toHaveBeenCalledWith(
+      extMsg, expect.any(Number), expect.any(Array), expect.any(Object),
+    );
+  });
+});
+
 describe("scanner scheduling", () => {
   beforeEach(async () => {
     resetAppState();
@@ -393,10 +520,109 @@ describe("scanner scheduling", () => {
 
     vi.advanceTimersByTime(200);
 
-    // Should process only the target + transition nodes, not all 50
+    // Should process only the target + transition nodes (latest assistant, absolute last),
+    // not all 50. In a list of 50 messages alternating user/assistant:
+    // - target: messages[10] (user at idx 10)
+    // - latestAssistant: messages[49] (assistant at idx 49)
+    // - absoluteLast: messages[49] (idx 49)
+    // Max 3 nodes expected.
     const callCount = processMessageNodeMock.mock.calls.length;
-    expect(callCount).toBeLessThan(50);
+    expect(callCount).toBeLessThanOrEqual(3);
     expect(callCount).toBeGreaterThanOrEqual(1);
+    // The target node must be among the processed nodes
+    const processedNodes = processMessageNodeMock.mock.calls.map(c => c[0]);
+    expect(processedNodes).toContain(messages[10]);
+  });
+
+  it("observer-driven append processes only new message plus transitions among 2000", async () => {
+    const { observeChatDom } = await import("../../src/content/scanner.js");
+
+    // Seed 2000 messages
+    for (let i = 0; i < 2000; i++) {
+      const msg = makeMessage(i % 2 === 0 ? "user" : "assistant", `msg${i}`);
+      document.body.appendChild(msg);
+    }
+    // Run a full scan first so all are processed and transition state is set
+    const { scheduleScan } = await import("../../src/content/scanner.js");
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+    processMessageNodeMock.mockClear();
+
+    // Now set up the observer and append one new message
+    observeChatDom();
+    await Promise.resolve();
+
+    const newMsg = makeMessage("assistant", "new-message");
+    document.body.appendChild(newMsg);
+    await Promise.resolve();
+
+    vi.advanceTimersByTime(200);
+
+    // Should process only the new message + transition nodes, never all 2000
+    const callCount = processMessageNodeMock.mock.calls.length;
+    expect(callCount).toBeLessThanOrEqual(3);
+    expect(callCount).toBeGreaterThanOrEqual(1);
+    const processedNodes = processMessageNodeMock.mock.calls.map(c => c[0]);
+    expect(processedNodes).toContain(newMsg);
+  });
+
+  it("scheduleMessageScan ignores null", async () => {
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    scheduleMessageScan(null);
+    // No timer armed
+    expect(state.scanTimer).toBe(0);
+  });
+
+  it("scheduleMessageScan ignores text nodes", async () => {
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const textNode = document.createTextNode("hello");
+    scheduleMessageScan(textNode);
+    expect(state.scanTimer).toBe(0);
+  });
+
+  it("scheduleMessageScan ignores non-message elements", async () => {
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const div = document.createElement("div");
+    div.className = "not-a-message";
+    scheduleMessageScan(div);
+    // Arm happens even for non-message elements (it adds to dirty set and arms timer)
+    // But when scan runs, it won't find a message
+    expect(state.scanTimer).toBeTruthy();
+    vi.advanceTimersByTime(200);
+    expect(processMessageNodeMock).not.toHaveBeenCalled();
+  });
+
+  it("scheduleMessageScan ignores elements within #bds-root", async () => {
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
+
+    const root = document.createElement("div");
+    root.id = "bds-root";
+    document.body.appendChild(root);
+    const inner = document.createElement("div");
+    inner.className = "ds-message _63c77b1";
+    root.appendChild(inner);
+
+    scheduleMessageScan(inner);
+    expect(state.scanTimer).toBe(0);
+  });
+
+  it("scheduleMessageScan ignores detached elements", async () => {
+    const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const detached = makeMessage("assistant", "detached");
+    // Not appended to document
+
+    scheduleMessageScan(detached);
+    vi.advanceTimersByTime(200);
+    // Detached at flush time → disposed (not processed)
+    expect(disposeMessageNodeMock).toHaveBeenCalledWith(detached);
+    expect(processMessageNodeMock).not.toHaveBeenCalled();
   });
 
   it("full scan supersedes targeted work", async () => {

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -590,10 +590,10 @@ describe("scanner scheduling", () => {
 
     const div = document.createElement("div");
     div.className = "not-a-message";
+    document.body.appendChild(div);
     scheduleMessageScan(div);
-    // Arm happens even for non-message elements (it adds to dirty set and arms timer)
-    // But when scan runs, it won't find a message
-    expect(state.scanTimer).toBeTruthy();
+    // Non-message element — no timer armed, no processing
+    expect(state.scanTimer).toBe(0);
     vi.advanceTimersByTime(200);
     expect(processMessageNodeMock).not.toHaveBeenCalled();
   });
@@ -615,13 +615,15 @@ describe("scanner scheduling", () => {
 
   it("scheduleMessageScan ignores detached elements", async () => {
     const { scheduleMessageScan } = await import("../../src/content/scanner.js");
+    const state = (await import("../../src/content/state.js")).default;
     const detached = makeMessage("assistant", "detached");
     // Not appended to document
 
     scheduleMessageScan(detached);
+    // Detached elements must not arm the timer
+    expect(state.scanTimer).toBe(0);
     vi.advanceTimersByTime(200);
-    // Detached at flush time → disposed (not processed)
-    expect(disposeMessageNodeMock).toHaveBeenCalledWith(detached);
+    expect(disposeMessageNodeMock).not.toHaveBeenCalled();
     expect(processMessageNodeMock).not.toHaveBeenCalled();
   });
 

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -13,6 +13,7 @@ const processMessageNodeMock = vi.hoisted(() => vi.fn());
 const disposeMessageNodeMock = vi.hoisted(() => vi.fn());
 const disposeDetachedMessageOverlaysMock = vi.hoisted(() => vi.fn());
 const isSystemGeneratingMock = vi.hoisted(() => vi.fn(() => false));
+const resetMessagePricingMock = vi.hoisted(() => vi.fn());
 
 vi.mock("svelte", () => ({
   mount: mountMock,
@@ -23,6 +24,7 @@ vi.mock("../../src/content/message-processor.svelte.js", () => ({
   disposeMessageNode: disposeMessageNodeMock,
   disposeDetachedMessageOverlays: disposeDetachedMessageOverlaysMock,
   isSystemGenerating: isSystemGeneratingMock,
+  resetMessagePricing: resetMessagePricingMock,
 }));
 
 vi.mock("../../src/content/ui/AttachMenu.svelte", () => ({
@@ -549,6 +551,8 @@ describe("scanner scheduling", () => {
     vi.advanceTimersByTime(200);
     processMessageNodeMock.mockClear();
 
+    const querySelectorAllSpy = vi.spyOn(document, "querySelectorAll");
+
     // Now set up the observer and append one new message
     observeChatDom();
     await Promise.resolve();
@@ -575,6 +579,38 @@ describe("scanner scheduling", () => {
     for (const call of calls) {
       expect(call[1]).toBeGreaterThanOrEqual(1999);
     }
+
+    const messageEnumerations = querySelectorAllSpy.mock.calls.filter(
+      ([selector]) => selector === "div.ds-message._63c77b1" || selector === "div.ds-message",
+    );
+    expect(messageEnumerations).toHaveLength(0);
+    querySelectorAllSpy.mockRestore();
+  });
+
+  it("reparents a known message without disposing or losing it from the ordered registry", async () => {
+    const { observeChatDom, scheduleScan } = await import("../../src/content/scanner.js");
+    const first = makeMessage("user", "first");
+    const moved = makeMessage("assistant", "moved");
+    const last = makeMessage("assistant", "last");
+    document.body.append(first, moved, last);
+
+    scheduleScan();
+    vi.advanceTimersByTime(200);
+    processMessageNodeMock.mockClear();
+    disposeMessageNodeMock.mockClear();
+
+    observeChatDom();
+    const newParent = document.createElement("section");
+    document.body.appendChild(newParent);
+    newParent.appendChild(moved);
+    await Promise.resolve();
+    vi.advanceTimersByTime(200);
+
+    expect(disposeMessageNodeMock).not.toHaveBeenCalledWith(moved);
+    const movedCall = processMessageNodeMock.mock.calls.find(([node]) => node === moved);
+    expect(movedCall).toBeTruthy();
+    expect(movedCall[1]).toBe(2);
+    expect(movedCall[2][2]).toBe(moved);
   });
 
   it("scheduleMessageScan ignores null", async () => {

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -342,7 +342,19 @@ describe("scanner scheduling", () => {
     resetIncrementalState();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Disconnect any observer and clear timers to prevent cross-test leaks
+    const state = (await import("../../src/content/state.js")).default;
+    if (state.observer) {
+      state.observer.disconnect();
+      state.observer = null;
+    }
+    if (state.scanTimer) {
+      clearTimeout(state.scanTimer);
+      state.scanTimer = 0;
+    }
+    const { resetIncrementalState } = await import("../../src/content/scanner.js");
+    resetIncrementalState();
     vi.useRealTimers();
   });
 

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -536,10 +536,12 @@ describe("scanner scheduling", () => {
   it("observer-driven append processes only new message plus transitions among 2000", async () => {
     const { observeChatDom } = await import("../../src/content/scanner.js");
 
-    // Seed 2000 messages
+    // Seed 2000 messages — capture all references for exact assertions
+    const allMsgs = [];
     for (let i = 0; i < 2000; i++) {
       const msg = makeMessage(i % 2 === 0 ? "user" : "assistant", `msg${i}`);
       document.body.appendChild(msg);
+      allMsgs.push(msg);
     }
     // Run a full scan first so all are processed and transition state is set
     const { scheduleScan } = await import("../../src/content/scanner.js");
@@ -557,22 +559,21 @@ describe("scanner scheduling", () => {
 
     vi.advanceTimersByTime(200);
 
-    // Previous full scan set latestAssistant=absoluteLast at msg index 1999.
+    // Previous full scan set latestAssistant=absoluteLast at msg index 1999 (0-based).
     // New assistant at index 2000 becomes new latestAssistant + absoluteLast.
     // Dirty: newMsg (idx 2000). Previous transition: messages[1999] (still in DOM).
-    // Current transition: newMsg itself (idx 2000). Total: exactly 2 unique nodes.
+    // Current transition: newMsg itself (idx 2000).
+    // Exactly 2 unique nodes, never all 2000, no historical re-enumeration.
     const calls = processMessageNodeMock.mock.calls;
     const processedIds = new Set(calls.map(c => c[0]));
-    // 2 unique nodes: the new message + the previous transition node
-    expect(processedIds.size).toBeGreaterThanOrEqual(1);
-    expect(processedIds.size).toBeLessThanOrEqual(3);
+    expect(processedIds.size).toBe(2);
     expect(processedIds.has(newMsg)).toBe(true);
+    expect(processedIds.has(allMsgs[1999])).toBe(true);
     expect(calls.filter(c => c[0] === newMsg)).toHaveLength(1);
-    // No unrelated historical message processed
+    expect(calls.filter(c => c[0] === allMsgs[1999])).toHaveLength(1);
+    // No unrelated historical message processed (indices 0..1997 untouched)
     for (const call of calls) {
-      // call[0] is the node, call[1] is the index
-      // The index should be near the end (1999 or 2000), not 0..1998
-      expect(call[1]).toBeGreaterThanOrEqual(1998);
+      expect(call[1]).toBeGreaterThanOrEqual(1999);
     }
   });
 

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -520,18 +520,17 @@ describe("scanner scheduling", () => {
 
     vi.advanceTimersByTime(200);
 
-    // Should process only the target + transition nodes (latest assistant, absolute last),
-    // not all 50. In a list of 50 messages alternating user/assistant:
-    // - target: messages[10] (user at idx 10)
-    // - latestAssistant: messages[49] (assistant at idx 49)
-    // - absoluteLast: messages[49] (idx 49)
-    // Max 3 nodes expected.
-    const callCount = processMessageNodeMock.mock.calls.length;
-    expect(callCount).toBeLessThanOrEqual(3);
-    expect(callCount).toBeGreaterThanOrEqual(1);
-    // The target node must be among the processed nodes
-    const processedNodes = processMessageNodeMock.mock.calls.map(c => c[0]);
-    expect(processedNodes).toContain(messages[10]);
+    // Exactly: dirty target messages[10] + transition node messages[49]
+    // (latestAssistant === absoluteLast at idx 49). No previous transition
+    // state exists. Total: exactly 2 unique nodes.
+    const calls = processMessageNodeMock.mock.calls;
+    const processedIds = new Set(calls.map(c => c[0]));
+    expect(processedIds.size).toBe(2);
+    expect(processedIds.has(messages[10])).toBe(true);
+    expect(processedIds.has(messages[49])).toBe(true);
+    // Each processed exactly once
+    expect(calls.filter(c => c[0] === messages[10])).toHaveLength(1);
+    expect(calls.filter(c => c[0] === messages[49])).toHaveLength(1);
   });
 
   it("observer-driven append processes only new message plus transitions among 2000", async () => {
@@ -558,12 +557,23 @@ describe("scanner scheduling", () => {
 
     vi.advanceTimersByTime(200);
 
-    // Should process only the new message + transition nodes, never all 2000
-    const callCount = processMessageNodeMock.mock.calls.length;
-    expect(callCount).toBeLessThanOrEqual(3);
-    expect(callCount).toBeGreaterThanOrEqual(1);
-    const processedNodes = processMessageNodeMock.mock.calls.map(c => c[0]);
-    expect(processedNodes).toContain(newMsg);
+    // Previous full scan set latestAssistant=absoluteLast at msg index 1999.
+    // New assistant at index 2000 becomes new latestAssistant + absoluteLast.
+    // Dirty: newMsg (idx 2000). Previous transition: messages[1999] (still in DOM).
+    // Current transition: newMsg itself (idx 2000). Total: exactly 2 unique nodes.
+    const calls = processMessageNodeMock.mock.calls;
+    const processedIds = new Set(calls.map(c => c[0]));
+    // 2 unique nodes: the new message + the previous transition node
+    expect(processedIds.size).toBeGreaterThanOrEqual(1);
+    expect(processedIds.size).toBeLessThanOrEqual(3);
+    expect(processedIds.has(newMsg)).toBe(true);
+    expect(calls.filter(c => c[0] === newMsg)).toHaveLength(1);
+    // No unrelated historical message processed
+    for (const call of calls) {
+      // call[0] is the node, call[1] is the index
+      // The index should be near the end (1999 or 2000), not 0..1998
+      expect(call[1]).toBeGreaterThanOrEqual(1998);
+    }
   });
 
   it("scheduleMessageScan ignores null", async () => {

--- a/tests/integration/storage.test.js
+++ b/tests/integration/storage.test.js
@@ -31,7 +31,7 @@ import {
   SYSTEM_PROMPT_TEMPLATE_VERSION,
 } from "../../src/lib/constants.js";
 import { resetAppState } from "../helpers/app-state.js";
-import { emitStorageChange, setChromeStorage } from "../mocks/chrome.js";
+import { emitStorageChange, setChromeStorage, resetChromeMock, installChromeMock } from "../mocks/chrome.js";
 
 describe("storage integration", () => {
   beforeEach(() => {
@@ -282,5 +282,249 @@ describe("storage loop prevention", () => {
       [STORAGE_KEYS.remoteConfig]: { newValue: { features: { test: true } } },
     });
     expect(bridgeMocks.pushConfigToPage).not.toHaveBeenCalled();
+  });
+});
+
+describe("storage mock contracts (#108)", () => {
+  beforeEach(() => {
+    resetChromeMock();
+    installChromeMock();
+    resetAppState();
+    bridgeMocks.pushConfigToPage.mockReset();
+    bridgeMocks.setMaxChatSessions.mockReset();
+    messageTextMocks.setHtmlToMarkdownMaxDepth.mockReset();
+  });
+
+  afterEach(async () => {
+    state.ui = null;
+    // Flush any pending notifications to avoid cross-test leaks
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    await flushStorageChanges();
+  });
+
+  it("local replaceRemote performs exactly one write", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    remoteConfig.resetToBuiltin();
+    chrome.storage.local.set.mockClear();
+
+    remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+
+    expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaceRemote write emits exactly one remote-config storage event", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    // Register an onChanged listener
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local" && changes[STORAGE_KEYS.remoteConfig]) {
+        events.push(changes[STORAGE_KEYS.remoteConfig]);
+      }
+    });
+
+    remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+    await flushStorageChanges();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].newValue).toEqual({ features: { attachMenu: { enabled: false } } });
+  });
+
+  it("repeating identical replacement performs zero writes and zero events", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    const data = { features: { attachMenu: { enabled: false } } };
+    remoteConfig.replaceRemote(data);
+    await flushStorageChanges();
+
+    // Register spy AFTER first event
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local" && changes[STORAGE_KEYS.remoteConfig]) {
+        events.push(changes[STORAGE_KEYS.remoteConfig]);
+      }
+    });
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.replaceRemote(data);
+    await flushStorageChanges();
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    expect(events).toHaveLength(0);
+  });
+
+  it("removing stored config restores built-ins without write-back", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    // Seed remote config via replaceRemote (writes to storage)
+    remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+    await flushStorageChanges();
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(false);
+
+    // Now remove from storage
+    chrome.storage.local.set.mockClear();
+    await chrome.storage.local.remove(STORAGE_KEYS.remoteConfig);
+    await flushStorageChanges();
+
+    // bindStorageChangeListener should process the removal via syncFromStorage
+    bindStorageChangeListener();
+    // Simulate the removal event (syncFromStorage sees empty/undefined value)
+    remoteConfig.syncFromStorage({});
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+
+    // No write-back — built-ins restored without persistence
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("external synchronization performs zero writes", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+    await flushStorageChanges();
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("invalid remote-config roots normalize without loop (array)", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.syncFromStorage([]);
+    await flushStorageChanges();
+
+    // Should normalize to default, no crash, no writes
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("invalid remote-config roots normalize without loop (primitive)", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.syncFromStorage("not-an-object");
+    await flushStorageChanges();
+
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("invalid remote-config roots normalize without loop (null)", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.syncFromStorage(null);
+    await flushStorageChanges();
+
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("invalid remote-config roots normalize without loop (undefined)", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    chrome.storage.local.set.mockClear();
+    remoteConfig.syncFromStorage(undefined);
+    await flushStorageChanges();
+
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+    expect(chrome.storage.local.set).not.toHaveBeenCalled();
+  });
+
+  it("identical writes produce no onChange event", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local") events.push(changes);
+    });
+
+    // Write value
+    await chrome.storage.local.set({ test: { a: 1 } });
+    await flushStorageChanges();
+    expect(events).toHaveLength(1);
+
+    // Identical write — no event
+    await chrome.storage.local.set({ test: { a: 1 } });
+    await flushStorageChanges();
+    expect(events).toHaveLength(1);
+  });
+
+  it("remove emits changes only for keys that existed", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+
+    await chrome.storage.local.set({ keep: 1, removeMe: 2 });
+    await flushStorageChanges();
+
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local") events.push(changes);
+    });
+
+    await chrome.storage.local.remove(["removeMe", "neverExisted"]);
+    await flushStorageChanges();
+
+    // Only "removeMe" was in storage — only one change
+    expect(events).toHaveLength(1);
+    expect(Object.keys(events[0])).toEqual(["removeMe"]);
+    expect(events[0].removeMe.newValue).toBeUndefined();
+  });
+
+  it("clear emits one change record for each removed key", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+
+    await chrome.storage.local.set({ a: 1, b: 2, c: 3 });
+    await flushStorageChanges();
+
+    const events = [];
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area === "local") events.push(changes);
+    });
+
+    await chrome.storage.local.clear();
+    await flushStorageChanges();
+
+    expect(events).toHaveLength(1);
+    expect(Object.keys(events[0]).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("listeners receive cloned values — mutating the change does not affect storage", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+
+    const mutations = [];
+    chrome.storage.onChanged.addListener((changes) => {
+      // Attempt to mutate the received change object
+      for (const key of Object.keys(changes)) {
+        if (changes[key].newValue && typeof changes[key].newValue === "object") {
+          changes[key].newValue.mutated = true;
+          mutations.push(key);
+        }
+      }
+    });
+
+    await chrome.storage.local.set({ config: { original: true } });
+    await flushStorageChanges();
+
+    expect(mutations).toHaveLength(1);
+    // Storage should still have the original value
+    const stored = await chrome.storage.local.get("config");
+    expect(stored.config).toEqual({ original: true });
+    expect(stored.config.mutated).toBeUndefined();
   });
 });

--- a/tests/integration/storage.test.js
+++ b/tests/integration/storage.test.js
@@ -307,8 +307,10 @@ describe("storage mock contracts (#108)", () => {
     remoteConfig.resetToBuiltin();
     chrome.storage.local.set.mockClear();
 
-    remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
+    const persisted = remoteConfig.replaceRemote({ features: { attachMenu: { enabled: false } } });
 
+    expect(persisted).toBeInstanceOf(Promise);
+    await persisted;
     expect(chrome.storage.local.set).toHaveBeenCalledTimes(1);
   });
 
@@ -641,6 +643,57 @@ describe("storage mock contracts", () => {
     const { setStorageMockMode } = await import("../mocks/chrome.js");
     expect(() => setStorageMockMode("webkit")).toThrow(/Invalid storage mock mode/);
     expect(() => setStorageMockMode("")).toThrow(/Invalid storage mock mode/);
+  });
+
+  it("isolates a throwing listener and continues future FIFO deliveries", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    const delivered = [];
+    chrome.storage.onChanged.addListener(() => {
+      delivered.push("throws");
+      throw new Error("listener failure");
+    });
+    chrome.storage.onChanged.addListener((changes) => {
+      delivered.push(changes.value.newValue);
+    });
+
+    await chrome.storage.local.set({ value: 1 });
+    await flushStorageChanges();
+    await chrome.storage.local.set({ value: 2 });
+    await flushStorageChanges();
+
+    expect(delivered).toEqual(["throws", 1, "throws", 2]);
+  });
+});
+
+describe("storage listener lifecycle", () => {
+  beforeEach(() => {
+    resetChromeMock();
+    installChromeMock();
+    resetAppState();
+  });
+
+  it("returns one idempotent cleanup handle for an active binding", () => {
+    const first = bindStorageChangeListener();
+    const second = bindStorageChangeListener();
+
+    expect(second).toBe(first);
+    first();
+  });
+
+  it("a stale cleanup cannot remove a later binding", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    const first = bindStorageChangeListener();
+    first();
+    const current = bindStorageChangeListener();
+
+    first();
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.settings]: { tokenPriceDisplay: true },
+    });
+    await flushStorageChanges();
+
+    expect(state.settings.tokenPriceDisplay).toBe(true);
+    current();
   });
 });
 

--- a/tests/integration/storage.test.js
+++ b/tests/integration/storage.test.js
@@ -195,11 +195,11 @@ describe("storage loop prevention", () => {
     expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsBefore);
   });
 
-  it("remote-config storage removal restores builtins without storage write", () => {
-    // Seed remote so removal has an effect
-    import("../../src/lib/remote-config.svelte.js").then(m => {
-      m.remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
-    });
+  it("remote-config storage removal restores builtins without storage write", async () => {
+    // Seed remote so removal has an effect — await the import
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(false);
 
     bindStorageChangeListener();
     const setCallsBefore = chrome.storage.local.set.mock.calls.length;
@@ -208,7 +208,10 @@ describe("storage loop prevention", () => {
       [STORAGE_KEYS.remoteConfig]: { newValue: undefined },
     });
 
+    // syncFromStorage never writes — zero new set calls
     expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+    // Built-ins restored
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
   });
 
   it("re-entrant same-value event terminates without second write", () => {

--- a/tests/integration/storage.test.js
+++ b/tests/integration/storage.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 const bridgeMocks = vi.hoisted(() => ({
   pushConfigToPage: vi.fn(),
@@ -168,5 +168,116 @@ describe("storage integration", () => {
     expect(normalizeCharacters([{ content: "", active: "yes" }, { name: "A", content: "B" }])).toHaveLength(1);
     expect(normalizeProjects([{ id: "p1", name: "P" }, null])).toHaveLength(1);
     expect(normalizeProjectFiles([{ id: "f1", projectId: "p1", content: "body" }, {}])).toHaveLength(1);
+  });
+});
+
+describe("storage loop prevention", () => {
+  beforeEach(() => {
+    resetAppState();
+    bridgeMocks.pushConfigToPage.mockReset();
+    bridgeMocks.setMaxChatSessions.mockReset();
+    messageTextMocks.setHtmlToMarkdownMaxDepth.mockReset();
+  });
+
+  afterEach(() => {
+    state.ui = null;
+  });
+
+  it("remote-config storage event writes zero times to storage (no re-entrant loop)", () => {
+    bindStorageChangeListener();
+
+    const setCallsBefore = chrome.storage.local.set.mock.calls.length;
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: { features: { attachMenu: { enabled: false } } } },
+    });
+
+    // syncFromStorage must never call set — zero new writes
+    expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+  });
+
+  it("remote-config storage removal restores builtins without storage write", () => {
+    // Seed remote so removal has an effect
+    import("../../src/lib/remote-config.svelte.js").then(m => {
+      m.remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+    });
+
+    bindStorageChangeListener();
+    const setCallsBefore = chrome.storage.local.set.mock.calls.length;
+
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: undefined },
+    });
+
+    expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+  });
+
+  it("re-entrant same-value event terminates without second write", () => {
+    bindStorageChangeListener();
+
+    // First event — sets remote with new data
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: { features: { test: true } } },
+    });
+
+    const setCallsAfterFirst = chrome.storage.local.set.mock.calls.length;
+
+    // Second event — same value. Must NOT cause another write.
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: { features: { test: true } } },
+    });
+
+    expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsAfterFirst);
+  });
+
+  it("remote-config storage removal restores builtins and emits zero writes", () => {
+    bindStorageChangeListener();
+
+    const setCallsBefore = chrome.storage.local.set.mock.calls.length;
+
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: undefined },
+    });
+
+    // Removal must not write to storage
+    expect(chrome.storage.local.set.mock.calls.length).toBe(setCallsBefore);
+  });
+
+  it("relevant storage keys push page config once; irrelevant keys push zero times", () => {
+    bindStorageChangeListener();
+
+    // settings = relevant → should push
+    bridgeMocks.pushConfigToPage.mockClear();
+    emitStorageChange({
+      [STORAGE_KEYS.settings]: { newValue: { preferredLang: "FR" } },
+    });
+    expect(bridgeMocks.pushConfigToPage).toHaveBeenCalledOnce();
+
+    // skills = relevant
+    bridgeMocks.pushConfigToPage.mockClear();
+    emitStorageChange({
+      [STORAGE_KEYS.skills]: { newValue: [{ name: "S", content: "X" }] },
+    });
+    expect(bridgeMocks.pushConfigToPage).toHaveBeenCalledOnce();
+
+    // savedItems = irrelevant (not injected into page config)
+    bridgeMocks.pushConfigToPage.mockClear();
+    emitStorageChange({
+      [STORAGE_KEYS.savedItems]: { newValue: [{ id: "x", content: "y" }] },
+    });
+    expect(bridgeMocks.pushConfigToPage).not.toHaveBeenCalled();
+
+    // chatTags = irrelevant
+    bridgeMocks.pushConfigToPage.mockClear();
+    emitStorageChange({
+      [STORAGE_KEYS.chatTags]: { newValue: { s1: ["tag1"] } },
+    });
+    expect(bridgeMocks.pushConfigToPage).not.toHaveBeenCalled();
+
+    // remoteConfig = irrelevant (has dedicated notification path)
+    bridgeMocks.pushConfigToPage.mockClear();
+    emitStorageChange({
+      [STORAGE_KEYS.remoteConfig]: { newValue: { features: { test: true } } },
+    });
+    expect(bridgeMocks.pushConfigToPage).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/storage.test.js
+++ b/tests/integration/storage.test.js
@@ -528,3 +528,207 @@ describe("storage mock contracts (#108)", () => {
     expect(stored.config.mutated).toBeUndefined();
   });
 });
+
+describe("storage mock contracts", () => {
+  beforeEach(async () => {
+    const { resetChromeMock, installChromeMock } = await import("../mocks/chrome.js");
+    resetChromeMock();
+    installChromeMock();
+  });
+
+  afterEach(async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    await flushStorageChanges();
+  });
+
+  it("reset after set() delivers no events and no unhandled rejection", async () => {
+    const { resetChromeMock, flushStorageChanges } = await import("../mocks/chrome.js");
+    const events = [];
+    chrome.storage.onChanged.addListener((c, a) => { if (a === "local") events.push(c); });
+
+    await chrome.storage.local.set({ key1: "value1" });
+    // Reset before microtask fires
+    resetChromeMock();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toHaveLength(0);
+  });
+
+  it("reset while listener delivery suspended stops remaining listeners", async () => {
+    const { resetChromeMock } = await import("../mocks/chrome.js");
+    const delivered = [];
+    chrome.storage.onChanged.addListener(() => { delivered.push("L1"); });
+    chrome.storage.onChanged.addListener(() => {
+      delivered.push("L2-start");
+      // Reset during L2 — L3+ should never fire
+      resetChromeMock();
+    });
+    chrome.storage.onChanged.addListener(() => { delivered.push("L3"); });
+
+    await chrome.storage.local.set({ k: "v" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(delivered).toContain("L1");
+    expect(delivered).toContain("L2-start");
+    expect(delivered).not.toContain("L3");
+  });
+
+  it("two FIFO writes to same key preserve separate old/new transitions", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    const events = [];
+    chrome.storage.onChanged.addListener((c, a) => { if (a === "local") events.push(c); });
+
+    await chrome.storage.local.set({ counter: 1 });
+    await chrome.storage.local.set({ counter: 2 });
+    await flushStorageChanges();
+
+    expect(events).toHaveLength(2);
+    expect(events[0].counter.oldValue).toBeUndefined();
+    expect(events[0].counter.newValue).toBe(1);
+    expect(events[1].counter.oldValue).toBe(1);
+    expect(events[1].counter.newValue).toBe(2);
+  });
+
+  it("two listeners receive independent deep clones", async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    const L1 = [];
+    const L2 = [];
+    chrome.storage.onChanged.addListener((c) => { if (c.x) L1.push(c.x.newValue); });
+    chrome.storage.onChanged.addListener((c) => { if (c.x) L2.push(c.x.newValue); });
+
+    await chrome.storage.local.set({ x: { nested: [1, 2] } });
+    await flushStorageChanges();
+
+    // Mutate what L1 received — must not affect L2's view
+    L1[0].nested.push(99);
+    expect(L2[0].nested).toEqual([1, 2]);
+  });
+
+  it("Chrome mode suppresses identical writes", async () => {
+    const { flushStorageChanges, setStorageMockMode } = await import("../mocks/chrome.js");
+    setStorageMockMode("chrome");
+    const events = [];
+    chrome.storage.onChanged.addListener((c, a) => { if (a === "local") events.push(c); });
+
+    await chrome.storage.local.set({ deep: { a: 1, b: { c: 2 } } });
+    await flushStorageChanges();
+    expect(events).toHaveLength(1);
+
+    await chrome.storage.local.set({ deep: { b: { c: 2 }, a: 1 } });
+    await flushStorageChanges();
+    expect(events).toHaveLength(1);
+  });
+
+  it("Firefox mode emits unchanged keys", async () => {
+    const { flushStorageChanges, setStorageMockMode } = await import("../mocks/chrome.js");
+    setStorageMockMode("firefox");
+    const events = [];
+    chrome.storage.onChanged.addListener((c, a) => { if (a === "local") events.push(c); });
+
+    await chrome.storage.local.set({ k: "same" });
+    await flushStorageChanges();
+    expect(events).toHaveLength(1);
+
+    await chrome.storage.local.set({ k: "same" });
+    await flushStorageChanges();
+    // Firefox mode: second write emits even for unchanged value
+    expect(events).toHaveLength(2);
+  });
+
+  it("setStorageMockMode rejects invalid values", async () => {
+    const { setStorageMockMode } = await import("../mocks/chrome.js");
+    expect(() => setStorageMockMode("webkit")).toThrow(/Invalid storage mock mode/);
+    expect(() => setStorageMockMode("")).toThrow(/Invalid storage mock mode/);
+  });
+});
+
+describe("real Firefox feedback loop test", () => {
+  beforeEach(async () => {
+    const { resetChromeMock, installChromeMock, setStorageMockMode } = await import("../mocks/chrome.js");
+    resetChromeMock();
+    installChromeMock();
+    setStorageMockMode("firefox");
+    resetAppState();
+  });
+
+  afterEach(async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    await flushStorageChanges();
+    state.ui = null;
+  });
+
+  it("external storage set triggers syncFromStorage exactly once, no write-back", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    remoteConfig.resetToBuiltin();
+
+    // Bind the real production storage listener
+    bindStorageChangeListener();
+    await flushStorageChanges();
+
+    // Perform one external storage.local.set for remote config
+    await chrome.storage.local.set({
+      bds_remote_config: { features: { attachMenu: { enabled: false } } },
+    });
+    await flushStorageChanges();
+
+    // Clear mock AFTER the external write flushed, so only write-backs remain
+    chrome.storage.local.set.mockClear();
+    await flushStorageChanges();
+
+    // The manager must have synced once via syncFromStorage
+    // and performed NO additional set() calls (no write-back loop)
+    const setCallsAfterSync = chrome.storage.local.set.mock.calls.filter(
+      (c) => "bds_remote_config" in (c[0] || {}),
+    );
+    expect(setCallsAfterSync).toHaveLength(0);
+
+    // Config was applied in memory
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(false);
+  });
+});
+
+describe("config-removal integration", () => {
+  beforeEach(async () => {
+    const { resetChromeMock, installChromeMock } = await import("../mocks/chrome.js");
+    resetChromeMock();
+    installChromeMock();
+    resetAppState();
+  });
+
+  afterEach(async () => {
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+    await flushStorageChanges();
+  });
+
+  it("bindStorageChangeListener active before remove restores built-ins with zero write-back", async () => {
+    const { remoteConfig } = await import("../../src/lib/remote-config.svelte.js");
+    const { flushStorageChanges } = await import("../mocks/chrome.js");
+
+    // Seed remote config
+    await chrome.storage.local.set({
+      bds_remote_config: { features: { attachMenu: { enabled: false } } },
+    });
+    await flushStorageChanges();
+    remoteConfig.syncFromStorage({ features: { attachMenu: { enabled: false } } });
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(false);
+
+    // Bind listener BEFORE removal
+    bindStorageChangeListener();
+    await flushStorageChanges();
+
+    // Remove the key
+    chrome.storage.local.set.mockClear();
+    await chrome.storage.local.remove("bds_remote_config");
+    await flushStorageChanges();
+
+    // Built-ins restored
+    expect(remoteConfig.getFlag("features.attachMenu.enabled")).toBe(true);
+    // No write-back — bds_remote_config was NOT re-set
+    const setCalls = chrome.storage.local.set.mock.calls;
+    const configWrites = setCalls.filter((c) => c[0] && "bds_remote_config" in c[0]);
+    expect(configWrites).toHaveLength(0);
+  });
+});

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -5,6 +5,8 @@ const listeners = new Set();
 export const chromeMockState = {
   storageData: {},
   extensionBaseUrl: "chrome-extension://better-deepseek-test/",
+  /** "chrome" | "firefox" — controls whether unchanged keys produce events. */
+  mode: "chrome",
 };
 
 function clone(value) {
@@ -12,17 +14,30 @@ function clone(value) {
   return structuredClone(value);
 }
 
-function shallowEqual(a, b) {
+/**
+ * Deep structural equality. Objects compared by sorted keys; arrays by index.
+ * Primitive-like types compared by ===.
+ */
+function deepEqual(a, b) {
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
   if (typeof a !== "object" || a === null || b === null) return false;
-  // Compare own keys shallowly — matches real chrome.storage behavior
-  const aKeys = Object.keys(a);
-  const bKeys = Object.keys(b);
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  if (Array.isArray(a)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
   if (aKeys.length !== bKeys.length) return false;
-  for (const key of aKeys) {
-    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
-    if (a[key] !== b[key]) return false;
+  for (let i = 0; i < aKeys.length; i++) {
+    if (aKeys[i] !== bKeys[i]) return false;
+    if (!deepEqual(a[aKeys[i]], b[bKeys[i]])) return false;
   }
   return true;
 }
@@ -34,8 +49,11 @@ function computeChanges(oldData, newValues, removedKeys = []) {
   for (const [key, newValue] of Object.entries(newValues)) {
     const oldValue = clone(chromeMockState.storageData[key]);
     if (oldValue === undefined && newValue === undefined) continue;
-    // Only emit if value actually changed (shallow compare per chrome.storage spec)
-    if (shallowEqual(oldValue, newValue)) continue;
+    // Chrome mode: only emit if value structurally changed
+    // Firefox mode: emit for every key supplied to set (see MDN compat note)
+    if (chromeMockState.mode === "chrome") {
+      if (deepEqual(oldValue, newValue)) continue;
+    }
     changes[key] = { oldValue, newValue: clone(newValue) };
   }
 
@@ -47,37 +65,53 @@ function computeChanges(oldData, newValues, removedKeys = []) {
   return changes;
 }
 
+// ── Per-operation FIFO notification queue ──
+
+/** @type {Array<Record<string, {oldValue?: any, newValue?: any}>>} */
+const notificationQueue = [];
+let flushPromise = null;
+let flushResolve = null;
+
+function scheduleNotification(changes) {
+  const changeKeys = Object.keys(changes);
+  if (changeKeys.length === 0) return;
+  notificationQueue.push({ ...changes });
+
+  if (!flushPromise) {
+    flushPromise = new Promise((resolve) => {
+      flushResolve = resolve;
+    }).then(async () => {
+      // Drain queue one operation at a time
+      while (notificationQueue.length > 0) {
+        const batch = notificationQueue.shift();
+        await notifyListeners(batch);
+      }
+      flushPromise = null;
+      flushResolve = null;
+    });
+    // Kick off the microtask
+    Promise.resolve().then(() => flushResolve());
+  }
+}
+
 async function notifyListeners(changes) {
   const changeKeys = Object.keys(changes);
   if (changeKeys.length === 0) return;
 
-  // Clone for each listener so they can't mutate shared state
+  // Deep-clone for each listener independently so no listener can mutate
+  // another listener's view or the internal state.
   for (const listener of listeners) {
     const cloned = {};
     for (const key of changeKeys) {
-      cloned[key] = { ...changes[key] };
+      cloned[key] = {
+        oldValue: clone(changes[key].oldValue),
+        newValue: clone(changes[key].newValue),
+      };
     }
     // Fire asynchronously to match real chrome.storage behavior
     await Promise.resolve();
     listener(cloned, "local");
   }
-}
-
-// Deferred notification queue for flushStorageChanges
-let pendingChanges = null;
-let flushPromise = null;
-
-function scheduleNotification(changes) {
-  if (!pendingChanges) {
-    pendingChanges = {};
-    flushPromise = Promise.resolve().then(async () => {
-      const c = pendingChanges;
-      pendingChanges = null;
-      flushPromise = null;
-      await notifyListeners(c);
-    });
-  }
-  Object.assign(pendingChanges, changes);
 }
 
 export const chromeMock = {
@@ -165,8 +199,11 @@ export function installChromeMock() {
 
 export function resetChromeMock() {
   chromeMockState.storageData = {};
-  pendingChanges = null;
+  chromeMockState.mode = "chrome";
+  // Invalidate pending notification jobs so no prior microtask fires in a later test
+  notificationQueue.length = 0;
   flushPromise = null;
+  flushResolve = null;
   chromeMock.storage.local.get.mockClear();
   chromeMock.storage.local.set.mockClear();
   chromeMock.storage.local.remove.mockClear();
@@ -196,6 +233,17 @@ export async function flushStorageChanges() {
   if (flushPromise) {
     await flushPromise;
   }
+  // Ensure any remaining microtasks complete
+  await Promise.resolve();
+}
+
+/**
+ * Set storage mock mode. "chrome" emits only structurally changed keys;
+ * "firefox" may emit keys supplied to `set` even when values are unchanged
+ * (per MDN compatibility note for Firefox's storage.onChanged behavior).
+ */
+export function setStorageMockMode(mode) {
+  chromeMockState.mode = mode;
 }
 
 /**

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -12,6 +12,123 @@ function clone(value) {
   return structuredClone(value);
 }
 
+function shallowEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  // Compare own keys shallowly — matches real chrome.storage behavior
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+function computeChanges(oldData, newValues, removedKeys = []) {
+  /** @type {Record<string, {oldValue?: any, newValue?: any}>} */
+  const changes = {};
+
+  for (const [key, newValue] of Object.entries(newValues)) {
+    const oldValue = clone(chromeMockState.storageData[key]);
+    if (oldValue === undefined && newValue === undefined) continue;
+    // Only emit if value actually changed (shallow compare per chrome.storage spec)
+    if (shallowEqual(oldValue, newValue)) continue;
+    changes[key] = { oldValue, newValue: clone(newValue) };
+  }
+
+  for (const key of removedKeys) {
+    if (!(key in chromeMockState.storageData)) continue;
+    changes[key] = { oldValue: clone(chromeMockState.storageData[key]) };
+  }
+
+  return changes;
+}
+
+async function notifyListeners(changes) {
+  const changeKeys = Object.keys(changes);
+  if (changeKeys.length === 0) return;
+
+  // Clone for each listener so they can't mutate shared state
+  for (const listener of listeners) {
+    const cloned = {};
+    for (const key of changeKeys) {
+      cloned[key] = { ...changes[key] };
+    }
+    // Fire asynchronously to match real chrome.storage behavior
+    await Promise.resolve();
+    listener(cloned, "local");
+  }
+}
+
+// Deferred notification queue for flushStorageChanges
+let pendingChanges = null;
+let flushPromise = null;
+
+function scheduleNotification(changes) {
+  if (!pendingChanges) {
+    pendingChanges = {};
+    flushPromise = Promise.resolve().then(async () => {
+      const c = pendingChanges;
+      pendingChanges = null;
+      flushPromise = null;
+      await notifyListeners(c);
+    });
+  }
+  Object.assign(pendingChanges, changes);
+}
+
+export const chromeMock = {
+  storage: {
+    local: {
+      get: vi.fn(async (keys) => normalizeGetResult(keys)),
+      set: vi.fn(async (values) => {
+        const changes = computeChanges(chromeMockState.storageData, values);
+        Object.assign(chromeMockState.storageData, clone(values));
+        scheduleNotification(changes);
+      }),
+      remove: vi.fn(async (keys) => {
+        const list = Array.isArray(keys) ? keys : [keys];
+        const changes = computeChanges(chromeMockState.storageData, {}, list);
+        for (const key of list) {
+          delete chromeMockState.storageData[key];
+        }
+        scheduleNotification(changes);
+      }),
+      clear: vi.fn(async () => {
+        const removedKeys = Object.keys(chromeMockState.storageData);
+        const changes = computeChanges(chromeMockState.storageData, {}, removedKeys);
+        chromeMockState.storageData = {};
+        scheduleNotification(changes);
+      }),
+    },
+    onChanged: {
+      addListener: vi.fn((listener) => {
+        listeners.add(listener);
+      }),
+      removeListener: vi.fn((listener) => {
+        listeners.delete(listener);
+      }),
+    },
+  },
+  runtime: {
+    sendMessage: vi.fn(async () => undefined),
+    getURL: vi.fn((path = "") => `${chromeMockState.extensionBaseUrl}${path}`),
+    onMessage: {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      hasListener: vi.fn(() => false),
+    },
+    onInstalled: {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      hasListener: vi.fn(() => false),
+    },
+  },
+};
+
 function normalizeGetResult(keys) {
   if (keys == null) {
     return clone(chromeMockState.storageData);
@@ -41,48 +158,6 @@ function normalizeGetResult(keys) {
   return {};
 }
 
-export const chromeMock = {
-  storage: {
-    local: {
-      get: vi.fn(async (keys) => normalizeGetResult(keys)),
-      set: vi.fn(async (values) => {
-        Object.assign(chromeMockState.storageData, clone(values));
-      }),
-      remove: vi.fn(async (keys) => {
-        const list = Array.isArray(keys) ? keys : [keys];
-        for (const key of list) {
-          delete chromeMockState.storageData[key];
-        }
-      }),
-      clear: vi.fn(async () => {
-        chromeMockState.storageData = {};
-      }),
-    },
-    onChanged: {
-      addListener: vi.fn((listener) => {
-        listeners.add(listener);
-      }),
-      removeListener: vi.fn((listener) => {
-        listeners.delete(listener);
-      }),
-    },
-  },
-  runtime: {
-    sendMessage: vi.fn(async () => undefined),
-    getURL: vi.fn((path = "") => `${chromeMockState.extensionBaseUrl}${path}`),
-    onMessage: {
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      hasListener: vi.fn(() => false),
-    },
-    onInstalled: {
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      hasListener: vi.fn(() => false),
-    },
-  },
-};
-
 export function installChromeMock() {
   globalThis.chrome = chromeMock;
   return chromeMock;
@@ -90,6 +165,8 @@ export function installChromeMock() {
 
 export function resetChromeMock() {
   chromeMockState.storageData = {};
+  pendingChanges = null;
+  flushPromise = null;
   chromeMock.storage.local.get.mockClear();
   chromeMock.storage.local.set.mockClear();
   chromeMock.storage.local.remove.mockClear();
@@ -111,6 +188,19 @@ export function setChromeStorage(data) {
   chromeMockState.storageData = clone(data) || {};
 }
 
+/**
+ * Flush all pending storage.onChanged notifications.
+ * Call this instead of arbitrary waits in tests.
+ */
+export async function flushStorageChanges() {
+  if (flushPromise) {
+    await flushPromise;
+  }
+}
+
+/**
+ * @deprecated Use storage.local.set() + flushStorageChanges() instead.
+ */
 export function emitStorageChange(changes, areaName = "local") {
   for (const listener of listeners) {
     listener(changes, areaName);

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { deepEqual } from "../../src/lib/deep-equal.js";
 
 const listeners = new Set();
 
@@ -12,34 +13,6 @@ export const chromeMockState = {
 function clone(value) {
   if (value === undefined) return undefined;
   return structuredClone(value);
-}
-
-/**
- * Deep structural equality. Objects compared by sorted keys; arrays by index.
- * Primitive-like types compared by ===.
- */
-function deepEqual(a, b) {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== "object" || a === null || b === null) return false;
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-  if (Array.isArray(a)) {
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i], b[i])) return false;
-    }
-    return true;
-  }
-
-  const aKeys = Object.keys(a).sort();
-  const bKeys = Object.keys(b).sort();
-  if (aKeys.length !== bKeys.length) return false;
-  for (let i = 0; i < aKeys.length; i++) {
-    if (aKeys[i] !== bKeys[i]) return false;
-    if (!deepEqual(a[aKeys[i]], b[bKeys[i]])) return false;
-  }
-  return true;
 }
 
 function computeChanges(oldData, newValues, removedKeys = []) {
@@ -65,12 +38,12 @@ function computeChanges(oldData, newValues, removedKeys = []) {
   return changes;
 }
 
-// ── Per-operation FIFO notification queue ──
+// ── Per-operation FIFO notification queue with generation-safe reset ──
 
 /** @type {Array<Record<string, {oldValue?: any, newValue?: any}>>} */
 const notificationQueue = [];
 let flushPromise = null;
-let flushResolve = null;
+let flushGeneration = 0;
 
 function scheduleNotification(changes) {
   const changeKeys = Object.keys(changes);
@@ -78,19 +51,19 @@ function scheduleNotification(changes) {
   notificationQueue.push({ ...changes });
 
   if (!flushPromise) {
-    flushPromise = new Promise((resolve) => {
-      flushResolve = resolve;
-    }).then(async () => {
+    const gen = flushGeneration;
+    flushPromise = Promise.resolve().then(async () => {
+      // Abort if reset occurred since scheduling
+      if (gen !== flushGeneration) return;
       // Drain queue one operation at a time
       while (notificationQueue.length > 0) {
+        // Check generation before each batch
+        if (gen !== flushGeneration) return;
         const batch = notificationQueue.shift();
         await notifyListeners(batch);
       }
       flushPromise = null;
-      flushResolve = null;
     });
-    // Kick off the microtask
-    Promise.resolve().then(() => flushResolve());
   }
 }
 
@@ -200,10 +173,12 @@ export function installChromeMock() {
 export function resetChromeMock() {
   chromeMockState.storageData = {};
   chromeMockState.mode = "chrome";
-  // Invalidate pending notification jobs so no prior microtask fires in a later test
+  // Invalidate pending notification jobs by advancing generation.
+  // Prior microtasks check the generation and abort, preventing delivery
+  // of stale events or calls to nulled callbacks.
+  flushGeneration += 1;
   notificationQueue.length = 0;
   flushPromise = null;
-  flushResolve = null;
   chromeMock.storage.local.get.mockClear();
   chromeMock.storage.local.set.mockClear();
   chromeMock.storage.local.remove.mockClear();
@@ -243,6 +218,9 @@ export async function flushStorageChanges() {
  * (per MDN compatibility note for Firefox's storage.onChanged behavior).
  */
 export function setStorageMockMode(mode) {
+  if (mode !== "chrome" && mode !== "firefox") {
+    throw new Error(`Invalid storage mock mode: "${mode}". Must be "chrome" or "firefox".`);
+  }
   chromeMockState.mode = mode;
 }
 

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -60,20 +60,24 @@ function scheduleNotification(changes) {
         // Check generation before each batch
         if (gen !== flushGeneration) return;
         const batch = notificationQueue.shift();
-        await notifyListeners(batch);
+        await notifyListeners(batch, gen);
       }
       flushPromise = null;
     });
   }
 }
 
-async function notifyListeners(changes) {
+async function notifyListeners(changes, generation) {
   const changeKeys = Object.keys(changes);
   if (changeKeys.length === 0) return;
 
   // Deep-clone for each listener independently so no listener can mutate
   // another listener's view or the internal state.
   for (const listener of listeners) {
+    // Recheck generation before each async yield — reset may have occurred
+    // while we were awaiting the previous listener.
+    if (generation !== flushGeneration) return;
+
     const cloned = {};
     for (const key of changeKeys) {
       cloned[key] = {
@@ -83,6 +87,9 @@ async function notifyListeners(changes) {
     }
     // Fire asynchronously to match real chrome.storage behavior
     await Promise.resolve();
+
+    // Recheck after the yield — a reset during await must not deliver
+    if (generation !== flushGeneration) return;
     listener(cloned, "local");
   }
 }
@@ -205,10 +212,12 @@ export function setChromeStorage(data) {
  * Call this instead of arbitrary waits in tests.
  */
 export async function flushStorageChanges() {
-  if (flushPromise) {
+  // Wait for the current generation's flush to complete,
+  // then yield once more so any chained microtasks settle.
+  const gen = flushGeneration;
+  while (flushPromise && gen === flushGeneration) {
     await flushPromise;
   }
-  // Ensure any remaining microtasks complete
   await Promise.resolve();
 }
 

--- a/tests/mocks/chrome.js
+++ b/tests/mocks/chrome.js
@@ -53,16 +53,22 @@ function scheduleNotification(changes) {
   if (!flushPromise) {
     const gen = flushGeneration;
     flushPromise = Promise.resolve().then(async () => {
-      // Abort if reset occurred since scheduling
-      if (gen !== flushGeneration) return;
-      // Drain queue one operation at a time
-      while (notificationQueue.length > 0) {
-        // Check generation before each batch
+      try {
+        // Abort if reset occurred since scheduling
         if (gen !== flushGeneration) return;
-        const batch = notificationQueue.shift();
-        await notifyListeners(batch, gen);
+        // Drain queue one operation at a time
+        while (notificationQueue.length > 0) {
+          // Check generation before each batch
+          if (gen !== flushGeneration) return;
+          const batch = notificationQueue.shift();
+          await notifyListeners(batch, gen);
+        }
+      } finally {
+        // Always clear so future notifications can schedule a new flush
+        if (flushPromise && gen === flushGeneration) {
+          flushPromise = null;
+        }
       }
-      flushPromise = null;
     });
   }
 }
@@ -90,7 +96,14 @@ async function notifyListeners(changes, generation) {
 
     // Recheck after the yield — a reset during await must not deliver
     if (generation !== flushGeneration) return;
-    listener(cloned, "local");
+
+    // Isolate listener exceptions — one throwing listener must not block
+    // later listeners or poison the notification queue.
+    try {
+      listener(cloned, "local");
+    } catch {
+      // Swallow: matches real chrome.storage.onChanged behavior
+    }
   }
 }
 
@@ -124,6 +137,9 @@ export const chromeMock = {
       }),
       removeListener: vi.fn((listener) => {
         listeners.delete(listener);
+      }),
+      hasListener: vi.fn((listener) => {
+        return listeners.has(listener);
       }),
     },
   },
@@ -192,6 +208,7 @@ export function resetChromeMock() {
   chromeMock.storage.local.clear.mockClear();
   chromeMock.storage.onChanged.addListener.mockClear();
   chromeMock.storage.onChanged.removeListener.mockClear();
+  chromeMock.storage.onChanged.hasListener.mockClear();
   chromeMock.runtime.sendMessage.mockClear();
   chromeMock.runtime.getURL.mockClear();
   chromeMock.runtime.onMessage.addListener.mockClear();

--- a/vitest.firefox.config.js
+++ b/vitest.firefox.config.js
@@ -3,11 +3,17 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["tests/e2e-firefox/**/*.spec.js"],
-    testTimeout: 60000,
-    hookTimeout: 60000,
-    // Firefox E2E runs in node environment (Selenium controls the browser)
+    testTimeout: 90000,
+    hookTimeout: 90000,
     environment: "node",
     globals: false,
+    fileParallelism: false,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
     reporters: process.env.CI ? ["default", "html"] : ["default"],
     outputFile: {
       html: "./test-results-firefox/index.html",

--- a/vitest.firefox.config.js
+++ b/vitest.firefox.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/e2e-firefox/**/*.spec.js"],
+    testTimeout: 60000,
+    hookTimeout: 60000,
+    // Firefox E2E runs in node environment (Selenium controls the browser)
+    environment: "node",
+    globals: false,
+    reporters: process.env.CI ? ["default", "html"] : ["default"],
+    outputFile: {
+      html: "./test-results-firefox/index.html",
+    },
+  },
+});


### PR DESCRIPTION
PR fixes the root causes of the performance degradation in #105 and repeated storage activity in #108 across the Chrome-target build and Firefox.

### Message scanning and pricing performance (#105)

- Replace repeated full-history filtering, reverse scans, and `indexOf` lookups with an ordered message registry backed by weak-map indexes.
- Keep the latest assistant message cached during ordinary append processing.
- Reserve linear registry reconstruction for initial scans and uncommon structural changes.
- Replace repeated full-message token-total enumeration with per-message pricing contributions and delta updates.
- Correctly remove pricing contributions when messages are disposed or sessions reset.
- Preserve connected messages during DOM reparenting and keep their registry position synchronized.
- Reconcile an existing message host wrapper after reparenting without duplicating or recreating its rendered content.

### Remote persistence and storage stability (#108)

- Add an explicit startup barrier covering remote status, remote configuration, and locale persistence.
- Make remote-config mutations await their corresponding storage operation so tests and callers observe the actual persistence boundary.
- Correct Firefox remote persistence by invoking `fetch` through a bound adapter.
- Make storage-listener registration return one stable cleanup handle.
- Prevent stale cleanup handles from removing a newer listener after rebinding.
- Isolate listener failures so one callback cannot prevent later queued deliveries.
- Reject malformed remote configuration and locale roots, including arrays and primitive `messages` values.
- Preserve deep-equality suppression so reordered but otherwise identical configuration produces no additional write or update event.

### Browser test infrastructure

- Add a dedicated real-Firefox extension fixture using Selenium, GeckoDriver, and BiDi interception.
- Run the same #105 performance, #108 storage-quiescence, and host-wrapper contracts in Firefox and Chrome-target Chromium.
- Replace fixed post-write delays with observable startup and storage-quiescence waits.
- Require exactly one event/write for a changed configuration and zero additional activity for a reordered identical replacement.
- Intercept all Firefox HTTP(S) traffic and reject unexpected external requests.
- Make unmatched requests fail the Chromium fixture instead of merely logging them.
- Add deterministic Google Fonts handling and reject nonexistent locale fixtures.
- Capture Firefox screenshots and page HTML when a test fails.
- Strengthen host-wrapper assertions to verify ownership, adjacency, layout, and the expected message.

Playwright runs the exact production `dist-chrome` build in bundled Chromium. Current branded Chrome releases cannot side-load unpacked extensions through Playwright, so store-installed branded-Chrome verification remains a manual release check: https://playwright.dev/docs/chrome-extensions

## Testing

- `npm test`
  - production Chrome and Firefox builds passed
  - 73 unit-test files passed
  - 1,098 unit tests passed
  - coverage thresholds passed
  - 34 Chromium E2E tests passed
  - 4 real-Firefox E2E tests passed
- `npm run test:android`
  - Android production build passed
  - 21 Android E2E tests passed
- Focused regression suite
  - 230 tests passed
- `git diff --check`

Closes #105
Closes #108