### PR TITLE
fix(ui): keep Deep Research aligned with attach menu in Expert mode

### DIFF
--- a/src/content/scanner.js
+++ b/src/content/scanner.js
@@ -669,9 +669,17 @@ function findComposerControlsWrapper(fileInput) {
     return fileInput.parentElement;
   }
 
-  const sendButton = findDeepSeekSendButton();
+  const sendButton = findDeepSeekSendButton() || findDeepSeekStopButton();
   if (sendButton?.parentElement) {
-    return sendButton.parentElement;
+    const parent = sendButton.parentElement;
+    if (
+      parent !== document.body &&
+      (parent.style.width === "fit-content" ||
+        getComputedStyle(parent).width === "fit-content")
+    ) {
+      return parent.parentElement || parent;
+    }
+    return parent;
   }
 
   const editor = findComposerEditor();
@@ -825,6 +833,22 @@ function findDeepSeekSendButton() {
       button.title === "Send message" ||
       button.ariaLabel === "Send Message" ||
       button.getAttribute("aria-label") === "Send Message"
+    );
+  }) || null;
+}
+
+function findDeepSeekStopButton() {
+  const buttons = Array.from(document.querySelectorAll('div[role="button"], button'));
+  return buttons.find((button) => {
+    if (button.closest("#bds-root")) {
+      return false;
+    }
+    return (
+      button.querySelector?.(".ds-icon-stop-circle, .ds-icon-stop") ||
+      button.querySelector?.('svg path[d*="M3 3h10v10H3z"], svg path[d*="M6 6h12v12H6z"], svg path[d*="M2 4.88"]') ||
+      button.title === "Stop generating" ||
+      button.title === "Stop" ||
+      button.getAttribute("aria-label")?.toLowerCase().includes("stop")
     );
   }) || null;
 }

--- a/tests/integration/scanner.test.js
+++ b/tests/integration/scanner.test.js
@@ -241,6 +241,65 @@ describe("scanner input controls", () => {
     expect(mountMock.mock.calls[0][0]).toBe(deepResearchToggleMock);
   });
 
+  it("mounts Deep Research in the composer row, not inside the send button shrink-wrap wrapper", async () => {
+    document.body.innerHTML = `
+      <div id="composer">
+        <textarea id="chat-input" placeholder="Message DeepSeek"></textarea>
+        <div id="actions">
+          <div id="send-wrap" style="width: fit-content;"><button id="send" title="Send message"></button></div>
+        </div>
+      </div>
+    `;
+    const { scanInputArea } = await import("../../src/content/scanner.js");
+
+    // Guard against layout-capable browsers resolving the computed width to
+    // pixels: the shrink-wrap detection must key off the inline style value.
+    const originalGetComputedStyle = window.getComputedStyle;
+    Object.defineProperty(window, "getComputedStyle", {
+      configurable: true,
+      value: () => ({ width: "243px" }),
+    });
+
+    try {
+      scanInputArea();
+    } finally {
+      Object.defineProperty(window, "getComputedStyle", {
+        configurable: true,
+        value: originalGetComputedStyle,
+      });
+    }
+
+    const deepResearchMount = document.querySelector(".bds-deep-research-mount");
+    const sendWrap = document.querySelector("#send-wrap");
+
+    expect(deepResearchMount).toBeTruthy();
+    expect(deepResearchMount.parentElement).toBe(document.querySelector("#actions"));
+    expect(sendWrap.querySelector(".bds-deep-research-mount")).toBeNull();
+  });
+
+  it("keeps Deep Research in the button row while generating, when the send button is replaced by a stop button", async () => {
+    document.body.innerHTML = `
+      <div id="composer">
+        <div id="editor-row">
+          <textarea id="chat-input" placeholder="Message DeepSeek"></textarea>
+        </div>
+        <div id="actions">
+          <div style="width: fit-content;"><button id="stop" title="Stop generating"></button></div>
+        </div>
+      </div>
+    `;
+    const { scanInputArea } = await import("../../src/content/scanner.js");
+
+    scanInputArea();
+
+    const deepResearchMount = document.querySelector(".bds-deep-research-mount");
+    const editorRow = document.querySelector("#editor-row");
+
+    expect(deepResearchMount).toBeTruthy();
+    expect(deepResearchMount.parentElement).toBe(document.querySelector("#actions"));
+    expect(editorRow.querySelector(".bds-deep-research-mount")).toBeNull();
+  });
+
   it("mounts Deep Research in prompt action row when DeepThink is in Turkish ('Derin Düşünme' and class/SVG match)", async () => {
     document.body.innerHTML = `
       <div id="composer">


### PR DESCRIPTION
## Problem

In Expert mode, the Deep Research toggle breaks out of the button row and misaligns with the attach menu. It also jumps to the top of the composer while a response is generating.

## Root cause

Expert mode has no native file input. Without one, the send-button fallback resolved to its `width: fit-content` shrink-wrap wrapper, so the Deep Research mount landed inside it instead of the composer row. The wrapper was also skipped unreliably because `getComputedStyle().width` returns pixels, never `fit-content`. During generation the send button becomes a stop button, which the fallback did not recognize, so the toggle was reparented to the editor container.

## Fix

- `findComposerControlsWrapper()` in `src/content/scanner.js` skips the send button's shrink-wrap wrapper and mounts into its parent flex row. Detection keys off the inline style value, with the computed style as fallback.
- The fallback also recognizes the stop button (visible while generating), so the toggle stays in the same row as the attach menu in both idle and generating states.

## Tests

Added regression tests for the Expert mode layout (send/stop button in a `width: fit-content` wrapper, no file input), forcing pixel widths to mirror real Chrome. Full integration suite passes (911 tests).